### PR TITLE
ABQM plugin

### DIFF
--- a/fabric_cf/actor/core/policy/broker_simpler_units_policy.py
+++ b/fabric_cf/actor/core/policy/broker_simpler_units_policy.py
@@ -54,7 +54,7 @@ from fabric_cf.actor.core.util.reservation_set import ReservationSet
 from fabric_cf.actor.core.policy.inventory import Inventory
 from fabric_cf.actor.core.apis.abc_client_reservation import ABCClientReservation
 from fabric_cf.actor.fim.fim_helper import FimHelper
-from fabric_cf.actor.fim.plugins.broker.aggregate_bqm_plugin import AggregateBQMPlugin
+from fabric_cf.actor.fim.plugins.broker.aggregate_bqm_plugin import AggregatedBQMPlugin
 
 if TYPE_CHECKING:
     from fabric_cf.actor.core.apis.abc_broker_mixin import ABCBrokerMixin
@@ -162,7 +162,7 @@ class BrokerSimplerUnitsPolicy(BrokerCalendarPolicy):
         self.combined_broker_model_graph_id = self.combined_broker_model.get_graph_id()
         self.logger.debug(f"Successfully loaded an Combined Broker Model Graph: {self.combined_broker_model_graph_id}")
         # TODO uncomment post complete integration
-        self.pluggable_registry.register_pluggable(t=PluggableType.Broker, p=AggregateBQMPlugin, actor=self.actor,
+        self.pluggable_registry.register_pluggable(t=PluggableType.Broker, p=AggregatedBQMPlugin, actor=self.actor,
                                                    logger=self.logger)
         self.logger.debug(f"Registered AggregateBQMPlugin")
 
@@ -443,7 +443,7 @@ class BrokerSimplerUnitsPolicy(BrokerCalendarPolicy):
             comps=sliver.attached_components_info)
 
     def __candidate_links(self, sliver: NetworkLinkSliver) -> List[str]:
-        pass
+        return list()
 
     def ticket_inventory(self, *, reservation: ABCBrokerReservation, inv: InventoryForType, term: Term,
                          node_id_to_reservations: dict) -> Tuple[bool, dict]:
@@ -779,6 +779,8 @@ class BrokerSimplerUnitsPolicy(BrokerCalendarPolicy):
                 snapshot_graph_id = self.combined_broker_model.snapshot()
             self.combined_broker_model.merge_adm(adm=adm_graph)
             self.combined_broker_model.validate_graph()
+            # delete the snapshot
+            self.combined_broker_model.importer.delete_graph(graph_id=snapshot_graph_id)
         except Exception as e:
             self.logger.error(f"Exception occurred: {e}")
             self.logger.error(traceback.format_exc())

--- a/fabric_cf/actor/core/policy/network_node_inventory.py
+++ b/fabric_cf/actor/core/policy/network_node_inventory.py
@@ -151,7 +151,7 @@ class NetworkNodeInventory(InventoryForType):
         return requested_component
 
     def __check_components(self, *, rid: ID, requested_components: AttachedComponentsInfo, graph_id: str,
-                           graph_node: BaseSliver, existing_reservations: List[ABCReservationMixin]) -> AttachedComponentsInfo:
+                           graph_node: NodeSliver, existing_reservations: List[ABCReservationMixin]) -> AttachedComponentsInfo:
         """
         Check if the requested capacities can be satisfied with the available capacities
         :param rid: reservation id of the reservation being served
@@ -186,7 +186,7 @@ class NetworkNodeInventory(InventoryForType):
                 if (reservation.is_active() or reservation.is_ticketed()) and reservation.get_resources() is not None:
                     allocated_sliver = reservation.get_resources().get_sliver()
 
-                if allocated_sliver is not None:
+                if allocated_sliver is not None and allocated_sliver.attached_components_info is not None:
                     for allocated in allocated_sliver.attached_components_info.devices.values():
                         if allocated.get_node_map() is not None:
                             self.logger.debug(f"Already allocated components {allocated} of resource_type "
@@ -232,8 +232,8 @@ class NetworkNodeInventory(InventoryForType):
 
         return requested_components
 
-    def allocate(self, *, reservation: ABCReservationMixin, graph_id: str, graph_node: BaseSliver,
-                 existing_reservations: List[ABCReservationMixin]) -> Tuple[str, BaseSliver]:
+    def allocate(self, *, reservation: ABCReservationMixin, graph_id: str, graph_node: NodeSliver,
+                 existing_reservations: List[ABCReservationMixin]) -> Tuple[str, NodeSliver]:
         """
         Allocate an extending or ticketing reservation
         :param reservation: reservation to be allocated

