### PR TITLE
Network Reservations do not redeem

### DIFF
--- a/fabric_cf/Design.md
+++ b/fabric_cf/Design.md
@@ -37,7 +37,7 @@ Complete Flow for all messages and processing at Orchestrator is described below
          - Trigger Kafka ticket exchange with broker
      - For NetworkNode:
        - Trigger Kafka ticket exchange with broker
-     - Redeem message exchange with AM once ticket is granted by Broker
+   - Redeem message exchange with AM once ticket is granted by Broker
 
 ### Broker
 Complete Flow for all messages and processing at Broker is described below:

--- a/fabric_cf/Design.md
+++ b/fabric_cf/Design.md
@@ -25,7 +25,7 @@ Complete Flow for all messages and processing at Orchestrator is described below
    - Ticket message exchange with broker
      - For NetworkServices: 
        - check for any predecessors i.e. NetworkNode reservations to be Ticketed
-       - If ticketed, reservation is moved to BlockedTicket state
+       - If not ticketed, reservation is moved to BlockedTicket state
        - If failed, fail the reservation
        - Else, 
          - Update BQM Node and Component Id in Node Map

--- a/fabric_cf/actor/core/apis/abc_database.py
+++ b/fabric_cf/actor/core/apis/abc_database.py
@@ -202,6 +202,20 @@ class ABCDatabase(ABC):
         """
 
     @abstractmethod
+    def get_reservations_by_graph_node_id_state(self, *, graph_node_id: str,
+                                                states: List[int]) -> List[ABCReservationMixin]:
+        """
+        Retrieves the specified reservations which correspond to a specific graph node
+
+        @param graph_node_id graph_node_id
+        @param states list of states
+
+        @return list of properties for reservations
+
+        @throws Exception in case of error
+        """
+
+    @abstractmethod
     def get_reservations_by_slice_id_state(self, *, slice_id: ID, state: int) -> List[ABCReservationMixin]:
         """
         Retrieves the specified reservations for a slice in a specific state

--- a/fabric_cf/actor/core/kernel/reservation_client.py
+++ b/fabric_cf/actor/core/kernel/reservation_client.py
@@ -448,11 +448,11 @@ class ReservationClient(Reservation, ABCKernelControllerReservationMixin):
 
         for ifs in self.resources.sliver.interface_info.interfaces.values():
             component_name, rid = ifs.get_node_map()
-            pred_state = self.redeem_predecessors.get(rid)
+            pred_state = self.redeem_predecessors.get(ID(uid=rid))
             parent_res = pred_state.get_reservation()
             if parent_res is not None and \
                     ReservationStates(parent_res.get_state()) == ReservationStates.Ticketed:
-                node_sliver = parent_res.get_sliver()
+                node_sliver = parent_res.get_resources().get_sliver()
                 component = node_sliver.attached_components_info.get_device(name=component_name)
                 graph_id, bqm_component_id = component.get_node_map()
                 graph_id, node_id = node_sliver.get_node_map()
@@ -500,7 +500,7 @@ class ReservationClient(Reservation, ABCKernelControllerReservationMixin):
         return approved
 
     def can_ticket(self) -> bool:
-        supported_ns = [ServiceType.L2STS.name, ServiceType.L2Bridge, ServiceType.L2PTP]
+        supported_ns = [ServiceType.L2STS.name, ServiceType.L2Bridge.name, ServiceType.L2PTP.name]
 
         ret_val = False
         if self.get_type() is not None:

--- a/fabric_cf/actor/core/kernel/reservation_client.py
+++ b/fabric_cf/actor/core/kernel/reservation_client.py
@@ -30,7 +30,9 @@ from typing import TYPE_CHECKING, List
 
 from datetime import datetime
 
+from fim.slivers.attached_components import ComponentType
 from fim.slivers.base_sliver import BaseSliver
+from fim.slivers.network_service import ServiceType, NetworkServiceSliver
 
 from fabric_cf.actor.core.apis.abc_authority_policy import ABCAuthorityPolicy
 from fabric_cf.actor.core.apis.abc_kernel_controller_reservation_mixin import ABCKernelControllerReservationMixin
