### PR TITLE
Better error reporting for Slices -- compare from 1.1.

### DIFF
--- a/fabric_cf/actor/core/kernel/reservation.py
+++ b/fabric_cf/actor/core/kernel/reservation.py
@@ -303,8 +303,8 @@ class Reservation(ABCKernelReservation):
 
         @return notices string
         """
-        msg = f"Reservation {self.rid} (Slice {self.slice} ) is in state [{self.get_state_name()}," \
-              f"{self.get_pending_state_name()}]"
+        msg = f"Reservation {self.rid} is in state ({self.get_state_name()}," \
+              f"{self.get_pending_state_name()})"
 
         if self.error_message is not None and self.error_message != "":
             msg += f", err={self.error_message}"

--- a/fabric_cf/actor/core/kernel/reservation_client.py
+++ b/fabric_cf/actor/core/kernel/reservation_client.py
@@ -782,17 +782,17 @@ class ReservationClient(Reservation, ABCKernelControllerReservationMixin):
         result = ""
         if self.last_ticket_update is not None:
             if self.last_ticket_update.get_message() is not None and self.last_ticket_update.get_message() != "":
-                result += f" [Last ticket update: {self.last_ticket_update.get_message()}]"
+                result += f" (Last ticket update: {self.last_ticket_update.get_message()})"
             ev = self.last_ticket_update.get_events()
             if ev is not None and ev != "":
-                result += f" [Ticket events: {ev}]"
+                result += f" (Ticket events: {ev})"
 
         if self.last_lease_update is not None:
             if self.last_lease_update.get_message() is not None and self.last_lease_update.get_message() != "":
-                result += f" [Last ticket update: {self.last_lease_update.get_message()}]"
+                result += f" (Last ticket update: {self.last_lease_update.get_message()})"
             ev = self.last_lease_update.get_events()
             if ev is not None and ev != "":
-                result += f" [Ticket events: {ev}]"
+                result += f" (Ticket events: {ev})"
         return result
 
     def is_active(self) -> bool:

--- a/fabric_cf/actor/core/policy/network_node_inventory.py
+++ b/fabric_cf/actor/core/policy/network_node_inventory.py
@@ -463,7 +463,7 @@ class NetworkNodeInventory(InventoryForType):
                 existing_reservations=existing_reservations)
 
         requested_sliver.capacity_allocations = Capacities()
-        requested_sliver.capacity_allocations.update(lab=requested_capacities)
+        requested_sliver.capacity_allocations = Labels.update(lab=requested_capacities)
         requested_sliver.label_allocations = Labels(instance_parent=graph_node.get_name())
 
         requested_sliver.set_node_map(node_map=(graph_id, graph_node.node_id))

--- a/fabric_cf/actor/core/util/update_data.py
+++ b/fabric_cf/actor/core/util/update_data.py
@@ -107,7 +107,7 @@ class UpdateData:
         if self.events is None:
             self.events = event
         else:
-            self.events = f"[{event}-{self.events}]"
+            self.events = f"({event}-{self.events})"
 
     def post_error(self, *, event: str):
         """

--- a/fabric_cf/orchestrator/core/response_builder.py
+++ b/fabric_cf/orchestrator/core/response_builder.py
@@ -124,13 +124,15 @@ class ResponseBuilder:
 
     @staticmethod
     def get_slice_summary(*, slice_list: List[SliceAvro], slice_id: str = None,
-                          slice_states: List[SliceState] = None, slice_model: str = None) -> dict:
+                          slice_states: List[SliceState] = None, slice_model: str = None,
+                          error_message: dict = None) -> dict:
         """
         Get slice summary
         :param slice_list:
         :param slice_id:
         :param slice_states:
         :param slice_model:
+        :param error_message:
         :return:
         """
         slices = []
@@ -151,8 +153,11 @@ class ResponseBuilder:
                 if end_time is not None:
                     s_dict[ResponseBuilder.PROP_LEASE_END_TIME] = end_time.strftime(Constants.LEASE_TIME_FORMAT)
 
-                if slice_id is not None and slice_model is not None:
-                    s_dict[ResponseBuilder.RESPONSE_SLICE_MODEL]: slice_model
+                if slice_model is not None:
+                    s_dict[ResponseBuilder.RESPONSE_SLICE_MODEL] = slice_model
+
+                if error_message is not None and s.get_slice_id() in error_message:
+                    s_dict[ResponseBuilder.PROP_NOTICES] = error_message.get(s.get_slice_id())
                 slices.append(s_dict)
         else:
             message = "No slices were found"


### PR DESCRIPTION
Addresses: https://github.com/fabric-testbed/ControlFramework/issues/146

For Slices not in StableOK state, returns status for all reservations in Closed, Failed or CloseWait state in notices field.
Snapshot response indicated below:

```
[{
    "graph_id": "33768d1e-0e8d-4306-8c41-9652fee8aff7",
    "lease_end": "2022-02-16 18:39:51",
    "notices": "[Reservation a03b7de6-e3fe-4388-affc-e1d2bb1af741 is in state (Closed,None_)  (Last ticket update: Redeem/Ticket timeout)],[Reservation 67363c30-e630-4713-9a5b-e497117b6ce4 is in state (Closed,None_)  (Last ticket update: Redeem/Ticket timeout)],[Reservation 403029cb-ef9c-4baf-938b-dac1e3baf9bc is in state (Closed,None_), err=redeem predecessor reservation# a03b7de6-e3fe-4388-affc-e1d2bb1af741 is in a terminal state ]",
    "slice_id": "96d91609-27a1-400a-9a58-53f1334903cc",
    "slice_name": "s1",
    "slice_state": "Dead"
}, {
    "graph_id": "2da644bf-1eca-411e-9c20-54229bdc52be",
    "lease_end": "2022-02-16 20:21:29",
    "notices": "[Reservation e3d3e286-dc28-4f6f-af05-29d0aae68d5a is in state (Closed,None_), err=redeem predecessor reservation# c95fea94-289e-4683-bd86-6c7a09adf047 is in a terminal state ],[Reservation c95fea94-289e-4683-bd86-6c7a09adf047 is in state (Closed,None_)  (Last ticket update: Redeem/Ticket timeout)],[Reservation 7cc513fe-0890-4c98-bd08-c0aa4f972cd6 is in state (Closed,None_)  (Last ticket update: Redeem/Ticket timeout)]",
    "slice_id": "549b59b4-0e76-4902-901c-b6ec6ec87726",
    "slice_name": "s1",
    "slice_state": "Dead"
}]
```