--- a/fabric_cf/actor/fim/plugins/broker/aggregate_bqm_plugin.py
+++ b/fabric_cf/actor/fim/plugins/broker/aggregate_bqm_plugin.py
@@ -34,18 +34,25 @@ from fim.graph.resources.abc_bqm import ABCBQMPropertyGraph
 from fim.graph.networkx_property_graph import NetworkXGraphImporter
 from fim.graph.resources.networkx_abqm import NetworkXAggregateBQM
 from fim.slivers.capacities_labels import Capacities
-from fim.slivers.network_node import CompositeNodeSliver
+from fim.slivers.network_node import CompositeNodeSliver, NodeType
 from fim.slivers.attached_components import ComponentSliver
+from fim.slivers.switch_fabric import SFType
+from fim.slivers.interface_info import InterfaceType
 
 
-class AggregateBQMPlugin:
+class AggregatedBQMPlugin:
     """
     Implement a plugin for simple aggregation of CBM into BQM, transforming site
     topologies into CompositeNodes and linking them with (Composite)Links
     This is based on fim.pluggable BrokerPluggable
     """
+    # set to true to test creating ABQM without talking to database or requiring
+    # an actor reference
+    DEBUG_FLAG = False
 
     def __init__(self, actor, logger=None):
+        if not self.DEBUG_FLAG:
+            assert actor is not None
         self.actor = actor
         self.log = logger
 