@@ -47,6 +49,7 @@ from fabric_cf.actor.core.kernel.reservation_states import ReservationPendingSta
 from fabric_cf.actor.core.util.id import ID
 from fabric_cf.actor.core.util.reservation_state import ReservationState
 from fabric_cf.actor.core.util.update_data import UpdateData
+from fabric_cf.actor.fim.fim_helper import FimHelper
 
 if TYPE_CHECKING:
     from fabric_cf.actor.core.apis.abc_slice import ABCSlice
@@ -430,6 +433,85 @@ class ReservationClient(Reservation, ABCKernelControllerReservationMixin):
             return True
         return False
 
+    def prepare_ticket(self):
+        # Parent reservations have been Ticketed; Update BQM Node and Component Id in Node Map
+        # Used by Broker to set vlan - source: (c)
+        # local_name source: (a)
+        # NSO device name source: (a) - need to find the owner switch of the network service in CBM
+        # and take its .name or labels.local_name
+
+        assert self.resources is not None
+        assert self.resources.sliver is not None
+
+        if not isinstance(self.resources.sliver, NetworkServiceSliver):
+            return
+
+        for ifs in self.resources.sliver.interface_info.interfaces.values():
+            component_name, rid = ifs.get_node_map()
+            pred_state = self.redeem_predecessors.get(rid)
+            parent_res = pred_state.get_reservation()
+            if parent_res is not None and \
+                    ReservationStates(parent_res.get_state()) == ReservationStates.Ticketed:
+                node_sliver = parent_res.get_sliver()
+                component = node_sliver.attached_components_info.get_device(name=component_name)
+                graph_id, bqm_component_id = component.get_node_map()
+                graph_id, node_id = node_sliver.get_node_map()
+                ifs.set_node_map(node_map=(node_id, bqm_component_id))
+
+                # For shared NICs grab the MAC & VLAN from corresponding Interface Sliver
+                # maintained in the Parent Reservation Sliver
+                if component.get_type() == ComponentType.SharedNIC:
+                    parent_res_ifs_sliver = FimHelper.get_site_interface_sliver(component=component,
+                                                                                local_name=ifs.get_labels().local_name)
+                    parent_labs = parent_res_ifs_sliver.get_label_allocations()
+
+                    ifs.labels.set_fields(mac=parent_labs.mac, vlan=parent_labs.vlan)
+
+            self.logger.trace(f"Updated Network Res# {self.get_reservation_id()} {self.resources.sliver}")
+
+    def approve_ticket(self):
+        """
+        Ticket predicate: invoked internally to determine if the reservation
+        should be ticketed. This gives subclasses an opportunity sequence actions at the orchestrator side.
+
+        If false, the reservation enters a "BlockedTicket" sub-state until a subsequent approve_ticket returns true.
+        When true, the reservation can manipulate the current reservation's attributes to
+        facilitate ticketing from the broker. Note that approve_ticket may be polled multiple
+        times, and should be idempotent.
+
+
+        @return true if approved; false otherwise
+        """
+        approved = True
+        for pred_state in self.redeem_predecessors.values():
+            if pred_state.get_reservation() is None or \
+                    pred_state.get_reservation().is_failed() or \
+                    pred_state.get_reservation().is_closed() or pred_state.get_reservation().is_closing():
+                self.logger.error("redeem predecessor reservation is in a terminal state or reservation is null."
+                                  " ignoring it: {}".format(pred_state.get_reservation()))
+                continue
+            if not (pred_state.get_reservation().is_ticketed() or pred_state.get_reservation().is_active_ticketed()):
+                approved = False
+                break
+
+        if approved:
+            self.prepare_ticket()
+
+        return approved
+
+    def can_ticket(self) -> bool:
+        supported_ns = [ServiceType.L2STS.name, ServiceType.L2Bridge, ServiceType.L2PTP]
+
+        ret_val = False
+        if self.get_type() is not None:
+            resource_type_str = str(self.get_type())
+            if resource_type_str in supported_ns:
+                ret_val = self.approve_ticket()
+            else:
+                ret_val = True
+
+        return ret_val
+
     def can_renew(self) -> bool:
         """
         The reservation cannot be renewed if a previous renew attempt failed, or
@@ -760,14 +842,26 @@ class ReservationClient(Reservation, ABCKernelControllerReservationMixin):
         Called from a probe to monitor asynchronous processing related to the joinstate for controller.
         @raises Exception passed through from prepareJoin or prepareRedeem
         """
