### PR TITLE
remove closed or active reservations from pendingRedem queue

### DIFF
--- a/fabric_cf/__init__.py
+++ b/fabric_cf/__init__.py
@@ -1,1 +1,1 @@
-__VERSION__ = "1.0rc1"
+__VERSION__ = "1.0rc2"

--- a/fabric_cf/actor/core/policy/controller_calendar_policy.py
+++ b/fabric_cf/actor/core/policy/controller_calendar_policy.py
@@ -83,7 +83,7 @@ class ControllerCalendarPolicy(Policy, ABCControllerPolicy):
             elif reservation.is_no_pending() and not reservation.is_pending_recover():
                 # No pending operation and we are not about the reissue a recovery operation on this reservation.
                 self.logger.debug("Controller pending request completed {}".format(reservation))
-                if reservation.get_state() == ReservationStates.Closed.value:
+                if reservation.is_closed():
                     # do nothing handled by close(IReservation)
                     self.logger.debug("No op")
                 elif reservation.is_active_ticketed():
@@ -152,10 +152,10 @@ class ControllerCalendarPolicy(Policy, ABCControllerPolicy):
                             reservation.set_dirty()
                             self.calendar.add_renewing(reservation=reservation, cycle=reservation.get_renew_time())
 
-                    if not reservation.is_active_joined():
-                        # add to the pending notify list so that we can raise the event
-                        # when transfer in operations complete.
-                        self.pending_notify.add(reservation=reservation)
+                        if not reservation.is_active_joined():
+                            # add to the pending notify list so that we can raise the event
+                            # when transfer in operations complete.
+                            self.pending_notify.add(reservation=reservation)
                 elif reservation.get_state() == ReservationStates.CloseWait or \
                         reservation.get_state() == ReservationStates.Failed:
                     self.pending_notify.remove(reservation=reservation)
@@ -164,7 +164,7 @@ class ControllerCalendarPolicy(Policy, ABCControllerPolicy):
                         reservation))
                     continue
 
-                if self.pending_notify.contains(reservation=reservation):
+                if not self.pending_notify.contains(reservation=reservation):
                     self.logger.debug("Removing from pending: {}".format(reservation))
                     self.calendar.remove_pending(reservation=reservation)
 

--- a/fabric_cf/actor/core/policy/controller_ticket_review_policy.py
+++ b/fabric_cf/actor/core/policy/controller_ticket_review_policy.py
@@ -174,5 +174,13 @@ class ControllerTicketReviewPolicy(ControllerSimplePolicy):
                         .format(reservation.get_reservation_id(), slice_obj.get_name()))
                     self.pending_redeem.add(reservation=reservation)
                     self.calendar.remove_pending(reservation=reservation)
+                else:
+                    # we don't need to look at any other reservations in this slice
+                    self.logger.debug("Removing from pendingRedeem: {}".format(reservation))
+                    self.pending_redeem.remove(reservation=reservation)
+            else:
+                # Remove active or close reservations
+                self.logger.debug("Removing from pendingRedeem: {}".format(reservation))
+                self.pending_redeem.remove(reservation=reservation)
 
         super().check_pending()


### PR DESCRIPTION
https://github.com/fabric-testbed/ControlFramework/issues/110


- Controller policy did not remove active or closed reservations from pending_redeem queue resulting in the active or closed reservations being added in the loop repeatedly and resulting in additional logs