@@ -57,14 +64,14 @@ class AggregateBQMPlugin:
         :param kwargs:
         :return:
         """
-        if kwargs['query_level'] != 1:
+        if kwargs.get('query_level', None) is None or kwargs['query_level'] != 1:
             return cbm.clone_graph(new_graph_id=str(uuid.uuid4()))
 
         # do a one-pass aggregation of servers, their components and interfaces
         nnodes = cbm.get_all_nodes_by_class(label=ABCPropertyGraph.CLASS_NetworkNode)
         slivers_by_site = defaultdict(list)
         for n in nnodes:
-            # build deep slivers, aggregate by site
+            # build deep slivers for each advertised server, aggregate by site
             node_sliver = cbm.build_deep_node_sliver(node_id=n)
             slivers_by_site[node_sliver.site].append(node_sliver)
 
@@ -72,16 +79,21 @@ class AggregateBQMPlugin:
         abqm = NetworkXAggregateBQM(graph_id=str(uuid.uuid4()),
                                     importer=NetworkXGraphImporter(logger=self.log),
                                     logger=self.log)
-        for s, ls in slivers_by_site.items():
 
+        site_to_composite_node_id = dict()
+        site_to_sf_node_id = dict()
+        for s, ls in slivers_by_site.items():
             # add up capacities and delegated capacities, skip labels for now
             # count up components and figure out links between sites
             site_sliver = CompositeNodeSliver()
             site_sliver.capacities = Capacities()
             site_sliver.resource_name = s
-            # FIXME need a resource type too
+            site_sliver.resource_type = NodeType.Server
             site_comps_by_type = defaultdict(dict)
             for sliver in ls:
+                if sliver.get_type() != NodeType.Server:
+                    # skipping NAS and dataplane switches
+                    continue
                 site_sliver.capacities = site_sliver.capacities + sliver.capacities
                 # collect components in lists by type and model for the site
                 if sliver.attached_components_info is None:
@@ -91,11 +103,21 @@ class AggregateBQMPlugin:
                         site_comps_by_type[comp.resource_type][comp.resource_model] = list()
                     site_comps_by_type[comp.resource_type][comp.resource_model].append(comp)
 
+
             # create a Composite node for every site
             site_node_id = str(uuid.uuid4())
+            site_to_composite_node_id[s] = site_node_id
             site_props = abqm.node_sliver_to_graph_properties_dict(site_sliver)
             abqm.add_node(node_id=site_node_id, label=ABCPropertyGraph.CLASS_CompositeNode,
                           props=site_props)
+            # add a switch fabric
+            sf_id = str(uuid.uuid4())
+            site_to_sf_node_id[s] = sf_id
+            sf_props = {ABCPropertyGraph.PROP_NAME: s + '_sf',
+                        ABCBQMPropertyGraph.PROP_TYPE: str(SFType.SwitchFabric)}
+            abqm.add_node(node_id=sf_id, label=ABCPropertyGraph.CLASS_SwitchFabric, props=sf_props)
+            abqm.add_link(node_a=site_node_id, rel=ABCPropertyGraph.REL_HAS, node_b=sf_id)
+
             # create a component sliver for every component type/model pairing
             # and add a node for it linking back to site node
             for ctype, cdict in site_comps_by_type.items():
@@ -113,5 +135,53 @@ class AggregateBQMPlugin:
                                   props=comp_props)
                     abqm.add_link(node_a=site_node_id, rel=ABCPropertyGraph.REL_HAS,
                                   node_b=comp_node_id)
+
+        # get all intersite links - add them to the aggregated BQM graph
+        intersite_links = cbm.get_intersite_links()
+        for l in intersite_links:
+            source_switch = l[0]
+            sink_switch = l[2]
+            link = l[1]
+            source_site = l[3]
+            sink_site = l[4]
+            source_cp = l[5]
+            sink_cp = l[6]
+            _, cbm_source_cp_props = cbm.get_node_properties(node_id=source_cp)
+            _, cbm_sink_cp_props = cbm.get_node_properties(node_id=sink_cp)
+            _, cbm_link_props = cbm.get_node_properties(node_id=link)
+            # add connection point, link, connection point between to SwitchFabrics
+            assert(site_to_sf_node_id.get(source_site, None) is not None and
+                   site_to_sf_node_id.get(sink_site, None) is not None)
+            source_cp_id = str(uuid.uuid4())
+            sink_cp_id = str(uuid.uuid4())
+            source_cp_props = {ABCPropertyGraph.PROP_NAME: "_".join([source_site, sink_site]),
+                               ABCPropertyGraph.PROP_TYPE: str(InterfaceType.TrunkPort),
+                               ABCPropertyGraph.PROP_CLASS: ABCPropertyGraph.CLASS_ConnectionPoint,
+                               ABCPropertyGraph.PROP_CAPACITIES: cbm_source_cp_props[ABCPropertyGraph.PROP_CAPACITIES]}
+            abqm.add_node(node_id=source_cp_id, label=ABCPropertyGraph.CLASS_ConnectionPoint,
+                          props=source_cp_props)
+            # FIXME: CP names may not be unique if we are dealing with a multigraph
+            sink_cp_props = {ABCPropertyGraph.PROP_NAME: "_".join([sink_site, source_site]),
+                             ABCPropertyGraph.PROP_TYPE: str(InterfaceType.TrunkPort),
+                             ABCPropertyGraph.PROP_CLASS: ABCPropertyGraph.CLASS_ConnectionPoint,
+                             ABCPropertyGraph.PROP_CAPACITIES: cbm_sink_cp_props[ABCPropertyGraph.PROP_CAPACITIES]}
+            abqm.add_node(node_id=sink_cp_id, label=ABCPropertyGraph.CLASS_ConnectionPoint,
+                          props=sink_cp_props)
+            # selectively replicate link node and its properties from CBM
+            new_link_props = {ABCPropertyGraph.PROP_NAME: cbm_link_props[ABCPropertyGraph.PROP_NAME],
+                              ABCPropertyGraph.PROP_TYPE: cbm_link_props[ABCPropertyGraph.PROP_TYPE],
+                              ABCPropertyGraph.PROP_CLASS: cbm_link_props[ABCPropertyGraph.PROP_CLASS],
+                              ABCPropertyGraph.PROP_LAYER: cbm_link_props[ABCPropertyGraph.PROP_LAYER]
+                              }
+            abqm.add_node(node_id=link, label=ABCPropertyGraph.CLASS_Link, props=new_link_props)
+            # connect them together
+            abqm.add_link(node_a=site_to_sf_node_id[source_site], rel=ABCPropertyGraph.REL_CONNECTS,
+                          node_b=source_cp_id)
+            abqm.add_link(node_a=source_cp_id, rel=ABCPropertyGraph.REL_CONNECTS,
+                          node_b=link)
+            abqm.add_link(node_a=link, rel=ABCPropertyGraph.REL_CONNECTS,
+                          node_b=sink_cp_id)
+            abqm.add_link(node_a=sink_cp_id, rel=ABCPropertyGraph.REL_CONNECTS,
+                          node_b=site_to_sf_node_id[sink_site])
 
         return abqm

--- a/fabric_cf/actor/fim/plugins/broker/aggregate_bqm_plugin.py
+++ b/fabric_cf/actor/fim/plugins/broker/aggregate_bqm_plugin.py
@@ -96,7 +96,7 @@ class AggregatedBQMPlugin:
                                 occupied_component_capacities[rt][rm] = Capacities()
 
                             occupied_component_capacities[rt][rm] = occupied_component_capacities[rt][rm] + \
-                                                          allocated_component.capacities
+                                                          allocated_component.capacity_allocations
 
         return occupied_capacities, occupied_component_capacities
 

--- a/fabric_cf/actor/handlers/no_op_handler.py
+++ b/fabric_cf/actor/handlers/no_op_handler.py
@@ -45,7 +45,7 @@ class NoOpHandler(HandlerBase):
             unit.sliver.state = 'active'
             unit.sliver.instance_name = 'instance_001'
             unit.sliver.management_ip = '1.2.3.4'
-            unit.sliver.management_interface_mac_address = 'fa:cb:ff:ee:ww'
+            #unit.sliver.management_interface_mac_address = 'fa:cb:ff:ee:ww'
             result = {Constants.PROPERTY_TARGET_NAME: Constants.TARGET_CREATE,
                       Constants.PROPERTY_TARGET_RESULT_CODE: Constants.RESULT_CODE_OK,
                       Constants.PROPERTY_ACTION_SEQUENCE_NUMBER: 0}

--- a/fabric_cf/actor/test/test_abqm.py
+++ b/fabric_cf/actor/test/test_abqm.py
@@ -1,0 +1,48 @@
+from fim.graph.abc_property_graph import ABCPropertyGraph
+from fim.graph.neo4j_property_graph import Neo4jGraphImporter, Neo4jPropertyGraph
+from fim.graph.resources.neo4j_cbm import Neo4jCBMFactory
+from fabric_cf.actor.fim.plugins.broker.aggregate_bqm_plugin import AggregatedBQMPlugin
+
+"""
+Test of an ABQM plugin
+"""
+
+neo4j = {"url": "neo4j://0.0.0.0:7687",
+         "user": "neo4j",
+         "pass": "password",
+         "import_host_dir": "/Users/ibaldin/workspace-fabric/InfoModelTests/neo4j/imports/",
+         "import_dir": "/imports"}
+
+
+def test_abqm(cbm_graph_id: str):
+    # turn on debug so we can test formation of ABQM without querying
+    # actor for reservations
+    AggregatedBQMPlugin.DEBUG_FLAG = True
+
+    n4j_imp = Neo4jGraphImporter(url=neo4j["url"], user=neo4j["user"],
+                                 pswd=neo4j["pass"],
+                                 import_host_dir=neo4j["import_host_dir"],
+                                 import_dir=neo4j["import_dir"])
+
+    n4j_pg = Neo4jPropertyGraph(graph_id=cbm_graph_id, importer=n4j_imp)
+
+    cbm = Neo4jCBMFactory.create(n4j_pg)
+
+    plugin = AggregatedBQMPlugin(actor=None, logger=None)
+
+    abqm = plugin.plug_produce_bqm(cbm=cbm, query_level=1)
+
+    abqm.validate_graph()
+
+    abqm_string = abqm.serialize_graph()
+
+    print('Writing ABQM to abqm.graphml')
+    with open('abqm.graphml', 'w') as f:
+        f.write(abqm_string)
+
+
+if __name__ == "__main__":
+
+    # make sure CBM exists in Neo4j with this ID
+    test_abqm("e599d589-cb1b-4ebd-8caa-b58edd33543f")
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ cryptography==3.3.2
 psycopg2-binary
 sqlalchemy
 fabric-message-bus
-fabric-fim==0.34
+fabric-fim==0.38
 waitress
 prometheus_client
 connexion


### PR DESCRIPTION
Be sure to approve PR on FIM repo and use FIM 0.38. 

This is a functioning plugin that is ready for testing. The code in plugin has  DEBUG_FLAG, when set to true does not try to talk to the actor database and produces an Aggregated BQM like everything is available. I was not able to test without this flag, moderate confidence that it works. All database access is in a single function called 
```
def __occupied_node_capacity(self, *, node_id: str) -> Tuple[Capacities,
                                                                 Dict[ComponentType, Dict[str, Capacities]]]:
```
which produces a tuple of a capacity object of all allocated capacities for this server and a dictionary organized by component resource type/model of capacities taken up on components within this node. 

To test do something like this (replace reading model from file with reading it from API call):

```
import fim.user as fu
Backend MacOSX is interactive backend. Turning interactive mode on.
topo = fu.AdvertisedTopology(graph_file='abqm.graphml')
print(topo)
RENC: { cpu: 6/6, core: 96/96, ram: 1536/1536G, disk: 109600/109600G, unit: 3/3, }
	Components:
		GPU-RTX6000:  GPU RTX6000 { unit: 2/2, }
		GPU-Tesla T4:  GPU Tesla T4 { unit: 4/4, }
		NVME-P4510:  NVME P4510 { disk: 10000/10000G, unit: 10/10, }
		SharedNIC-ConnectX-6:  SharedNIC ConnectX-6 { unit: 3/3, }
		SmartNIC-ConnectX-6:  SmartNIC ConnectX-6 { unit: 2/2, }
		SmartNIC-ConnectX-5:  SmartNIC ConnectX-5 { unit: 2/2, }
	Site Interfaces:
		RENC_UKY: TrunkPort { bw: 100/100G, }
		RENC_LBNL: TrunkPort { bw: 100/100G, }
UKY: { cpu: 6/6, core: 96/96, ram: 1536/1536G, disk: 109600/109600G, unit: 3/3, }
	Components:
		SmartNIC-ConnectX-5:  SmartNIC ConnectX-5 { unit: 2/2, }
		GPU-RTX6000:  GPU RTX6000 { unit: 2/2, }
		GPU-Tesla T4:  GPU Tesla T4 { unit: 4/4, }
		SharedNIC-ConnectX-6:  SharedNIC ConnectX-6 { unit: 3/3, }
		NVME-P4510:  NVME P4510 { disk: 10000/10000G, unit: 10/10, }
		SmartNIC-ConnectX-6:  SmartNIC ConnectX-6 { unit: 2/2, }
	Site Interfaces:
		UKY_LBNL: TrunkPort { bw: 100/100G, }
		UKY_RENC: TrunkPort { bw: 100/100G, }
LBNL: { cpu: 6/6, core: 96/96, ram: 1536/1536G, disk: 109600/109600G, unit: 3/3, }
	Components:
		GPU-RTX6000:  GPU RTX6000 { unit: 2/2, }
		GPU-Tesla T4:  GPU Tesla T4 { unit: 4/4, }
		SharedNIC-ConnectX-6:  SharedNIC ConnectX-6 { unit: 3/3, }
		NVME-P4510:  NVME P4510 { disk: 10000/10000G, unit: 10/10, }
		SmartNIC-ConnectX-6:  SmartNIC ConnectX-6 { unit: 2/2, }
		SmartNIC-ConnectX-5:  SmartNIC ConnectX-5 { unit: 2/2, }
	Site Interfaces:
		LBNL_RENC: TrunkPort { bw: 100/100G, }
		LBNL_UKY: TrunkPort { bw: 100/100G, }
Links:
	l1[L2Path]: ['UKY_RENC', 'RENC_UKY']
	l2[L2Path]: ['UKY_LBNL', 'LBNL_UKY']
	l3[L2Path]: ['LBNL_RENC', 'RENC_LBNL']

```