-        if self.state == ReservationStates.Nascent or self.state == ReservationStates.Closed or\
-                self.state == ReservationStates.Failed:
+        if self.state == ReservationStates.Closed or self.state == ReservationStates.Failed:
             self.transition_with_join(prefix="clearing join state for terminal reservation", state=self.state,
                                       pending=self.pending_state,
                                       join_state=JoinState.NoJoin)
             return
 
-        if self.joinstate == JoinState.BlockedRedeem:
+        if self.joinstate == JoinState.BlockedTicket:
+            # this is new reservation, and the ticket is
+            # blocked for a predecessor: see if we can get it going now.
+            assert self.state == ReservationStates.Nascent
+
+            if self.approve_ticket():
+                self.transition_with_join(prefix="unblock ticket", state=ReservationStates.Nascent,
+                                          pending=ReservationPendingStates.Ticketing, join_state=JoinState.NoJoin)
+
+                # This is a regular request for network resources to an upstream broker.
+                self.sequence_ticket_out += 1
+                RPCManagerSingleton.get().ticket(reservation=self)
+
+        elif self.joinstate == JoinState.BlockedRedeem:
             # this reservation has a ticket to redeem, and the redeem is
             # blocked for a predecessor: see if we can get it going now.
             assert self.state == ReservationStates.Ticketed
@@ -920,10 +1014,13 @@ class ReservationClient(Reservation, ABCKernelControllerReservationMixin):
                             pending=ReservationPendingStates.Ticketing)
 
             if not self.exported:
