### PR TITLE
Redeem order and SQ warnings

### DIFF
--- a/fabric_cf/actor/core/kernel/reservation_client.py
+++ b/fabric_cf/actor/core/kernel/reservation_client.py
@@ -379,7 +379,7 @@ class ReservationClient(Reservation, ABCKernelControllerReservationMixin):
                 self.logger.error("join predecessor reservation is in a terminal state. ignoring it: {}".
                                   format(pred_state.get_reservation()))
                 continue
-            if pred_state.get_reservation().is_active_joined():
+            if not pred_state.get_reservation().is_active_joined():
                 approved = False
                 break
 
@@ -411,7 +411,7 @@ class ReservationClient(Reservation, ABCKernelControllerReservationMixin):
                 self.logger.error("redeem predecessor reservation is in a terminal state or reservation is null."
                                   " ignoring it: {}".format(pred_state.get_reservation()))
                 continue
-            if pred_state.get_reservation().is_active_joined():
+            if not pred_state.get_reservation().is_active_joined():
                 approved = False
                 break
 

--- a/fabric_cf/actor/core/policy/authority_calendar_policy.py
+++ b/fabric_cf/actor/core/policy/authority_calendar_policy.py
@@ -450,7 +450,8 @@ class AuthorityCalendarPolicy(AuthorityPolicy):
         else:
             raise AuthorityException(Constants.UNSUPPORTED_RESOURCE_TYPE.format(token.get_resource_type()))
 
-    def is_expired(self, *, reservation: ABCReservationMixin) -> bool:
+    @staticmethod
+    def is_expired(*, reservation: ABCReservationMixin) -> bool:
         """
         See if a reservation has expired
 
@@ -548,7 +549,7 @@ class AuthorityCalendarPolicy(AuthorityPolicy):
                     break
             raise e
 
-    def get_network_node_from_graph(self, *, node_id: str) -> NodeSliver:
+    def get_network_node_from_graph(self, *, node_id: str) -> NodeSliver or None:
         try:
             self.lock.acquire()
             if self.aggregate_resource_model is None:
@@ -557,7 +558,7 @@ class AuthorityCalendarPolicy(AuthorityPolicy):
         finally:
             self.lock.release()
 
-    def get_network_service_from_graph(self, *, node_id: str) -> NetworkServiceSliver:
+    def get_network_service_from_graph(self, *, node_id: str) -> NetworkServiceSliver or None:
         try:
             self.lock.acquire()
             if self.aggregate_resource_model is None:

--- a/fabric_cf/actor/core/policy/broker_calendar_policy.py
+++ b/fabric_cf/actor/core/policy/broker_calendar_policy.py
@@ -25,11 +25,9 @@
 # Author: Komal Thareja (kthare10@renci.org)
 from __future__ import annotations
 
-import threading
 from datetime import datetime
 from typing import TYPE_CHECKING
 
-from fabric_cf.actor.core.common.constants import Constants
 from fabric_cf.actor.core.common.exceptions import BrokerException, ExceptionErrorCode
 from fabric_cf.actor.core.kernel.reservation_states import ReservationStates, ReservationPendingStates
 from fabric_cf.actor.core.time.calendar.broker_calendar import BrokerCalendar

--- a/fabric_cf/actor/core/policy/controller_calendar_policy.py
+++ b/fabric_cf/actor/core/policy/controller_calendar_policy.py
@@ -36,7 +36,6 @@ from fabric_cf.actor.core.kernel.reservation_states import ReservationStates, Re
 from fabric_cf.actor.core.kernel.resource_set import ResourceSet
 from fabric_cf.actor.core.time.term import Term
 from fabric_cf.actor.core.time.calendar.controller_calendar import ControllerCalendar
-from fabric_cf.actor.core.util.bids import Bids
 from fabric_cf.actor.core.util.reservation_set import ReservationSet
 
 


### PR DESCRIPTION
Addresses: https://github.com/fabric-testbed/ControlFramework/issues/116
Issue: Redeem for Network Services was triggered before the VMs became Active
Root cause: missing not operator while checking the state of the preceding reservations 


Also, addresses some of SQ warnings about unused arguments and imports