-                # This is a regular request for new resources to an upstream
-                # broker.
-                self.sequence_ticket_out += 1
-                RPCManagerSingleton.get().ticket(reservation=self)
+                if not self.can_ticket():
+                    self.transition_with_join(prefix="ticket blocked", state=ReservationStates.Nascent,
+                                              pending=self.pending_state, join_state=JoinState.BlockedTicket)
+                else:
+                    # This is a regular request for new resources to an upstream broker.
+                    self.sequence_ticket_out += 1
+                    RPCManagerSingleton.get().ticket(reservation=self)
 
         elif self.state == ReservationStates.Ticketed:
             self.transition_with_join(prefix="redeem blocked", state=ReservationStates.Ticketed,

--- a/fabric_cf/actor/core/kernel/reservation_states.py
+++ b/fabric_cf/actor/core/kernel/reservation_states.py
@@ -100,6 +100,7 @@ class JoinState(Enum):
     BlockedJoin = 33
     BlockedRedeem = 34
     Joining = 35
+    BlockedTicket = 36
 
     def __repr__(self):
         return self.name

--- a/fabric_cf/actor/core/plugins/db/actor_database.py
+++ b/fabric_cf/actor/core/plugins/db/actor_database.py
@@ -452,6 +452,26 @@ class ActorDatabase(ABCDatabase):
                 result.append(res_obj)
         return result
 
+    def get_reservations_by_graph_node_id_state(self, *, graph_node_id: str,
+                                                states: List[int]) -> List[ABCReservationMixin]:
+        result = []
+        res_dict_list = None
+        try:
+            self.lock.acquire()
+            res_dict_list = self.db.get_reservations_by_graph_node_id_and_state(graph_node_id=graph_node_id,
+                                                                                states=states)
+        except Exception as e:
+            self.logger.error(e)
+        finally:
+            self.lock.release()
+        if res_dict_list is not None:
+            for r in res_dict_list:
+                pickled_res = r.get(Constants.PROPERTY_PICKLE_PROPERTIES)
+                slice_id = r.get(Constants.RSV_SLC_ID)
+                res_obj = self._load_reservation_from_pickled_object(pickled_res=pickled_res, slice_id=slice_id)
+                result.append(res_obj)
+        return result
+
     def get_reservations_by_oidc_claim_sub(self, *, oidc_claim_sub: str) -> List[ABCReservationMixin]:
         result = []
         res_dict_list = None

--- a/fabric_cf/actor/core/policy/broker_simpler_units_policy.py
+++ b/fabric_cf/actor/core/policy/broker_simpler_units_policy.py
@@ -425,6 +425,7 @@ class BrokerSimplerUnitsPolicy(BrokerCalendarPolicy):
             inv = self.inventory.get(resource_type=resource_type)
 
             if inv is not None:
+                self.logger.debug(f"Inventory type: {type(inv)}")
                 term = Term(start=start, end=end)
                 return self.ticket_inventory(reservation=reservation, inv=inv, term=term,
                                              node_id_to_reservations=node_id_to_reservations)
@@ -913,8 +914,14 @@ class BrokerSimplerUnitsPolicy(BrokerCalendarPolicy):
         :param node_id_to_reservations:
         :return: list of reservations
         """
-        existing_reservations = self.actor.get_plugin().get_database().get_reservations_by_graph_node_id(
-            graph_node_id=node_id)
+        states = [ReservationStates.Active.value,
+                  ReservationStates.ActiveTicketed.value,
+                  ReservationStates.Ticketed.value,
+                  ReservationStates.Nascent.value]
+
+        # Only get Active or Ticketing reservations
+        existing_reservations = self.actor.get_plugin().get_database().get_reservations_by_graph_node_id_state(
+            graph_node_id=node_id, states=states)
 
         reservations_allocated_in_cycle = node_id_to_reservations.get(node_id, None)
 

--- a/fabric_cf/actor/core/policy/broker_simpler_units_policy.py
+++ b/fabric_cf/actor/core/policy/broker_simpler_units_policy.py
@@ -47,6 +47,7 @@ from fabric_cf.actor.core.apis.abc_reservation_mixin import ABCReservationMixin
 from fabric_cf.actor.core.common.constants import Constants
 from fabric_cf.actor.core.delegation.resource_ticket import ResourceTicketFactory
 from fabric_cf.actor.core.common.exceptions import BrokerException, ExceptionErrorCode
+from fabric_cf.actor.core.kernel.reservation_states import ReservationStates
 from fabric_cf.actor.core.policy.broker_calendar_policy import BrokerCalendarPolicy
 from fabric_cf.actor.core.policy.fifo_queue import FIFOQueue
 from fabric_cf.actor.core.time.actor_clock import ActorClock
@@ -63,7 +64,6 @@ if TYPE_CHECKING:
     from fabric_cf.actor.core.apis.abc_broker_mixin import ABCBrokerMixin
     from fabric_cf.actor.core.policy.inventory_for_type import InventoryForType
     from fabric_cf.actor.core.util.resource_type import ResourceType
-    from fabric_cf.actor.core.kernel.resource_set import ResourceSet
 
 
 class BrokerAllocationAlgorithm(Enum):

--- a/fabric_cf/actor/handlers/no_op_handler.py
+++ b/fabric_cf/actor/handlers/no_op_handler.py
@@ -70,6 +70,9 @@ class NoOpHandler(HandlerBase):
                                 if ns.interface_info is not None and ns.interface_info.interfaces is not None:
                                     for i in ns.interface_info.interfaces.values():
                                         self.get_logger().debug(f"ifs: {i}")
+                result = {Constants.PROPERTY_TARGET_NAME: Constants.TARGET_CREATE,
+                          Constants.PROPERTY_TARGET_RESULT_CODE: Constants.RESULT_CODE_OK,
+                          Constants.PROPERTY_ACTION_SEQUENCE_NUMBER: 0}
 
             elif isinstance(sliver, NetworkServiceSliver):
                 assert (sliver.get_type() is not None)
@@ -95,9 +98,9 @@ class NoOpHandler(HandlerBase):
                         assert (sliver.get_gateway().lab.ipv6 is not None)
                         assert (interface.labels.vlan is not None)
 
-            result = {Constants.PROPERTY_TARGET_NAME: Constants.TARGET_CREATE,
-                      Constants.PROPERTY_TARGET_RESULT_CODE: Constants.RESULT_CODE_OK,
-                      Constants.PROPERTY_ACTION_SEQUENCE_NUMBER: 0}
+                result = {Constants.PROPERTY_TARGET_NAME: Constants.TARGET_CREATE,
+                          Constants.PROPERTY_TARGET_RESULT_CODE: Constants.RESULT_CODE_OK,
+                          Constants.PROPERTY_ACTION_SEQUENCE_NUMBER: 0}
         except Exception as e:
             result = {Constants.PROPERTY_TARGET_NAME: Constants.TARGET_CREATE,
                       Constants.PROPERTY_TARGET_RESULT_CODE: Constants.RESULT_CODE_EXCEPTION,

--- a/fabric_cf/actor/security/access_checker.py
+++ b/fabric_cf/actor/security/access_checker.py
@@ -50,9 +50,7 @@ class AccessChecker:
         pdp_config = GlobalsSingleton.get().get_config().get_global_config().get_pdp_config()
 
         fabric_token = FabricToken(logger=logger, token=token)
-
-        if pdp_config['enable']:
-            fabric_token.validate()
+        fabric_token.validate()
 
         pdp_auth = PdpAuth(config=pdp_config, logger=logger)
         pdp_auth.check_access(fabric_token=fabric_token.get_decoded_token(),

--- a/fabric_cf/actor/security/access_checker.py
+++ b/fabric_cf/actor/security/access_checker.py
@@ -50,7 +50,9 @@ class AccessChecker:
         pdp_config = GlobalsSingleton.get().get_config().get_global_config().get_pdp_config()
 
         fabric_token = FabricToken(logger=logger, token=token)
-        fabric_token.validate()
+
+        if pdp_config['enable']:
+            fabric_token.validate()
 
         pdp_auth = PdpAuth(config=pdp_config, logger=logger)
         pdp_auth.check_access(fabric_token=fabric_token.get_decoded_token(),

--- a/fabric_cf/authority/test/test-netam.yaml
+++ b/fabric_cf/authority/test/test-netam.yaml
@@ -28,8 +28,8 @@
 # actor will use sane defaults, in the absence of this configuration file.
 
 runtime:
-  kafka-server: 152.54.15.56:29092
-  kafka-schema-registry-url: http://152.54.15.56:8081
+  kafka-server: alpha-6.fabric-testbed.net:29092
+  kafka-schema-registry-url: http://alpha-6.fabric-testbed.net:8081
   kafka-key-schema: ../../../schema/key.avsc
   kafka-value-schema: ../../../schema/message.avsc
   kafka-ssl-ca-location:  ../../../secrets/snakeoil-ca-1.crt
@@ -79,7 +79,7 @@ database:
   db-user: fabric
   db-password: fabric
   db-name: netam
-  db-host: 152.54.15.56:5432
+  db-host: alpha-6.fabric-testbed.net:5432
 
 container:
   container.guid: net1-am-conainer

--- a/fabric_cf/authority/test/test.yaml
+++ b/fabric_cf/authority/test/test.yaml
@@ -28,8 +28,8 @@
 # actor will use sane defaults, in the absence of this configuration file.
 
 runtime:
-  kafka-server: 152.54.15.56:29092
-  kafka-schema-registry-url: http://152.54.15.56:8081
+  kafka-server: alpha-6.fabric-testbed.net:29092
+  kafka-schema-registry-url: http://alpha-6.fabric-testbed.net:8081
   kafka-key-schema: ../../../schema/key.avsc
   kafka-value-schema: ../../../schema/message.avsc
   kafka-ssl-ca-location:  ../../../secrets/snakeoil-ca-1.crt
@@ -79,7 +79,7 @@ database:
   db-user: fabric
   db-password: fabric
   db-name: am
-  db-host: 152.54.15.56:5432
+  db-host: alpha-6.fabric-testbed.net:5432
 
 container:
   container.guid: site1-am-conainer

--- a/fabric_cf/broker/test/test.yaml
+++ b/fabric_cf/broker/test/test.yaml
@@ -28,8 +28,8 @@
 # actor will use sane defaults, in the absence of this configuration file.
 
 runtime:
-  kafka-server: 152.54.15.56:29092
-  kafka-schema-registry-url: http://152.54.15.56:8081
+  kafka-server: alpha-6.fabric-testbed.net:29092
+  kafka-schema-registry-url: http://alpha-6.fabric-testbed.net:8081
   kafka-key-schema: ../../../schema/key.avsc
   kafka-value-schema: ../../../schema/message.avsc
   kafka-ssl-ca-location:  ../../../secrets/snakeoil-ca-1.crt
@@ -77,7 +77,7 @@ database:
   db-user: fabric
   db-password: fabric
   db-name: broker
-  db-host: 152.54.15.56:5432
+  db-host: alpha-6.fabric-testbed.net:5432
 
 container:
   container.guid: broker-conainer

--- a/fabric_cf/orchestrator/core/orchestrator_handler.py
+++ b/fabric_cf/orchestrator/core/orchestrator_handler.py
@@ -68,9 +68,6 @@ class OrchestratorHandler:
         :param token:
         :return:
         """
-        # for testing; disable token validation
-        if not self.pdp_config['enable']:
-            return {}
         try:
             fabric_token = FabricToken(logger=self.logger, token=token)
 

--- a/fabric_cf/orchestrator/core/orchestrator_handler.py
+++ b/fabric_cf/orchestrator/core/orchestrator_handler.py
@@ -264,7 +264,8 @@ class OrchestratorHandler:
             # Once added to the policy; Actor Tick Handler will do following asynchronously:
             # 1. Ticket message exchange with broker and
             # 2. Redeem message exchange with AM once ticket is granted by Broker
-            self.controller_state.get_sdt().process_slice(controller_slice=orchestrator_slice)
+            self.controller_state.demand_slice(controller_slice=orchestrator_slice)
+            # self.controller_state.get_sdt().process_slice(controller_slice=orchestrator_slice)
 
             return ResponseBuilder.get_reservation_summary(res_list=computed_reservations)
         except Exception as e:

--- a/fabric_cf/orchestrator/core/orchestrator_handler.py
+++ b/fabric_cf/orchestrator/core/orchestrator_handler.py
@@ -68,6 +68,9 @@ class OrchestratorHandler:
         :param token:
         :return:
         """
+        # for testing; disable token validation
+        if not self.pdp_config['enable']:
+            return {}
         try:
             fabric_token = FabricToken(logger=self.logger, token=token)
 

--- a/fabric_cf/orchestrator/core/response_builder.py
+++ b/fabric_cf/orchestrator/core/response_builder.py
@@ -210,7 +210,7 @@ class ResponseBuilder:
 
         # Network Service Specific Fields
         if isinstance(sliver, NetworkServiceSliver):
-            print("TODO")
+            print("TODO: populate NetworkServiceSliver fields")
 
         return result
 

--- a/fabric_cf/orchestrator/core/slice_defer_thread.py
+++ b/fabric_cf/orchestrator/core/slice_defer_thread.py
@@ -33,7 +33,6 @@ from fim.user import ServiceType
 
 from fabric_cf.actor.core.common.constants import Constants
 from fabric_cf.actor.core.kernel.reservation_states import ReservationStates
-from fabric_cf.actor.core.time.term import Term
 from fabric_cf.orchestrator.core.exceptions import OrchestratorException
 from fabric_cf.orchestrator.core.orchestrator_slice_wrapper import OrchestratorSliceWrapper
 
@@ -68,9 +67,9 @@ class SliceDeferThread:
             self.max_create_wait_time = wait_time
 
         self.delay_resource_types = []
-        self.delay_resource_types.append(str(ServiceType.L2STS))
-        self.delay_resource_types.append(str(ServiceType.L2Bridge))
-        self.delay_resource_types.append(str(ServiceType.L2PTP))
+        # self.delay_resource_types.append(str(ServiceType.L2STS))
+        # self.delay_resource_types.append(str(ServiceType.L2Bridge))
+        # self.delay_resource_types.append(str(ServiceType.L2PTP))
 
     def queue_slice(self, *, controller_slice: OrchestratorSliceWrapper):
         """

--- a/fabric_cf/orchestrator/core/slice_defer_thread.py
+++ b/fabric_cf/orchestrator/core/slice_defer_thread.py
@@ -260,10 +260,10 @@ class SliceDeferThread:
                     self.logger.debug(f"Reservation not in {reservation.get_state()} state, ignoring it")
                     continue
 
-                if not controller_slice.check_predecessors_ticketed(reservation=reservation) and not force:
-                    self.logger.info(f"Reservation waiting for predecessors to be ticketed, ignoring it")
-                    ret_val = True
-                    continue
+                #if not controller_slice.check_predecessors_ticketed(reservation=reservation) and not force:
+                #    self.logger.info(f"Reservation waiting for predecessors to be ticketed, ignoring it")
+                #    ret_val = True
+                #    continue
 
                 if not controller.demand_reservation(reservation=reservation):
                     raise OrchestratorException(f"Could not demand resources: {controller.get_last_error()}")

--- a/fabric_cf/orchestrator/core/slice_defer_thread.py
+++ b/fabric_cf/orchestrator/core/slice_defer_thread.py
@@ -66,10 +66,9 @@ class SliceDeferThread:
         else:
             self.max_create_wait_time = wait_time
 
-        self.delay_resource_types = []
-        # self.delay_resource_types.append(str(ServiceType.L2STS))
-        # self.delay_resource_types.append(str(ServiceType.L2Bridge))
-        # self.delay_resource_types.append(str(ServiceType.L2PTP))
+        self.delay_resource_types = [ServiceType.L2STS.name,
+                                     ServiceType.L2Bridge.name,
+                                     ServiceType.L2PTP.name]
 
     def queue_slice(self, *, controller_slice: OrchestratorSliceWrapper):
         """
@@ -260,10 +259,10 @@ class SliceDeferThread:
                     self.logger.debug(f"Reservation not in {reservation.get_state()} state, ignoring it")
                     continue
 
-                #if not controller_slice.check_predecessors_ticketed(reservation=reservation) and not force:
-                #    self.logger.info(f"Reservation waiting for predecessors to be ticketed, ignoring it")
-                #    ret_val = True
-                #    continue
+                if not controller_slice.check_predecessors_ticketed(reservation=reservation) and not force:
+                    self.logger.info(f"Reservation waiting for predecessors to be ticketed, ignoring it")
+                    ret_val = True
+                    continue
 
                 if not controller.demand_reservation(reservation=reservation):
                     raise OrchestratorException(f"Could not demand resources: {controller.get_last_error()}")

--- a/fabric_cf/orchestrator/test/test.yaml
+++ b/fabric_cf/orchestrator/test/test.yaml
@@ -28,8 +28,8 @@
 # actor will use sane defaults, in the absence of this configuration file.
 
 runtime:
-  kafka-server: 152.54.15.56:29092
-  kafka-schema-registry-url: http://152.54.15.56:8081
+  kafka-server: alpha-6.fabric-testbed.net:29092
+  kafka-schema-registry-url: http://alpha-6.fabric-testbed.net:8081
   kafka-key-schema: ../../../schema/key.avsc
   kafka-value-schema: ../../../schema/message.avsc
   kafka-ssl-ca-location:  ../../../secrets/snakeoil-ca-1.crt
@@ -73,7 +73,7 @@ database:
   db-user: fabric
   db-password: fabric
   db-name: orchestrator
-  db-host: 152.54.15.56:5432
+  db-host: alpha-6.fabric-testbed.net:5432
 
 pdp:
   url: http://localhost:8082/services/pdp


### PR DESCRIPTION
Addresses: https://github.com/fabric-testbed/ControlFramework/issues/151

- Removed Slice Defer Thread
- Demand reservations as they are requested
- Modified the Reservation Client for Network Service Reservations
   - Check predecessors before triggering ticket
   - Fail network reservations if any of the predecessors are in failed or closed state
- Improve Broker policy to look for only Active/Ticketed reservations when doing lookups for a specific BQM node reservations 