### PR TITLE
Updated code for generating ABQM that accommodates facilities; tested

### DIFF
--- a/fabric_cf/actor/fim/plugins/broker/aggregate_bqm_plugin.py
+++ b/fabric_cf/actor/fim/plugins/broker/aggregate_bqm_plugin.py
@@ -29,7 +29,7 @@ from collections import defaultdict
 
 import uuid
 
-from fim.graph.abc_property_graph import ABCPropertyGraph
+from fim.graph.abc_property_graph import ABCPropertyGraph, PropertyGraphQueryException
 from fim.graph.resources.abc_cbm import ABCCBMPropertyGraph
 from fim.graph.resources.abc_bqm import ABCBQMPropertyGraph
 from fim.graph.networkx_property_graph import NetworkXGraphImporter
@@ -115,6 +115,7 @@ class AggregatedBQMPlugin:
             return cbm.clone_graph(new_graph_id=str(uuid.uuid4()))
 
         # do a one-pass aggregation of servers, their components and interfaces
+        # this includes facilities
         nnodes = cbm.get_all_nodes_by_class(label=ABCPropertyGraph.CLASS_NetworkNode)
         slivers_by_site = defaultdict(list)
         for n in nnodes:
@@ -129,6 +130,7 @@ class AggregatedBQMPlugin:
 
         site_to_composite_node_id = dict()
         site_to_ns_node_id = dict()
+        facilities_by_site = defaultdict(list)
         for s, ls in slivers_by_site.items():
             # add up capacities and delegated capacities, skip labels for now
             # count up components and figure out links between site
@@ -149,7 +151,10 @@ class AggregatedBQMPlugin:
             loc = None
             for sliver in ls:
                 if sliver.get_type() != NodeType.Server:
-                    # skipping NAS and dataplane switches
+                    # skipping NAS, Facility and dataplane switches
+                    if sliver.get_type() == NodeType.Facility:
+                        # keep track of facilities for each site
+                        facilities_by_site[s].append(sliver)
                     continue
                 if self.DEBUG_FLAG:
                     # for debugging and running in a test environment
@@ -250,18 +255,21 @@ class AggregatedBQMPlugin:
             source_cp_props = {ABCPropertyGraph.PROP_NAME: "_".join([source_site, sink_site]),
                                ABCPropertyGraph.PROP_TYPE: str(InterfaceType.TrunkPort),
                                ABCPropertyGraph.PROP_CLASS: ABCPropertyGraph.CLASS_ConnectionPoint,
-                               ABCPropertyGraph.PROP_CAPACITIES:
-                                   cbm_source_cp_props.get(ABCPropertyGraph.PROP_CAPACITIES)}
-            source_cp_props = self._remove_none_entries(source_cp_props)
+                               ABCPropertyGraph.PROP_LABELS: cbm_source_cp_props.get(ABCPropertyGraph.PROP_LABELS),
+                               ABCPropertyGraph.PROP_CAPACITIES: cbm_source_cp_props.get(ABCPropertyGraph.PROP_CAPACITIES)
+                               }
+            source_cp_props = {k: v for (k, v) in source_cp_props.items() if v}
+
             abqm.add_node(node_id=source_cp_id, label=ABCPropertyGraph.CLASS_ConnectionPoint,
                           props=source_cp_props)
             # FIXME: CP names may not be unique if we are dealing with a multigraph
             sink_cp_props = {ABCPropertyGraph.PROP_NAME: "_".join([sink_site, source_site]),
                              ABCPropertyGraph.PROP_TYPE: str(InterfaceType.TrunkPort),
                              ABCPropertyGraph.PROP_CLASS: ABCPropertyGraph.CLASS_ConnectionPoint,
-                             ABCPropertyGraph.PROP_CAPACITIES:
-                                 cbm_sink_cp_props.get(ABCPropertyGraph.PROP_CAPACITIES)}
-            sink_cp_props = self._remove_none_entries(sink_cp_props)
+                             ABCPropertyGraph.PROP_LABELS: cbm_sink_cp_props.get(ABCPropertyGraph.PROP_LABELS),
+                             ABCPropertyGraph.PROP_CAPACITIES: cbm_sink_cp_props.get(ABCPropertyGraph.PROP_CAPACITIES)
+                             }
+            sink_cp_props = {k: v for (k, v) in sink_cp_props.items() if v}
             abqm.add_node(node_id=sink_cp_id, label=ABCPropertyGraph.CLASS_ConnectionPoint,
                           props=sink_cp_props)
             # selectively replicate link node and its properties from CBM
@@ -281,62 +289,96 @@ class AggregatedBQMPlugin:
             abqm.add_link(node_a=sink_cp_id, rel=ABCPropertyGraph.REL_CONNECTS,
                           node_b=site_to_ns_node_id[sink_site])
 
-        # get all stitch ports and connect them to the CompositeNode
-        facility_ports = cbm.get_all_nodes_by_class_and_type(label=ABCPropertyGraph.CLASS_ConnectionPoint,
-                                                             ntype=str(InterfaceType.FacilityPort))
-        # figure out which composite node/site this connects to
-        for fac_port in facility_ports:
-            peers = cbm.find_peer_connection_points(node_id=fac_port)
-            _, fac_port_props = cbm.get_node_properties(node_id=fac_port)
-            for peer in peers:
-                _, peer_props = cbm.get_node_properties(node_id=peer)
-                # find matching trunk port
-                if peer_props[ABCPropertyGraph.PROP_TYPE] == str(InterfaceType.TrunkPort):
-                    # trace to its parent
-                    peer_parents = cbm.get_first_and_second_neighbor(node_id=peer,
-                                                                     rel1=ABCPropertyGraph.REL_CONNECTS,
-                                                                     node1_label=ABCPropertyGraph.CLASS_NetworkService,
-                                                                     rel2=ABCPropertyGraph.REL_HAS,
-                                                                     node2_label=ABCPropertyGraph.CLASS_NetworkNode)
-                    # link connecting peer to facility port
-                    peer_link = cbm.get_first_neighbor(node_id=peer, rel=ABCPropertyGraph.REL_CONNECTS,
-                                                       node_label=ABCPropertyGraph.CLASS_Link)[0]
-                    _, peer_link_props = cbm.get_node_properties(node_id=peer_link)
-                    if len(peer_parents) != 1:
-                        # something strange here, skip
-                        continue
+        # link facilities to their sites
+        for s, lf in facilities_by_site.items():
+            # multiple facilities per site possible
+            for fac_sliver in lf:
+                fac_nbs = cbm.get_first_and_second_neighbor(node_id=fac_sliver.node_id,
+                                                            rel1=ABCPropertyGraph.REL_HAS,
+                                                            node1_label=ABCPropertyGraph.CLASS_NetworkService,
+                                                            rel2=ABCPropertyGraph.REL_CONNECTS,
+                                                            node2_label=ABCPropertyGraph.CLASS_ConnectionPoint)
+                try:
+                    fac_ns_node_id = fac_nbs[0][0]
+                    fac_cp_node_id = fac_nbs[0][1]
+                except KeyError:
+                    if self.logger:
+                        self.logger.warning(f'Unable to trace facility ConnectionPoint for '
+                                            f'facility {fac_sliver.resource_name}, continuing')
                     else:
-                        _, parent_props = cbm.get_node_properties(node_id=peer_parents[0][1])
-                        parent_site = parent_props[ABCPropertyGraph.PROP_SITE]
-                        fp_link_props = {ABCPropertyGraph.PROP_NAME: fac_port_props[ABCPropertyGraph.PROP_NAME],
-                                         ABCPropertyGraph.PROP_TYPE: peer_link_props[ABCPropertyGraph.PROP_TYPE]}
-                        fp_cpoint_props = {ABCPropertyGraph.PROP_NAME: parent_props[ABCPropertyGraph.PROP_NAME] + '-' +
-                                                                       fac_port_props[ABCPropertyGraph.PROP_NAME],
-                                           ABCPropertyGraph.PROP_TYPE: peer_props[ABCPropertyGraph.PROP_TYPE],
-                                           ABCPropertyGraph.PROP_CAPACITIES:
-                                               peer_props.get(ABCPropertyGraph.PROP_CAPACITIES),
-                                           ABCPropertyGraph.PROP_LABELS: peer_props.get(ABCPropertyGraph.PROP_LABELS)}
-                        fp_props = {ABCPropertyGraph.PROP_NAME: fac_port_props[ABCPropertyGraph.PROP_NAME],
-                                    ABCPropertyGraph.PROP_TYPE: fac_port_props[ABCPropertyGraph.PROP_TYPE],
-                                    ABCPropertyGraph.PROP_LABELS: fac_port_props.get(ABCPropertyGraph.PROP_LABELS),
-                                    ABCPropertyGraph.PROP_CAPACITIES:
-                                        fac_port_props.get(ABCPropertyGraph.PROP_CAPACITIES)}
-                        fp_cpoint_props = self._remove_none_entries(fp_cpoint_props)
-                        fp_props = self._remove_none_entries(fp_props)
-                        fp_link_id = str(uuid.uuid4())
-                        fp_cpoint_id = str(uuid.uuid4())
-                        fp_id = str(uuid.uuid4())
-                        abqm.add_node(node_id=fp_link_id, label=ABCPropertyGraph.CLASS_Link,
-                                      props=fp_link_props)
-                        abqm.add_node(node_id=fp_cpoint_id, label=ABCPropertyGraph.CLASS_ConnectionPoint,
-                                      props=fp_cpoint_props)
-                        abqm.add_node(node_id=fp_id, label=ABCPropertyGraph.CLASS_ConnectionPoint,
-                                      props=fp_props)
-                        abqm.add_link(node_a=site_to_ns_node_id[parent_site], rel=ABCPropertyGraph.REL_CONNECTS,
-                                      node_b=fp_cpoint_id)
-                        abqm.add_link(node_a=fp_cpoint_id, rel=ABCPropertyGraph.REL_CONNECTS,
-                                      node_b=fp_link_id)
-                        abqm.add_link(node_a=fp_link_id, rel=ABCPropertyGraph.REL_CONNECTS,
-                                      node_b=fp_id)
+                        print(f'Unable to trace facility ConnectionPoint for '
+                              f'facility {fac_sliver.resource_name}, continuing')
+                    continue
+                _, fac_props = cbm.get_node_properties(node_id=fac_sliver.node_id)
+                _, fac_ns_props = cbm.get_node_properties(node_id=fac_ns_node_id)
+                _, fac_cp_props = cbm.get_node_properties(node_id=fac_cp_node_id)
+
+                # filter down only the needed properties then recreate the structure of facility in ABQM
+                new_fac_props = {ABCPropertyGraph.PROP_NAME: fac_props[ABCPropertyGraph.PROP_NAME],
+                                 ABCPropertyGraph.PROP_TYPE: fac_props[ABCPropertyGraph.PROP_TYPE]
+                                 }
+                abqm.add_node(node_id=fac_sliver.node_id, label=ABCPropertyGraph.CLASS_NetworkNode,
+                              props=new_fac_props)
+                new_ns_props = {ABCPropertyGraph.PROP_NAME: fac_ns_props[ABCPropertyGraph.PROP_NAME],
+                                ABCPropertyGraph.PROP_TYPE: fac_ns_props[ABCPropertyGraph.PROP_TYPE]
+                                }
+                abqm.add_node(node_id=fac_ns_node_id, label=ABCPropertyGraph.CLASS_NetworkService,
+                              props=new_ns_props)
+                new_cp_props = {ABCPropertyGraph.PROP_NAME: fac_cp_props[ABCPropertyGraph.PROP_NAME],
+                                ABCPropertyGraph.PROP_TYPE: fac_cp_props[ABCPropertyGraph.PROP_TYPE],
+                                ABCPropertyGraph.PROP_LABELS: fac_cp_props.get(ABCPropertyGraph.PROP_LABELS),
+                                ABCPropertyGraph.PROP_CAPACITIES: fac_cp_props.get(ABCPropertyGraph.PROP_CAPACITIES)
+                                }
+                new_cp_props = {k: v for (k, v) in new_cp_props.items() if v}
+                abqm.add_node(node_id=fac_cp_node_id, label=ABCPropertyGraph.CLASS_ConnectionPoint,
+                              props=new_cp_props)
+                abqm.add_link(node_a=fac_sliver.node_id, rel=ABCPropertyGraph.REL_HAS, node_b=fac_ns_node_id)
+                abqm.add_link(node_a=fac_ns_node_id, rel=ABCPropertyGraph.REL_CONNECTS, node_b=fac_cp_node_id)
+
+                # trace the link to a switch port/ConnectionPoint and replicate them for simplicity
+                fac_cp_nbs = cbm.get_first_and_second_neighbor(node_id=fac_cp_node_id,
+                                                               rel1=ABCPropertyGraph.REL_CONNECTS,
+                                                               node1_label=ABCPropertyGraph.CLASS_Link,
+                                                               rel2=ABCPropertyGraph.REL_CONNECTS,
+                                                               node2_label=ABCPropertyGraph.CLASS_ConnectionPoint)
+                if len(fac_cp_nbs) == 0 or len(fac_cp_nbs) > 1:
+                    if self.logger:
+                        self.logger.warning(f'Unable to trace switch port from Facility port '
+                                            f'for facility {fac_sliver.resource_name} {fac_cp_nbs}')
+                    else:
+                        print(f'Unable to trace switch port from Facility port '
+                              f'for facility {fac_sliver.resource_name} {fac_cp_nbs}')
+                    continue
+
+                fac_link_id = fac_cp_nbs[0][0]
+                fac_sp_id = fac_cp_nbs[0][1]
+
+                _, fac_link_props = cbm.get_node_properties(node_id=fac_link_id)
+                # selectively replicate link properties
+                new_link_props = {ABCPropertyGraph.PROP_NAME: fac_link_props[ABCPropertyGraph.PROP_NAME],
+                                  ABCPropertyGraph.PROP_TYPE: fac_link_props[ABCPropertyGraph.PROP_TYPE],
+                                  ABCPropertyGraph.PROP_LAYER: fac_link_props[ABCPropertyGraph.PROP_LAYER]
+                                  }
+                abqm.add_node(node_id=fac_link_id, label=ABCPropertyGraph.CLASS_Link,
+                              props=new_link_props)
+                try:
+                    abqm.get_node_properties(node_id=fac_sp_id)
+                except PropertyGraphQueryException:
+                    # if the node doesn't exist we need to create it (it could have been created in the first pass)
+                    _, fac_sp_props = cbm.get_node_properties(node_id=fac_sp_id)
+                    new_sp_props = {ABCPropertyGraph.PROP_NAME: fac_sp_props[ABCPropertyGraph.PROP_NAME],
+                                    ABCPropertyGraph.PROP_TYPE: fac_sp_props[ABCPropertyGraph.PROP_TYPE],
+                                    ABCPropertyGraph.PROP_CAPACITIES: fac_sp_props.get(
+                                        ABCPropertyGraph.PROP_CAPACITIES),
+                                    ABCPropertyGraph.PROP_LABELS: fac_sp_props.get(ABCPropertyGraph.PROP_LABELS)
+                                    }
+                    new_sp_props = {k: v for (k, v) in new_sp_props.items() if v}
+                    abqm.add_node(node_id=fac_sp_id, label=ABCPropertyGraph.CLASS_ConnectionPoint,
+                                  props=new_sp_props)
+
+                # link these together
+                abqm.add_link(node_a=fac_cp_node_id, rel=ABCPropertyGraph.REL_CONNECTS, node_b=fac_link_id)
+                abqm.add_link(node_a=fac_link_id, rel=ABCPropertyGraph.REL_CONNECTS, node_b=fac_sp_id)
+                abqm.add_link(node_a=fac_sp_id, rel=ABCPropertyGraph.REL_CONNECTS, node_b=site_to_ns_node_id[s])
 
         return abqm

--- a/fabric_cf/actor/test/config/config.test.yaml
+++ b/fabric_cf/actor/test/config/config.test.yaml
@@ -107,7 +107,7 @@ neo4j:
   url: bolt://localhost:7687
   user: neo4j
   pass: password
-  import_host_dir: ../../../../../neo4j1/imports/
+  import_host_dir: ../../../neo4j1/imports/
   import_dir: /imports
 
 actor:
@@ -116,7 +116,7 @@ actor:
   guid: site1-am-guid
   description: Site AM
   kafka-topic: site1-am-topic
-  substrate.file: ../../../../../neo4j/RENCI-ad.graphml
+  substrate.file: ../../neo4j/RENCI-ad.graphml
   policy:
       module: fabric_cf.actor.core.policy.authority_calendar_policy
       class: AuthorityCalendarPolicy

--- a/neo4j/LBNL-ad.graphml
+++ b/neo4j/LBNL-ad.graphml
@@ -16,184 +16,218 @@
   <key id="d1" for="node" attr.name="Class" attr.type="string" />
   <key id="d0" for="node" attr.name="GraphID" attr.type="string" />
   <graph edgedefault="undirected">
-    <node id="1">
-      <data key="d0">307a43ea-2e59-42c6-8581-71e2a37300f6</data>
+    <node id="603">
+      <data key="d0">feb611c8-5b09-4132-a69c-be9adf894536</data>
       <data key="d1">NetworkNode</data>
       <data key="d2">5B3BR53</data>
-      <data key="d3">lbnl-w1.fabric-testbed.net</data>
+      <data key="d3">lbnl-w1</data>
       <data key="d4">Server</data>
       <data key="d5">R7525</data>
-      <data key="d6">{"core": 64, "cpu": 2, "disk": 51000, "ram": 512, "unit": 1}</data>
+      <data key="d6">{"core": 32, "cpu": 2, "disk": 100000, "ram": 512, "unit": 1}</data>
       <data key="d7">false</data>
       <data key="d8">LBNL</data>
-      <data key="d9">{"postal": "1 Cyclotron Rd,Berkeley, CA 94720"}</data>
-      <data key="d10">{"primary": {"pool_id": "_", "capacities": {"cpu": 2, "core": 64, "ram": 512, "disk": 51000, "unit": 1}}}</data>
+      <data key="d9">{"postal": "1 Cyclotron Rd, Berkeley, CA 94720"}</data>
+      <data key="d10">{"primary": {"pool_id": "_", "capacities": {"cpu": 2, "core": 32, "ram": 512, "disk": 100000, "unit": 1}}}</data>
     </node>
-    <node id="2">
-      <data key="d0">307a43ea-2e59-42c6-8581-71e2a37300f6</data>
-      <data key="d1">Component</data>
-      <data key="d2">PHLJ015301XE1P0FGN</data>
-      <data key="d3">lbnl-w1.fabric-testbed.net-nvme-1</data>
-      <data key="d4">NVME</data>
-      <data key="d5">P4510</data>
-      <data key="d6">{"disk": 1000, "unit": 1}</data>
-      <data key="d11">{"bdf": "0000:21:00.0"}</data>
-      <data key="d12">Dell Express Flash NVMe P4510 1TB SFF in PCIe SSD Slot 22 in Bay 2 (0000:21:00.0)</data>
-      <data key="d7">false</data>
-      <data key="d10">{"primary": {"pool_id": "_", "capacities": {"disk": 1000, "unit": 1}}}</data>
-      <data key="d13">{"primary": {"pool_id": "_", "labels": {"bdf": "0000:21:00.0"}}}</data>
-    </node>
-    <node id="3">
-      <data key="d0">307a43ea-2e59-42c6-8581-71e2a37300f6</data>
-      <data key="d1">Component</data>
-      <data key="d2">PHLJ015301K31P0FGN</data>
-      <data key="d3">lbnl-w1.fabric-testbed.net-nvme-2</data>
-      <data key="d4">NVME</data>
-      <data key="d5">P4510</data>
-      <data key="d6">{"disk": 1000, "unit": 1}</data>
-      <data key="d11">{"bdf": "0000:22:00.0"}</data>
-      <data key="d12">Dell Express Flash NVMe P4510 1TB SFF in PCIe SSD Slot 23 in Bay 2 (0000:22:00.0)</data>
-      <data key="d7">false</data>
-      <data key="d10">{"primary": {"pool_id": "_", "capacities": {"disk": 1000, "unit": 1}}}</data>
-      <data key="d13">{"primary": {"pool_id": "_", "labels": {"bdf": "0000:22:00.0"}}}</data>
-    </node>
-    <node id="4">
-      <data key="d0">307a43ea-2e59-42c6-8581-71e2a37300f6</data>
-      <data key="d1">Component</data>
-      <data key="d2">5B3BR53-gpu-1</data>
-      <data key="d3">lbnl-w1.fabric-testbed.net-gpu-1</data>
-      <data key="d4">GPU</data>
-      <data key="d5">RTX6000</data>
-      <data key="d6">{"unit": 1}</data>
-      <data key="d11">{"bdf": "0000:25:00.0"}</data>
-      <data key="d12">NVIDIA Corporation TU102GL [Quadro RTX 6000/8000] (rev a1)</data>
-      <data key="d7">false</data>
-      <data key="d10">{"primary": {"pool_id": "_", "capacities": {"unit": 1}}}</data>
-      <data key="d13">{"primary": {"pool_id": "_", "labels": {"bdf": "0000:25:00.0"}}}</data>
-    </node>
-    <node id="5">
-      <data key="d0">307a43ea-2e59-42c6-8581-71e2a37300f6</data>
-      <data key="d1">Component</data>
-      <data key="d2">5B3BR53-gpu-2</data>
-      <data key="d3">lbnl-w1.fabric-testbed.net-gpu-2</data>
-      <data key="d4">GPU</data>
-      <data key="d5">RTX6000</data>
-      <data key="d6">{"unit": 1}</data>
-      <data key="d11">{"bdf": "0000:81:00.0"}</data>
-      <data key="d12">NVIDIA Corporation TU102GL [Quadro RTX 6000/8000] (rev a1)</data>
-      <data key="d7">false</data>
-      <data key="d10">{"primary": {"pool_id": "_", "capacities": {"unit": 1}}}</data>
-      <data key="d13">{"primary": {"pool_id": "_", "labels": {"bdf": "0000:81:00.0"}}}</data>
-    </node>
-    <node id="6">
-      <data key="d0">307a43ea-2e59-42c6-8581-71e2a37300f6</data>
-      <data key="d1">Component</data>
-      <data key="d2">5B3BR53-slot6</data>
-      <data key="d3">lbnl-w1.fabric-testbed.net-slot6</data>
-      <data key="d4">SharedNIC</data>
-      <data key="d5">ConnectX-6</data>
-      <data key="d6">{"unit": 127}</data>
-      <data key="d11">{"bdf": ["0000:a1:15.5", "0000:a1:1f.1", "0000:a1:1f.3", "0000:a1:1c.2", "0000:a1:14.3", "0000:a1:16.3", "0000:a1:12.4", "0000:a1:11.2", "0000:a1:10.3", "0000:a1:10.2", "0000:a1:1e.0", "0000:a1:16.5", "0000:a1:18.5", "0000:a1:18.0", "0000:a1:16.6", "0000:a1:14.1", "0000:a1:15.7", "0000:a1:1c.6", "0000:a1:13.2", "0000:a1:16.2", "0000:a1:10.4", "0000:a1:1d.5", "0000:a1:1d.0", "0000:a1:19.1", "0000:a1:15.0", "0000:a1:15.2", "0000:a1:13.7", "0000:a1:1d.1", "0000:a1:1e.3", "0000:a1:1d.6", "0000:a1:1b.2", "0000:a1:17.5", "0000:a1:19.4", "0000:a1:13.0", "0000:a1:1c.5", "0000:a1:1c.0", "0000:a1:18.3", "0000:a1:15.6", "0000:a1:18.6", "0000:a1:1a.2", "0000:a1:17.4", "0000:a1:1c.1", "0000:a1:1e.2", "0000:a1:11.5", "0000:a1:14.0", "0000:a1:1e.6", "0000:a1:13.5", "0000:a1:17.0", "0000:a1:1a.6", "0000:a1:1b.7", "0000:a1:1f.2", "0000:a1:17.3", "0000:a1:12.7", "0000:a1:1b.4", "0000:a1:11.7", "0000:a1:1f.0", "0000:a1:18.2", "0000:a1:1e.5", "0000:a1:14.4", "0000:a1:1b.5", "0000:a1:1d.4", "0000:a1:1b.0", "0000:a1:12.5", "0000:a1:13.6", "0000:a1:14.2", "0000:a1:13.1", "0000:a1:11.0", "0000:a1:10.7", "0000:a1:19.5", "0000:a1:11.6", "0000:a1:1b.6", "0000:a1:16.4", "0000:a1:10.6", "0000:a1:1e.7", "0000:a1:1a.0", "0000:a1:19.6", "0000:a1:1f.4", "0000:a1:1f.5", "0000:a1:16.7", "0000:a1:15.4", "0000:a1:19.2", "0000:a1:13.4", "0000:a1:12.2", "0000:a1:10.5", "0000:a1:1f.6", "0000:a1:17.7", "0000:a1:1d.2", "0000:a1:18.7", "0000:a1:1b.1", "0000:a1:12.0", "0000:a1:11.1", "0000:a1:1b.3", "0000:a1:1a.5", "0000:a1:15.1", "0000:a1:14.7", "0000:a1:14.5", "0000:a1:1a.7", "0000:a1:17.6", "0000:a1:16.0", "0000:a1:14.6", "0000:a1:1c.7", "0000:a1:15.3", "0000:a1:1a.3", "0000:a1:17.1", "0000:a1:1f.7", "0000:a1:1e.4", "0000:a1:16.1", "0000:a1:12.1", "0000:a1:10.1", "0000:a1:19.7", "0000:a1:11.4", "0000:a1:1d.7", "0000:a1:19.0", "0000:a1:1c.3", "0000:a1:18.1", "0000:a1:17.2", "0000:a1:18.4", "0000:a1:1c.4", "0000:a1:1a.1", "0000:a1:12.6", "0000:a1:13.3", "0000:a1:1a.4", "0000:a1:1e.1", "0000:a1:19.3", "0000:a1:11.3", "0000:a1:12.3", "0000:a1:1d.3"]}</data>
-      <data key="d12">Mellanox Technologies MT28908 Family [ConnectX-6] in PCIe Slot 6 (0000:a1:00.1)</data>
-      <data key="d7">false</data>
-      <data key="d10">{"primary": {"pool_id": "_", "capacities": {"unit": 127}}}</data>
-      <data key="d13">{"primary": {"pool_id": "_", "labels": {"bdf": ["0000:a1:15.5", "0000:a1:1f.1", "0000:a1:1f.3", "0000:a1:1c.2", "0000:a1:14.3", "0000:a1:16.3", "0000:a1:12.4", "0000:a1:11.2", "0000:a1:10.3", "0000:a1:10.2", "0000:a1:1e.0", "0000:a1:16.5", "0000:a1:18.5", "0000:a1:18.0", "0000:a1:16.6", "0000:a1:14.1", "0000:a1:15.7", "0000:a1:1c.6", "0000:a1:13.2", "0000:a1:16.2", "0000:a1:10.4", "0000:a1:1d.5", "0000:a1:1d.0", "0000:a1:19.1", "0000:a1:15.0", "0000:a1:15.2", "0000:a1:13.7", "0000:a1:1d.1", "0000:a1:1e.3", "0000:a1:1d.6", "0000:a1:1b.2", "0000:a1:17.5", "0000:a1:19.4", "0000:a1:13.0", "0000:a1:1c.5", "0000:a1:1c.0", "0000:a1:18.3", "0000:a1:15.6", "0000:a1:18.6", "0000:a1:1a.2", "0000:a1:17.4", "0000:a1:1c.1", "0000:a1:1e.2", "0000:a1:11.5", "0000:a1:14.0", "0000:a1:1e.6", "0000:a1:13.5", "0000:a1:17.0", "0000:a1:1a.6", "0000:a1:1b.7", "0000:a1:1f.2", "0000:a1:17.3", "0000:a1:12.7", "0000:a1:1b.4", "0000:a1:11.7", "0000:a1:1f.0", "0000:a1:18.2", "0000:a1:1e.5", "0000:a1:14.4", "0000:a1:1b.5", "0000:a1:1d.4", "0000:a1:1b.0", "0000:a1:12.5", "0000:a1:13.6", "0000:a1:14.2", "0000:a1:13.1", "0000:a1:11.0", "0000:a1:10.7", "0000:a1:19.5", "0000:a1:11.6", "0000:a1:1b.6", "0000:a1:16.4", "0000:a1:10.6", "0000:a1:1e.7", "0000:a1:1a.0", "0000:a1:19.6", "0000:a1:1f.4", "0000:a1:1f.5", "0000:a1:16.7", "0000:a1:15.4", "0000:a1:19.2", "0000:a1:13.4", "0000:a1:12.2", "0000:a1:10.5", "0000:a1:1f.6", "0000:a1:17.7", "0000:a1:1d.2", "0000:a1:18.7", "0000:a1:1b.1", "0000:a1:12.0", "0000:a1:11.1", "0000:a1:1b.3", "0000:a1:1a.5", "0000:a1:15.1", "0000:a1:14.7", "0000:a1:14.5", "0000:a1:1a.7", "0000:a1:17.6", "0000:a1:16.0", "0000:a1:14.6", "0000:a1:1c.7", "0000:a1:15.3", "0000:a1:1a.3", "0000:a1:17.1", "0000:a1:1f.7", "0000:a1:1e.4", "0000:a1:16.1", "0000:a1:12.1", "0000:a1:10.1", "0000:a1:19.7", "0000:a1:11.4", "0000:a1:1d.7", "0000:a1:19.0", "0000:a1:1c.3", "0000:a1:18.1", "0000:a1:17.2", "0000:a1:18.4", "0000:a1:1c.4", "0000:a1:1a.1", "0000:a1:12.6", "0000:a1:13.3", "0000:a1:1a.4", "0000:a1:1e.1", "0000:a1:19.3", "0000:a1:11.3", "0000:a1:12.3", "0000:a1:1d.3"]}}}</data>
-    </node>
-    <node id="7">
-      <data key="d0">307a43ea-2e59-42c6-8581-71e2a37300f6</data>
-      <data key="d1">NetworkService</data>
-      <data key="d2">5B3BR53-slot6-ns</data>
-      <data key="d3">lbnl-w1.fabric-testbed.net-lbnl-w1.fabric-testbed.net-slot6-l2ovs</data>
-      <data key="d4">OVS</data>
-      <data key="d7">false</data>
-      <data key="d14">L2</data>
-    </node>
-    <node id="8">
-      <data key="d0">307a43ea-2e59-42c6-8581-71e2a37300f6</data>
-      <data key="d1">ConnectionPoint</data>
-      <data key="d2">node_id-04-3F-72-B7-19-8D</data>
-      <data key="d3">lbnl-w1.fabric-testbed.net-slot6-p1</data>
-      <data key="d4">SharedPort</data>
-      <data key="d6">{"unit": 127}</data>
-      <data key="d11">{"bdf": ["0000:a1:15.5", "0000:a1:1f.1", "0000:a1:1f.3", "0000:a1:1c.2", "0000:a1:14.3", "0000:a1:16.3", "0000:a1:12.4", "0000:a1:11.2", "0000:a1:10.3", "0000:a1:10.2", "0000:a1:1e.0", "0000:a1:16.5", "0000:a1:18.5", "0000:a1:18.0", "0000:a1:16.6", "0000:a1:14.1", "0000:a1:15.7", "0000:a1:1c.6", "0000:a1:13.2", "0000:a1:16.2", "0000:a1:10.4", "0000:a1:1d.5", "0000:a1:1d.0", "0000:a1:19.1", "0000:a1:15.0", "0000:a1:15.2", "0000:a1:13.7", "0000:a1:1d.1", "0000:a1:1e.3", "0000:a1:1d.6", "0000:a1:1b.2", "0000:a1:17.5", "0000:a1:19.4", "0000:a1:13.0", "0000:a1:1c.5", "0000:a1:1c.0", "0000:a1:18.3", "0000:a1:15.6", "0000:a1:18.6", "0000:a1:1a.2", "0000:a1:17.4", "0000:a1:1c.1", "0000:a1:1e.2", "0000:a1:11.5", "0000:a1:14.0", "0000:a1:1e.6", "0000:a1:13.5", "0000:a1:17.0", "0000:a1:1a.6", "0000:a1:1b.7", "0000:a1:1f.2", "0000:a1:17.3", "0000:a1:12.7", "0000:a1:1b.4", "0000:a1:11.7", "0000:a1:1f.0", "0000:a1:18.2", "0000:a1:1e.5", "0000:a1:14.4", "0000:a1:1b.5", "0000:a1:1d.4", "0000:a1:1b.0", "0000:a1:12.5", "0000:a1:13.6", "0000:a1:14.2", "0000:a1:13.1", "0000:a1:11.0", "0000:a1:10.7", "0000:a1:19.5", "0000:a1:11.6", "0000:a1:1b.6", "0000:a1:16.4", "0000:a1:10.6", "0000:a1:1e.7", "0000:a1:1a.0", "0000:a1:19.6", "0000:a1:1f.4", "0000:a1:1f.5", "0000:a1:16.7", "0000:a1:15.4", "0000:a1:19.2", "0000:a1:13.4", "0000:a1:12.2", "0000:a1:10.5", "0000:a1:1f.6", "0000:a1:17.7", "0000:a1:1d.2", "0000:a1:18.7", "0000:a1:1b.1", "0000:a1:12.0", "0000:a1:11.1", "0000:a1:1b.3", "0000:a1:1a.5", "0000:a1:15.1", "0000:a1:14.7", "0000:a1:14.5", "0000:a1:1a.7", "0000:a1:17.6", "0000:a1:16.0", "0000:a1:14.6", "0000:a1:1c.7", "0000:a1:15.3", "0000:a1:1a.3", "0000:a1:17.1", "0000:a1:1f.7", "0000:a1:1e.4", "0000:a1:16.1", "0000:a1:12.1", "0000:a1:10.1", "0000:a1:19.7", "0000:a1:11.4", "0000:a1:1d.7", "0000:a1:19.0", "0000:a1:1c.3", "0000:a1:18.1", "0000:a1:17.2", "0000:a1:18.4", "0000:a1:1c.4", "0000:a1:1a.1", "0000:a1:12.6", "0000:a1:13.3", "0000:a1:1a.4", "0000:a1:1e.1", "0000:a1:19.3", "0000:a1:11.3", "0000:a1:12.3", "0000:a1:1d.3"], "local_name": ["p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1"], "mac": ["02:2A:8B:08:61:79", "02:F6:F2:0A:DD:99", "06:98:6E:FE:D9:D2", "06:C0:47:5A:CF:EC", "0A:02:4A:FB:F7:A4", "0A:08:CD:65:9D:17", "0A:DC:49:9C:64:95", "0E:2E:EE:54:50:61", "0E:36:4F:4B:2C:C2", "12:5A:A7:8F:9C:02", "1A:42:36:1D:41:F9", "1A:5A:E3:F1:FE:65", "1A:CC:1C:FA:52:91", "1A:EC:43:D9:9D:C8", "1A:FF:11:5D:DE:57", "1E:F3:F8:64:0C:1E", "22:18:C1:FA:BB:29", "22:DA:43:34:CB:F4", "2E:3A:D1:85:5C:10", "2E:79:9F:F4:D7:DC", "36:FC:0F:DD:56:6A", "3A:19:C9:13:39:69", "3A:EC:7F:B3:FF:8A", "3A:F3:B2:C9:8C:38", "3E:2B:50:26:BD:F4", "3E:5A:22:67:D4:B6", "42:38:41:A8:79:BE", "42:89:A4:4F:15:08", "42:C6:87:58:58:FF", "46:73:5E:96:5B:2D", "4A:28:E1:53:95:A7", "4A:90:E7:FA:BE:D4", "4A:AA:D1:8B:82:AD", "4A:C2:47:04:0D:C8", "4E:05:7D:F0:37:09", "4E:17:8E:02:AE:B7", "4E:55:85:3A:8C:5E", "4E:7C:7C:12:7C:92", "4E:96:74:05:AB:A5", "4E:9A:56:11:B1:7E", "52:12:E4:38:D6:B3", "52:30:81:51:41:14", "52:36:94:96:D2:73", "52:3C:2D:37:35:48", "5A:6E:33:7B:75:23", "5A:79:FB:C1:C6:3A", "5A:AE:A0:FD:91:72", "5E:8A:9B:30:E7:A6", "5E:CA:E9:55:CE:B1", "62:67:55:53:AB:B3", "66:98:D7:D5:75:E9", "6E:5F:F0:22:D9:F4", "6E:92:2F:CD:16:33", "6E:E0:3C:E1:30:F8", "72:24:EE:9C:29:C8", "76:6F:CA:A6:FF:63", "76:BF:9D:08:D2:D8", "7A:DE:E2:6E:97:8C", "7E:3D:EB:FF:7A:05", "7E:48:82:4A:1E:36", "7E:DD:14:D1:81:9D", "82:49:96:7D:8C:EA", "82:CE:EA:E0:AD:95", "86:C5:97:97:21:E6", "8A:8E:24:3D:40:3B", "8A:9E:0C:9D:B3:B2", "8A:DD:B9:D5:8C:34", "8E:70:3E:35:F7:33", "8E:77:39:B4:33:97", "8E:9A:B1:20:13:26", "92:AC:AE:51:62:47", "92:EF:1F:E0:39:F2", "92:F7:B3:8B:A6:CE", "96:73:3C:D2:5C:64", "96:D6:79:E7:0B:BD", "9A:50:A5:E6:B3:53", "9E:06:40:94:B0:B8", "9E:0B:C1:61:BF:7F", "9E:0F:74:06:E9:59", "9E:D7:FF:B2:A5:5C", "A6:B6:E6:AC:D6:36", "A6:D8:58:69:56:01", "A6:FC:F4:3C:86:2D", "AA:A2:E6:D9:E8:24", "AA:C7:87:1D:25:49", "AA:F9:31:86:A0:DD", "AE:0B:EC:E5:30:3E", "AE:13:37:7B:CB:59", "AE:1F:D0:9F:C4:AA", "AE:32:12:87:D3:03", "B2:25:1D:5C:C8:1E", "B2:64:14:AE:13:C1", "B2:81:DE:A6:E5:82", "B2:AB:4D:D2:13:9E", "B6:07:BE:9A:18:BC", "BA:32:19:3C:4B:05", "BA:71:B9:56:3F:D4", "BA:72:8C:E8:87:D1", "BA:A3:D4:32:D2:91", "BE:00:49:58:6B:EA", "BE:81:8B:8B:D1:ED", "BE:9B:29:64:1E:1F", "C2:1C:3B:65:46:E8", "CA:2F:A2:F9:15:81", "CA:90:CD:91:F4:20", "CE:48:07:70:7C:7C", "CE:99:08:47:4E:CD", "CE:AA:56:CD:21:D1", "CE:BA:8E:99:E5:30", "D2:C8:50:F5:7B:30", "D6:0F:F1:DF:64:FA", "DA:47:4C:FE:89:B6", "DE:F9:A8:EF:8D:2C", "EA:29:80:68:6A:87", "EA:93:DA:88:0A:35", "EA:AB:43:05:85:74", "EE:36:D6:63:73:FD", "EE:6D:CF:3D:74:28", "EE:7B:23:9A:19:BF", "EE:A5:B7:1B:2E:19", "F2:C2:C1:A0:8B:83", "F2:DC:AA:09:26:F2", "FA:6A:EE:9E:5C:A2", "FA:98:8D:9A:97:8C", "FA:BA:7C:1C:68:EE", "FE:35:F1:33:EB:C3", "FE:9E:CF:1D:34:1D"], "vlan": ["2044", "2120", "2122", "2097", "2034", "2050", "2019", "2009", "2002", "2001", "2111", "2052", "2068", "2063", "2053", "2032", "2046", "2101", "2025", "2049", "2003", "2108", "2103", "2072", "2039", "2041", "2030", "2104", "2114", "2109", "2089", "2060", "2075", "2023", "2100", "2095", "2066", "2045", "2069", "2081", "2059", "2096", "2113", "2012", "2031", "2117", "2028", "2055", "2085", "2094", "2121", "2058", "2022", "2091", "2014", "2119", "2065", "2116", "2035", "2092", "2107", "2087", "2020", "2029", "2033", "2024", "2007", "2006", "2076", "2013", "2093", "2051", "2005", "2118", "2079", "2077", "2123", "2124", "2054", "2043", "2073", "2027", "2017", "2004", "2125", "2062", "2105", "2070", "2088", "2015", "2008", "2090", "2084", "2040", "2038", "2036", "2086", "2061", "2047", "2037", "2102", "2042", "2082", "2056", "2126", "2115", "2048", "2016", "2000", "2078", "2011", "2110", "2071", "2098", "2064", "2057", "2067", "2099", "2080", "2021", "2026", "2083", "2112", "2074", "2010", "2018", "2106"]}</data>
-      <data key="d7">false</data>
-      <data key="d10">{"primary": {"pool_id": "_", "capacities": {"unit": 127}}}</data>
-      <data key="d13">{"primary": {"pool_id": "_", "labels": {"bdf": ["0000:a1:15.5", "0000:a1:1f.1", "0000:a1:1f.3", "0000:a1:1c.2", "0000:a1:14.3", "0000:a1:16.3", "0000:a1:12.4", "0000:a1:11.2", "0000:a1:10.3", "0000:a1:10.2", "0000:a1:1e.0", "0000:a1:16.5", "0000:a1:18.5", "0000:a1:18.0", "0000:a1:16.6", "0000:a1:14.1", "0000:a1:15.7", "0000:a1:1c.6", "0000:a1:13.2", "0000:a1:16.2", "0000:a1:10.4", "0000:a1:1d.5", "0000:a1:1d.0", "0000:a1:19.1", "0000:a1:15.0", "0000:a1:15.2", "0000:a1:13.7", "0000:a1:1d.1", "0000:a1:1e.3", "0000:a1:1d.6", "0000:a1:1b.2", "0000:a1:17.5", "0000:a1:19.4", "0000:a1:13.0", "0000:a1:1c.5", "0000:a1:1c.0", "0000:a1:18.3", "0000:a1:15.6", "0000:a1:18.6", "0000:a1:1a.2", "0000:a1:17.4", "0000:a1:1c.1", "0000:a1:1e.2", "0000:a1:11.5", "0000:a1:14.0", "0000:a1:1e.6", "0000:a1:13.5", "0000:a1:17.0", "0000:a1:1a.6", "0000:a1:1b.7", "0000:a1:1f.2", "0000:a1:17.3", "0000:a1:12.7", "0000:a1:1b.4", "0000:a1:11.7", "0000:a1:1f.0", "0000:a1:18.2", "0000:a1:1e.5", "0000:a1:14.4", "0000:a1:1b.5", "0000:a1:1d.4", "0000:a1:1b.0", "0000:a1:12.5", "0000:a1:13.6", "0000:a1:14.2", "0000:a1:13.1", "0000:a1:11.0", "0000:a1:10.7", "0000:a1:19.5", "0000:a1:11.6", "0000:a1:1b.6", "0000:a1:16.4", "0000:a1:10.6", "0000:a1:1e.7", "0000:a1:1a.0", "0000:a1:19.6", "0000:a1:1f.4", "0000:a1:1f.5", "0000:a1:16.7", "0000:a1:15.4", "0000:a1:19.2", "0000:a1:13.4", "0000:a1:12.2", "0000:a1:10.5", "0000:a1:1f.6", "0000:a1:17.7", "0000:a1:1d.2", "0000:a1:18.7", "0000:a1:1b.1", "0000:a1:12.0", "0000:a1:11.1", "0000:a1:1b.3", "0000:a1:1a.5", "0000:a1:15.1", "0000:a1:14.7", "0000:a1:14.5", "0000:a1:1a.7", "0000:a1:17.6", "0000:a1:16.0", "0000:a1:14.6", "0000:a1:1c.7", "0000:a1:15.3", "0000:a1:1a.3", "0000:a1:17.1", "0000:a1:1f.7", "0000:a1:1e.4", "0000:a1:16.1", "0000:a1:12.1", "0000:a1:10.1", "0000:a1:19.7", "0000:a1:11.4", "0000:a1:1d.7", "0000:a1:19.0", "0000:a1:1c.3", "0000:a1:18.1", "0000:a1:17.2", "0000:a1:18.4", "0000:a1:1c.4", "0000:a1:1a.1", "0000:a1:12.6", "0000:a1:13.3", "0000:a1:1a.4", "0000:a1:1e.1", "0000:a1:19.3", "0000:a1:11.3", "0000:a1:12.3", "0000:a1:1d.3"], "mac": ["02:2A:8B:08:61:79", "02:F6:F2:0A:DD:99", "06:98:6E:FE:D9:D2", "06:C0:47:5A:CF:EC", "0A:02:4A:FB:F7:A4", "0A:08:CD:65:9D:17", "0A:DC:49:9C:64:95", "0E:2E:EE:54:50:61", "0E:36:4F:4B:2C:C2", "12:5A:A7:8F:9C:02", "1A:42:36:1D:41:F9", "1A:5A:E3:F1:FE:65", "1A:CC:1C:FA:52:91", "1A:EC:43:D9:9D:C8", "1A:FF:11:5D:DE:57", "1E:F3:F8:64:0C:1E", "22:18:C1:FA:BB:29", "22:DA:43:34:CB:F4", "2E:3A:D1:85:5C:10", "2E:79:9F:F4:D7:DC", "36:FC:0F:DD:56:6A", "3A:19:C9:13:39:69", "3A:EC:7F:B3:FF:8A", "3A:F3:B2:C9:8C:38", "3E:2B:50:26:BD:F4", "3E:5A:22:67:D4:B6", "42:38:41:A8:79:BE", "42:89:A4:4F:15:08", "42:C6:87:58:58:FF", "46:73:5E:96:5B:2D", "4A:28:E1:53:95:A7", "4A:90:E7:FA:BE:D4", "4A:AA:D1:8B:82:AD", "4A:C2:47:04:0D:C8", "4E:05:7D:F0:37:09", "4E:17:8E:02:AE:B7", "4E:55:85:3A:8C:5E", "4E:7C:7C:12:7C:92", "4E:96:74:05:AB:A5", "4E:9A:56:11:B1:7E", "52:12:E4:38:D6:B3", "52:30:81:51:41:14", "52:36:94:96:D2:73", "52:3C:2D:37:35:48", "5A:6E:33:7B:75:23", "5A:79:FB:C1:C6:3A", "5A:AE:A0:FD:91:72", "5E:8A:9B:30:E7:A6", "5E:CA:E9:55:CE:B1", "62:67:55:53:AB:B3", "66:98:D7:D5:75:E9", "6E:5F:F0:22:D9:F4", "6E:92:2F:CD:16:33", "6E:E0:3C:E1:30:F8", "72:24:EE:9C:29:C8", "76:6F:CA:A6:FF:63", "76:BF:9D:08:D2:D8", "7A:DE:E2:6E:97:8C", "7E:3D:EB:FF:7A:05", "7E:48:82:4A:1E:36", "7E:DD:14:D1:81:9D", "82:49:96:7D:8C:EA", "82:CE:EA:E0:AD:95", "86:C5:97:97:21:E6", "8A:8E:24:3D:40:3B", "8A:9E:0C:9D:B3:B2", "8A:DD:B9:D5:8C:34", "8E:70:3E:35:F7:33", "8E:77:39:B4:33:97", "8E:9A:B1:20:13:26", "92:AC:AE:51:62:47", "92:EF:1F:E0:39:F2", "92:F7:B3:8B:A6:CE", "96:73:3C:D2:5C:64", "96:D6:79:E7:0B:BD", "9A:50:A5:E6:B3:53", "9E:06:40:94:B0:B8", "9E:0B:C1:61:BF:7F", "9E:0F:74:06:E9:59", "9E:D7:FF:B2:A5:5C", "A6:B6:E6:AC:D6:36", "A6:D8:58:69:56:01", "A6:FC:F4:3C:86:2D", "AA:A2:E6:D9:E8:24", "AA:C7:87:1D:25:49", "AA:F9:31:86:A0:DD", "AE:0B:EC:E5:30:3E", "AE:13:37:7B:CB:59", "AE:1F:D0:9F:C4:AA", "AE:32:12:87:D3:03", "B2:25:1D:5C:C8:1E", "B2:64:14:AE:13:C1", "B2:81:DE:A6:E5:82", "B2:AB:4D:D2:13:9E", "B6:07:BE:9A:18:BC", "BA:32:19:3C:4B:05", "BA:71:B9:56:3F:D4", "BA:72:8C:E8:87:D1", "BA:A3:D4:32:D2:91", "BE:00:49:58:6B:EA", "BE:81:8B:8B:D1:ED", "BE:9B:29:64:1E:1F", "C2:1C:3B:65:46:E8", "CA:2F:A2:F9:15:81", "CA:90:CD:91:F4:20", "CE:48:07:70:7C:7C", "CE:99:08:47:4E:CD", "CE:AA:56:CD:21:D1", "CE:BA:8E:99:E5:30", "D2:C8:50:F5:7B:30", "D6:0F:F1:DF:64:FA", "DA:47:4C:FE:89:B6", "DE:F9:A8:EF:8D:2C", "EA:29:80:68:6A:87", "EA:93:DA:88:0A:35", "EA:AB:43:05:85:74", "EE:36:D6:63:73:FD", "EE:6D:CF:3D:74:28", "EE:7B:23:9A:19:BF", "EE:A5:B7:1B:2E:19", "F2:C2:C1:A0:8B:83", "F2:DC:AA:09:26:F2", "FA:6A:EE:9E:5C:A2", "FA:98:8D:9A:97:8C", "FA:BA:7C:1C:68:EE", "FE:35:F1:33:EB:C3", "FE:9E:CF:1D:34:1D"], "vlan": ["2044", "2120", "2122", "2097", "2034", "2050", "2019", "2009", "2002", "2001", "2111", "2052", "2068", "2063", "2053", "2032", "2046", "2101", "2025", "2049", "2003", "2108", "2103", "2072", "2039", "2041", "2030", "2104", "2114", "2109", "2089", "2060", "2075", "2023", "2100", "2095", "2066", "2045", "2069", "2081", "2059", "2096", "2113", "2012", "2031", "2117", "2028", "2055", "2085", "2094", "2121", "2058", "2022", "2091", "2014", "2119", "2065", "2116", "2035", "2092", "2107", "2087", "2020", "2029", "2033", "2024", "2007", "2006", "2076", "2013", "2093", "2051", "2005", "2118", "2079", "2077", "2123", "2124", "2054", "2043", "2073", "2027", "2017", "2004", "2125", "2062", "2105", "2070", "2088", "2015", "2008", "2090", "2084", "2040", "2038", "2036", "2086", "2061", "2047", "2037", "2102", "2042", "2082", "2056", "2126", "2115", "2048", "2016", "2000", "2078", "2011", "2110", "2071", "2098", "2064", "2057", "2067", "2099", "2080", "2021", "2026", "2083", "2112", "2074", "2010", "2018", "2106"], "local_name": ["p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1"]}}}</data>
-    </node>
-    <node id="9">
-      <data key="d0">307a43ea-2e59-42c6-8581-71e2a37300f6</data>
+    <node id="604">
+      <data key="d0">feb611c8-5b09-4132-a69c-be9adf894536</data>
       <data key="d1">NetworkNode</data>
       <data key="d2">5B38R53</data>
-      <data key="d3">lbnl-w2.fabric-testbed.net</data>
+      <data key="d3">lbnl-w2</data>
       <data key="d4">Server</data>
       <data key="d5">R7525</data>
-      <data key="d6">{"core": 64, "cpu": 2, "disk": 4800, "ram": 512, "unit": 1}</data>
+      <data key="d6">{"core": 32, "cpu": 2, "disk": 4800, "ram": 512, "unit": 1}</data>
       <data key="d7">false</data>
       <data key="d8">LBNL</data>
-      <data key="d9">{"postal": "1 Cyclotron Rd,Berkeley, CA 94720"}</data>
-      <data key="d10">{"primary": {"pool_id": "_", "capacities": {"cpu": 2, "core": 64, "ram": 512, "disk": 4800, "unit": 1}}}</data>
+      <data key="d9">{"postal": "1 Cyclotron Rd, Berkeley, CA 94720"}</data>
+      <data key="d10">{"primary": {"pool_id": "_", "capacities": {"cpu": 2, "core": 32, "ram": 512, "disk": 4800, "unit": 1}}}</data>
     </node>
-    <node id="10">
-      <data key="d0">307a43ea-2e59-42c6-8581-71e2a37300f6</data>
+    <node id="605">
+      <data key="d0">feb611c8-5b09-4132-a69c-be9adf894536</data>
+      <data key="d1">NetworkNode</data>
+      <data key="d2">5B39R53</data>
+      <data key="d3">lbnl-w3</data>
+      <data key="d4">Server</data>
+      <data key="d5">R7525</data>
+      <data key="d6">{"core": 32, "cpu": 2, "disk": 4800, "ram": 512, "unit": 1}</data>
+      <data key="d7">false</data>
+      <data key="d8">LBNL</data>
+      <data key="d9">{"postal": "1 Cyclotron Rd, Berkeley, CA 94720"}</data>
+      <data key="d10">{"primary": {"pool_id": "_", "capacities": {"cpu": 2, "core": 32, "ram": 512, "disk": 4800, "unit": 1}}}</data>
+    </node>
+    <node id="606">
+      <data key="d0">feb611c8-5b09-4132-a69c-be9adf894536</data>
       <data key="d1">Component</data>
-      <data key="d2">PHLJ015301LQ1P0FGN</data>
-      <data key="d3">lbnl-w2.fabric-testbed.net-nvme-1</data>
+      <data key="d2">PHLJ015301XE1P0FGN</data>
+      <data key="d3">lbnl-w1-nvme1</data>
       <data key="d4">NVME</data>
       <data key="d5">P4510</data>
       <data key="d6">{"disk": 1000, "unit": 1}</data>
       <data key="d11">{"bdf": "0000:21:00.0"}</data>
-      <data key="d12">Dell Express Flash NVMe P4510 1TB SFF in PCIe SSD Slot 22 in Bay 2 (0000:21:00.0)</data>
+      <data key="d12">Dell Express Flash NVMe P4510 1TB SFF</data>
       <data key="d7">false</data>
       <data key="d10">{"primary": {"pool_id": "_", "capacities": {"disk": 1000, "unit": 1}}}</data>
       <data key="d13">{"primary": {"pool_id": "_", "labels": {"bdf": "0000:21:00.0"}}}</data>
     </node>
-    <node id="11">
-      <data key="d0">307a43ea-2e59-42c6-8581-71e2a37300f6</data>
+    <node id="607">
+      <data key="d0">feb611c8-5b09-4132-a69c-be9adf894536</data>
       <data key="d1">Component</data>
-      <data key="d2">PHLJ015301LE1P0FGN</data>
-      <data key="d3">lbnl-w2.fabric-testbed.net-nvme-2</data>
+      <data key="d2">PHLJ015301K31P0FGN</data>
+      <data key="d3">lbnl-w1-nvme2</data>
       <data key="d4">NVME</data>
       <data key="d5">P4510</data>
       <data key="d6">{"disk": 1000, "unit": 1}</data>
       <data key="d11">{"bdf": "0000:22:00.0"}</data>
-      <data key="d12">Dell Express Flash NVMe P4510 1TB SFF in PCIe SSD Slot 23 in Bay 2 (0000:22:00.0)</data>
+      <data key="d12">Dell Express Flash NVMe P4510 1TB SFF</data>
       <data key="d7">false</data>
       <data key="d10">{"primary": {"pool_id": "_", "capacities": {"disk": 1000, "unit": 1}}}</data>
       <data key="d13">{"primary": {"pool_id": "_", "labels": {"bdf": "0000:22:00.0"}}}</data>
     </node>
-    <node id="12">
-      <data key="d0">307a43ea-2e59-42c6-8581-71e2a37300f6</data>
+    <node id="608">
+      <data key="d0">feb611c8-5b09-4132-a69c-be9adf894536</data>
+      <data key="d1">Component</data>
+      <data key="d2">PHLJ015301LQ1P0FGN</data>
+      <data key="d3">lbnl-w2-nvme1</data>
+      <data key="d4">NVME</data>
+      <data key="d5">P4510</data>
+      <data key="d6">{"disk": 1000, "unit": 1}</data>
+      <data key="d11">{"bdf": "000:21:00.0"}</data>
+      <data key="d12">Dell Express Flash NVMe P4510 1TB SFF</data>
+      <data key="d7">false</data>
+      <data key="d10">{"primary": {"pool_id": "_", "capacities": {"disk": 1000, "unit": 1}}}</data>
+      <data key="d13">{"primary": {"pool_id": "_", "labels": {"bdf": "000:21:00.0"}}}</data>
+    </node>
+    <node id="609">
+      <data key="d0">feb611c8-5b09-4132-a69c-be9adf894536</data>
+      <data key="d1">Component</data>
+      <data key="d2">PHLJ015301LE1P0FGN</data>
+      <data key="d3">lbnl-w2-nvme2</data>
+      <data key="d4">NVME</data>
+      <data key="d5">P4510</data>
+      <data key="d6">{"disk": 1000, "unit": 1}</data>
+      <data key="d11">{"bdf": "0000:22:00.0"}</data>
+      <data key="d12">Dell Express Flash NVMe P4510 1TB SFF</data>
+      <data key="d7">false</data>
+      <data key="d10">{"primary": {"pool_id": "_", "capacities": {"disk": 1000, "unit": 1}}}</data>
+      <data key="d13">{"primary": {"pool_id": "_", "labels": {"bdf": "0000:22:00.0"}}}</data>
+    </node>
+    <node id="610">
+      <data key="d0">feb611c8-5b09-4132-a69c-be9adf894536</data>
       <data key="d1">Component</data>
       <data key="d2">PHLJ015301M31P0FGN</data>
-      <data key="d3">lbnl-w2.fabric-testbed.net-nvme-3</data>
+      <data key="d3">lbnl-w2-nvme3</data>
       <data key="d4">NVME</data>
       <data key="d5">P4510</data>
       <data key="d6">{"disk": 1000, "unit": 1}</data>
       <data key="d11">{"bdf": "0000:23:00.0"}</data>
-      <data key="d12">Dell Express Flash NVMe P4510 1TB SFF in PCIe SSD Slot 20 in Bay 2 (0000:23:00.0)</data>
+      <data key="d12">Dell Express Flash NVMe P4510 1TB SFF</data>
       <data key="d7">false</data>
       <data key="d10">{"primary": {"pool_id": "_", "capacities": {"disk": 1000, "unit": 1}}}</data>
       <data key="d13">{"primary": {"pool_id": "_", "labels": {"bdf": "0000:23:00.0"}}}</data>
     </node>
-    <node id="13">
-      <data key="d0">307a43ea-2e59-42c6-8581-71e2a37300f6</data>
+    <node id="611">
+      <data key="d0">feb611c8-5b09-4132-a69c-be9adf894536</data>
       <data key="d1">Component</data>
       <data key="d2">PHLJ015301LS1P0FGN</data>
-      <data key="d3">lbnl-w2.fabric-testbed.net-nvme-4</data>
+      <data key="d3">lbnl-w2-nvme4</data>
       <data key="d4">NVME</data>
       <data key="d5">P4510</data>
       <data key="d6">{"disk": 1000, "unit": 1}</data>
       <data key="d11">{"bdf": "0000:24:00.0"}</data>
-      <data key="d12">Dell Express Flash NVMe P4510 1TB SFF in PCIe SSD Slot 21 in Bay 2 (0000:24:00.0)</data>
+      <data key="d12">Dell Express Flash NVMe P4510 1TB SFF</data>
       <data key="d7">false</data>
       <data key="d10">{"primary": {"pool_id": "_", "capacities": {"disk": 1000, "unit": 1}}}</data>
       <data key="d13">{"primary": {"pool_id": "_", "labels": {"bdf": "0000:24:00.0"}}}</data>
     </node>
-    <node id="14">
-      <data key="d0">307a43ea-2e59-42c6-8581-71e2a37300f6</data>
+    <node id="612">
+      <data key="d0">feb611c8-5b09-4132-a69c-be9adf894536</data>
       <data key="d1">Component</data>
-      <data key="d2">5B38R53-gpu-1</data>
-      <data key="d3">lbnl-w2.fabric-testbed.net-gpu-1</data>
+      <data key="d2">PHLJ015301KV1P0FGN</data>
+      <data key="d3">lbnl-w3-nvme1</data>
+      <data key="d4">NVME</data>
+      <data key="d5">P4510</data>
+      <data key="d6">{"disk": 1000, "unit": 1}</data>
+      <data key="d11">{"bdf": "0000:21:00.0"}</data>
+      <data key="d12">Dell Express Flash NVMe P4510 1TB SFF</data>
+      <data key="d7">false</data>
+      <data key="d10">{"primary": {"pool_id": "_", "capacities": {"disk": 1000, "unit": 1}}}</data>
+      <data key="d13">{"primary": {"pool_id": "_", "labels": {"bdf": "0000:21:00.0"}}}</data>
+    </node>
+    <node id="613">
+      <data key="d0">feb611c8-5b09-4132-a69c-be9adf894536</data>
+      <data key="d1">Component</data>
+      <data key="d2">PHLJ015301RL1P0FGN</data>
+      <data key="d3">lbnl-w3-nvme2</data>
+      <data key="d4">NVME</data>
+      <data key="d5">P4510</data>
+      <data key="d6">{"disk": 1000, "unit": 1}</data>
+      <data key="d11">{"bdf": "0000:22:00.0"}</data>
+      <data key="d12">Dell Express Flash NVMe P4510 1TB SFF</data>
+      <data key="d7">false</data>
+      <data key="d10">{"primary": {"pool_id": "_", "capacities": {"disk": 1000, "unit": 1}}}</data>
+      <data key="d13">{"primary": {"pool_id": "_", "labels": {"bdf": "0000:22:00.0"}}}</data>
+    </node>
+    <node id="614">
+      <data key="d0">feb611c8-5b09-4132-a69c-be9adf894536</data>
+      <data key="d1">Component</data>
+      <data key="d2">PHLJ015301L91P0FGN</data>
+      <data key="d3">lbnl-w3-nvme3</data>
+      <data key="d4">NVME</data>
+      <data key="d5">P4510</data>
+      <data key="d6">{"disk": 1000, "unit": 1}</data>
+      <data key="d11">{"bdf": "0000:23:00.0"}</data>
+      <data key="d12">Dell Express Flash NVMe P4510 1TB SFF</data>
+      <data key="d7">false</data>
+      <data key="d10">{"primary": {"pool_id": "_", "capacities": {"disk": 1000, "unit": 1}}}</data>
+      <data key="d13">{"primary": {"pool_id": "_", "labels": {"bdf": "0000:23:00.0"}}}</data>
+    </node>
+    <node id="615">
+      <data key="d0">feb611c8-5b09-4132-a69c-be9adf894536</data>
+      <data key="d1">Component</data>
+      <data key="d2">PHLJ015301SK1P0FGN</data>
+      <data key="d3">lbnl-w3-nvme4</data>
+      <data key="d4">NVME</data>
+      <data key="d5">P4510</data>
+      <data key="d6">{"disk": 1000, "unit": 1}</data>
+      <data key="d11">{"bdf": "0000:24:00.0"}</data>
+      <data key="d12">Dell Express Flash NVMe P4510 1TB SFF</data>
+      <data key="d7">false</data>
+      <data key="d10">{"primary": {"pool_id": "_", "capacities": {"disk": 1000, "unit": 1}}}</data>
+      <data key="d13">{"primary": {"pool_id": "_", "labels": {"bdf": "0000:24:00.0"}}}</data>
+    </node>
+    <node id="616">
+      <data key="d0">feb611c8-5b09-4132-a69c-be9adf894536</data>
+      <data key="d1">Component</data>
+      <data key="d2">5B3BR53-gpu1</data>
+      <data key="d3">lbnl-w1-gpu1</data>
+      <data key="d4">GPU</data>
+      <data key="d5">RTX6000</data>
+      <data key="d6">{"unit": 1}</data>
+      <data key="d11">{"bdf": "0000:25:00.0"}</data>
+      <data key="d12">NVIDIA Corporation TU102GL [Quadro RTX 6000/8000] (rev a1)</data>
+      <data key="d7">false</data>
+      <data key="d10">{"primary": {"pool_id": "_", "capacities": {"unit": 1}}}</data>
+      <data key="d13">{"primary": {"pool_id": "_", "labels": {"bdf": "0000:25:00.0"}}}</data>
+    </node>
+    <node id="617">
+      <data key="d0">feb611c8-5b09-4132-a69c-be9adf894536</data>
+      <data key="d1">Component</data>
+      <data key="d2">5B3BR53-gpu2</data>
+      <data key="d3">lbnl-w1-gpu2</data>
+      <data key="d4">GPU</data>
+      <data key="d5">RTX6000</data>
+      <data key="d6">{"unit": 1}</data>
+      <data key="d11">{"bdf": "0000:81:00.0"}</data>
+      <data key="d12">NVIDIA Corporation TU102GL [Quadro RTX 6000/8000] (rev a1)</data>
+      <data key="d7">false</data>
+      <data key="d10">{"primary": {"pool_id": "_", "capacities": {"unit": 1}}}</data>
+      <data key="d13">{"primary": {"pool_id": "_", "labels": {"bdf": "0000:81:00.0"}}}</data>
+    </node>
+    <node id="618">
+      <data key="d0">feb611c8-5b09-4132-a69c-be9adf894536</data>
+      <data key="d1">Component</data>
+      <data key="d2">5B38R53-gpu1</data>
+      <data key="d3">lbnl-w2-gpu1</data>
       <data key="d4">GPU</data>
       <data key="d5">Tesla T4</data>
       <data key="d6">{"unit": 1}</data>
@@ -203,11 +237,11 @@
       <data key="d10">{"primary": {"pool_id": "_", "capacities": {"unit": 1}}}</data>
       <data key="d13">{"primary": {"pool_id": "_", "labels": {"bdf": "0000:25:00.0"}}}</data>
     </node>
-    <node id="15">
-      <data key="d0">307a43ea-2e59-42c6-8581-71e2a37300f6</data>
+    <node id="619">
+      <data key="d0">feb611c8-5b09-4132-a69c-be9adf894536</data>
       <data key="d1">Component</data>
-      <data key="d2">5B38R53-gpu-2</data>
-      <data key="d3">lbnl-w2.fabric-testbed.net-gpu-2</data>
+      <data key="d2">5B38R53-gpu2</data>
+      <data key="d3">lbnl-w2-gpu2</data>
       <data key="d4">GPU</data>
       <data key="d5">Tesla T4</data>
       <data key="d6">{"unit": 1}</data>
@@ -217,116 +251,214 @@
       <data key="d10">{"primary": {"pool_id": "_", "capacities": {"unit": 1}}}</data>
       <data key="d13">{"primary": {"pool_id": "_", "labels": {"bdf": "0000:81:00.0"}}}</data>
     </node>
-    <node id="16">
-      <data key="d0">307a43ea-2e59-42c6-8581-71e2a37300f6</data>
+    <node id="620">
+      <data key="d0">feb611c8-5b09-4132-a69c-be9adf894536</data>
       <data key="d1">Component</data>
-      <data key="d2">5B38R53-slot3</data>
-      <data key="d3">lbnl-w2.fabric-testbed.net-slot3</data>
+      <data key="d2">5B39R53-gpu1</data>
+      <data key="d3">lbnl-w3-gpu1</data>
+      <data key="d4">GPU</data>
+      <data key="d5">Tesla T4</data>
+      <data key="d6">{"unit": 1}</data>
+      <data key="d11">{"bdf": "0000:25:00.0"}</data>
+      <data key="d12">NVIDIA Corporation TU104GL [Tesla T4] (rev a1)</data>
+      <data key="d7">false</data>
+      <data key="d10">{"primary": {"pool_id": "_", "capacities": {"unit": 1}}}</data>
+      <data key="d13">{"primary": {"pool_id": "_", "labels": {"bdf": "0000:25:00.0"}}}</data>
+    </node>
+    <node id="621">
+      <data key="d0">feb611c8-5b09-4132-a69c-be9adf894536</data>
+      <data key="d1">Component</data>
+      <data key="d2">5B39R53-gpu2</data>
+      <data key="d3">lbnl-w3-gpu2</data>
+      <data key="d4">GPU</data>
+      <data key="d5">Tesla T4</data>
+      <data key="d6">{"unit": 1}</data>
+      <data key="d11">{"bdf": "0000:81:00.0"}</data>
+      <data key="d12">NVIDIA Corporation TU104GL [Tesla T4] (rev a1)</data>
+      <data key="d7">false</data>
+      <data key="d10">{"primary": {"pool_id": "_", "capacities": {"unit": 1}}}</data>
+      <data key="d13">{"primary": {"pool_id": "_", "labels": {"bdf": "0000:81:00.0"}}}</data>
+    </node>
+    <node id="622">
+      <data key="d0">feb611c8-5b09-4132-a69c-be9adf894536</data>
+      <data key="d1">Component</data>
+      <data key="d2">5B3BR53-shnic</data>
+      <data key="d3">lbnl-w1-shnic</data>
       <data key="d4">SharedNIC</data>
       <data key="d5">ConnectX-6</data>
-      <data key="d6">{"unit": 127}</data>
-      <data key="d11">{"bdf": ["0000:41:0d.4", "0000:41:09.6", "0000:41:08.0", "0000:41:0a.5", "0000:41:03.4", "0000:41:00.3", "0000:41:04.4", "0000:41:0e.0", "0000:41:0d.0", "0000:41:0c.5", "0000:41:0a.7", "0000:41:0e.1", "0000:41:05.2", "0000:41:0b.7", "0000:41:08.2", "0000:41:0f.2", "0000:41:0a.1", "0000:41:02.1", "0000:41:04.6", "0000:41:0c.0", "0000:41:05.7", "0000:41:07.7", "0000:41:07.0", "0000:41:04.7", "0000:41:07.1", "0000:41:02.7", "0000:41:0d.5", "0000:41:03.1", "0000:41:02.6", "0000:41:08.1", "0000:41:05.1", "0000:41:0d.2", "0000:41:0d.6", "0000:41:0f.6", "0000:41:01.0", "0000:41:02.4", "0000:41:06.5", "0000:41:05.3", "0000:41:08.6", "0000:41:08.3", "0000:41:06.2", "0000:41:04.0", "0000:41:01.1", "0000:41:07.6", "0000:41:0f.0", "0000:41:01.7", "0000:41:03.0", "0000:41:00.7", "0000:41:0a.0", "0000:41:09.1", "0000:41:0e.2", "0000:41:0d.1", "0000:41:04.3", "0000:41:0c.4", "0000:41:0f.7", "0000:41:0d.7", "0000:41:08.7", "0000:41:03.5", "0000:41:01.5", "0000:41:0e.4", "0000:41:0c.1", "0000:41:03.7", "0000:41:08.5", "0000:41:03.3", "0000:41:0b.6", "0000:41:08.4", "0000:41:0b.3", "0000:41:09.4", "0000:41:09.5", "0000:41:01.6", "0000:41:0c.6", "0000:41:0c.7", "0000:41:0e.3", "0000:41:07.5", "0000:41:0b.0", "0000:41:09.2", "0000:41:06.1", "0000:41:06.6", "0000:41:04.2", "0000:41:05.6", "0000:41:0a.4", "0000:41:00.5", "0000:41:0f.1", "0000:41:06.0", "0000:41:07.4", "0000:41:03.6", "0000:41:04.5", "0000:41:00.2", "0000:41:0b.2", "0000:41:07.2", "0000:41:05.5", "0000:41:03.2", "0000:41:06.7", "0000:41:01.2", "0000:41:00.4", "0000:41:0a.3", "0000:41:06.3", "0000:41:02.5", "0000:41:02.2", "0000:41:09.0", "0000:41:02.0", "0000:41:0c.3", "0000:41:0e.7", "0000:41:00.6", "0000:41:05.4", "0000:41:05.0", "0000:41:0d.3", "0000:41:0a.6", "0000:41:09.3", "0000:41:0c.2", "0000:41:0f.4", "0000:41:04.1", "0000:41:0f.3", "0000:41:0b.1", "0000:41:01.3", "0000:41:06.4", "0000:41:0f.5", "0000:41:10.0", "0000:41:0e.5", "0000:41:0b.4", "0000:41:0e.6", "0000:41:01.4", "0000:41:0b.5", "0000:41:09.7", "0000:41:02.3", "0000:41:07.3", "0000:41:0a.2"]}</data>
-      <data key="d12">Mellanox Technologies MT28908 Family [ConnectX-6] in PCIe Slot 3 (0000:41:00.0)</data>
+      <data key="d6">{"unit": 4}</data>
+      <data key="d11">{"bdf": ["0000:a1:00.2", "0000:a1:00.3", "0000:a1:00.4", "0000:a1:00.5"]}</data>
+      <data key="d12">Shared NIC: Mellanox Technologies MT28908 Family [ConnectX-6]</data>
       <data key="d7">false</data>
-      <data key="d10">{"primary": {"pool_id": "_", "capacities": {"unit": 127}}}</data>
-      <data key="d13">{"primary": {"pool_id": "_", "labels": {"bdf": ["0000:41:0d.4", "0000:41:09.6", "0000:41:08.0", "0000:41:0a.5", "0000:41:03.4", "0000:41:00.3", "0000:41:04.4", "0000:41:0e.0", "0000:41:0d.0", "0000:41:0c.5", "0000:41:0a.7", "0000:41:0e.1", "0000:41:05.2", "0000:41:0b.7", "0000:41:08.2", "0000:41:0f.2", "0000:41:0a.1", "0000:41:02.1", "0000:41:04.6", "0000:41:0c.0", "0000:41:05.7", "0000:41:07.7", "0000:41:07.0", "0000:41:04.7", "0000:41:07.1", "0000:41:02.7", "0000:41:0d.5", "0000:41:03.1", "0000:41:02.6", "0000:41:08.1", "0000:41:05.1", "0000:41:0d.2", "0000:41:0d.6", "0000:41:0f.6", "0000:41:01.0", "0000:41:02.4", "0000:41:06.5", "0000:41:05.3", "0000:41:08.6", "0000:41:08.3", "0000:41:06.2", "0000:41:04.0", "0000:41:01.1", "0000:41:07.6", "0000:41:0f.0", "0000:41:01.7", "0000:41:03.0", "0000:41:00.7", "0000:41:0a.0", "0000:41:09.1", "0000:41:0e.2", "0000:41:0d.1", "0000:41:04.3", "0000:41:0c.4", "0000:41:0f.7", "0000:41:0d.7", "0000:41:08.7", "0000:41:03.5", "0000:41:01.5", "0000:41:0e.4", "0000:41:0c.1", "0000:41:03.7", "0000:41:08.5", "0000:41:03.3", "0000:41:0b.6", "0000:41:08.4", "0000:41:0b.3", "0000:41:09.4", "0000:41:09.5", "0000:41:01.6", "0000:41:0c.6", "0000:41:0c.7", "0000:41:0e.3", "0000:41:07.5", "0000:41:0b.0", "0000:41:09.2", "0000:41:06.1", "0000:41:06.6", "0000:41:04.2", "0000:41:05.6", "0000:41:0a.4", "0000:41:00.5", "0000:41:0f.1", "0000:41:06.0", "0000:41:07.4", "0000:41:03.6", "0000:41:04.5", "0000:41:00.2", "0000:41:0b.2", "0000:41:07.2", "0000:41:05.5", "0000:41:03.2", "0000:41:06.7", "0000:41:01.2", "0000:41:00.4", "0000:41:0a.3", "0000:41:06.3", "0000:41:02.5", "0000:41:02.2", "0000:41:09.0", "0000:41:02.0", "0000:41:0c.3", "0000:41:0e.7", "0000:41:00.6", "0000:41:05.4", "0000:41:05.0", "0000:41:0d.3", "0000:41:0a.6", "0000:41:09.3", "0000:41:0c.2", "0000:41:0f.4", "0000:41:04.1", "0000:41:0f.3", "0000:41:0b.1", "0000:41:01.3", "0000:41:06.4", "0000:41:0f.5", "0000:41:10.0", "0000:41:0e.5", "0000:41:0b.4", "0000:41:0e.6", "0000:41:01.4", "0000:41:0b.5", "0000:41:09.7", "0000:41:02.3", "0000:41:07.3", "0000:41:0a.2"]}}}</data>
+      <data key="d10">{"primary": {"pool_id": "_", "capacities": {"unit": 4}}}</data>
+      <data key="d13">{"primary": {"pool_id": "_", "labels": {"bdf": ["0000:a1:00.2", "0000:a1:00.3", "0000:a1:00.4", "0000:a1:00.5"]}}}</data>
     </node>
-    <node id="17">
-      <data key="d0">307a43ea-2e59-42c6-8581-71e2a37300f6</data>
+    <node id="623">
+      <data key="d0">feb611c8-5b09-4132-a69c-be9adf894536</data>
       <data key="d1">NetworkService</data>
-      <data key="d2">5B38R53-slot3-ns</data>
-      <data key="d3">lbnl-w2.fabric-testbed.net-lbnl-w2.fabric-testbed.net-slot3-l2ovs</data>
+      <data key="d2">5B3BR53-shnic-sf</data>
+      <data key="d3">lbnl-w1-lbnl-w1-shnic-l2ovs</data>
       <data key="d4">OVS</data>
       <data key="d7">false</data>
       <data key="d14">L2</data>
     </node>
-    <node id="18">
-      <data key="d0">307a43ea-2e59-42c6-8581-71e2a37300f6</data>
+    <node id="624">
+      <data key="d0">feb611c8-5b09-4132-a69c-be9adf894536</data>
       <data key="d1">ConnectionPoint</data>
-      <data key="d2">node_id-04-3F-72-B7-15-6C</data>
-      <data key="d3">lbnl-w2.fabric-testbed.net-slot3-p1</data>
+      <data key="d2">node_id-04-3F-72-B7-19-8C</data>
+      <data key="d3">lbnl-w1-shnic-p1</data>
       <data key="d4">SharedPort</data>
-      <data key="d6">{"unit": 127}</data>
-      <data key="d11">{"bdf": ["0000:41:0d.4", "0000:41:09.6", "0000:41:08.0", "0000:41:0a.5", "0000:41:03.4", "0000:41:00.3", "0000:41:04.4", "0000:41:0e.0", "0000:41:0d.0", "0000:41:0c.5", "0000:41:0a.7", "0000:41:0e.1", "0000:41:05.2", "0000:41:0b.7", "0000:41:08.2", "0000:41:0f.2", "0000:41:0a.1", "0000:41:02.1", "0000:41:04.6", "0000:41:0c.0", "0000:41:05.7", "0000:41:07.7", "0000:41:07.0", "0000:41:04.7", "0000:41:07.1", "0000:41:02.7", "0000:41:0d.5", "0000:41:03.1", "0000:41:02.6", "0000:41:08.1", "0000:41:05.1", "0000:41:0d.2", "0000:41:0d.6", "0000:41:0f.6", "0000:41:01.0", "0000:41:02.4", "0000:41:06.5", "0000:41:05.3", "0000:41:08.6", "0000:41:08.3", "0000:41:06.2", "0000:41:04.0", "0000:41:01.1", "0000:41:07.6", "0000:41:0f.0", "0000:41:01.7", "0000:41:03.0", "0000:41:00.7", "0000:41:0a.0", "0000:41:09.1", "0000:41:0e.2", "0000:41:0d.1", "0000:41:04.3", "0000:41:0c.4", "0000:41:0f.7", "0000:41:0d.7", "0000:41:08.7", "0000:41:03.5", "0000:41:01.5", "0000:41:0e.4", "0000:41:0c.1", "0000:41:03.7", "0000:41:08.5", "0000:41:03.3", "0000:41:0b.6", "0000:41:08.4", "0000:41:0b.3", "0000:41:09.4", "0000:41:09.5", "0000:41:01.6", "0000:41:0c.6", "0000:41:0c.7", "0000:41:0e.3", "0000:41:07.5", "0000:41:0b.0", "0000:41:09.2", "0000:41:06.1", "0000:41:06.6", "0000:41:04.2", "0000:41:05.6", "0000:41:0a.4", "0000:41:00.5", "0000:41:0f.1", "0000:41:06.0", "0000:41:07.4", "0000:41:03.6", "0000:41:04.5", "0000:41:00.2", "0000:41:0b.2", "0000:41:07.2", "0000:41:05.5", "0000:41:03.2", "0000:41:06.7", "0000:41:01.2", "0000:41:00.4", "0000:41:0a.3", "0000:41:06.3", "0000:41:02.5", "0000:41:02.2", "0000:41:09.0", "0000:41:02.0", "0000:41:0c.3", "0000:41:0e.7", "0000:41:00.6", "0000:41:05.4", "0000:41:05.0", "0000:41:0d.3", "0000:41:0a.6", "0000:41:09.3", "0000:41:0c.2", "0000:41:0f.4", "0000:41:04.1", "0000:41:0f.3", "0000:41:0b.1", "0000:41:01.3", "0000:41:06.4", "0000:41:0f.5", "0000:41:10.0", "0000:41:0e.5", "0000:41:0b.4", "0000:41:0e.6", "0000:41:01.4", "0000:41:0b.5", "0000:41:09.7", "0000:41:02.3", "0000:41:07.3", "0000:41:0a.2"], "local_name": ["p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1"], "mac": ["02:42:55:63:D2:74", "02:44:FF:2F:74:3E", "02:60:FE:FD:E0:83", "02:6D:A3:F4:0F:68", "06:3B:17:94:9E:61", "0A:E0:19:FA:9C:83", "12:5B:A7:A9:18:34", "12:F1:C2:E0:2C:EA", "16:64:F7:09:30:DC", "16:A0:5F:C4:49:AF", "1A:F8:25:3B:89:B9", "1E:86:E6:21:4D:E6", "1E:A3:49:2C:6E:20", "1E:AA:D7:3B:C2:38", "1E:E5:9C:B0:86:A5", "1E:E7:58:1F:80:DA", "22:17:33:6E:CB:87", "22:C8:F2:6D:92:94", "26:5C:B1:D7:C1:89", "26:72:A7:98:CB:B1", "2A:77:66:0D:B2:9C", "2E:4E:3E:15:79:47", "2E:F7:9D:84:5E:BA", "36:12:48:F8:44:16", "36:83:6A:EB:1E:2F", "36:9D:33:05:3F:EC", "36:E1:8C:59:29:49", "3E:A0:4B:AF:3C:C1", "42:18:7E:DD:C2:69", "46:B5:10:4A:74:52", "46:CB:3C:12:37:70", "46:D0:F5:89:67:B7", "46:D2:93:09:B3:DD", "46:D6:FC:3C:A4:77", "46:E3:63:56:98:63", "4A:05:DB:4E:27:6C", "4A:65:61:55:93:DC", "4E:2E:52:E2:CC:EF", "4E:6B:59:96:71:C1", "4E:B1:35:42:6B:46", "4E:C0:04:8B:6C:95", "4E:DD:2C:80:39:8F", "4E:ED:EF:46:EA:29", "52:32:1F:5D:DB:A3", "52:E3:8E:79:09:56", "56:48:BF:BC:A7:8A", "5A:67:39:13:61:21", "5A:A0:C7:F7:D6:81", "5A:EA:6B:20:C9:3B", "5E:F4:AB:23:46:AD", "66:01:9B:E8:6F:7A", "66:36:63:8E:56:96", "66:4C:10:A2:C4:59", "66:87:89:3F:F9:E0", "6A:50:CB:A3:DE:76", "6A:80:F1:63:C8:21", "6A:BB:1F:4C:0C:51", "6E:43:AA:E7:9F:C3", "72:58:65:7E:08:37", "72:CF:B7:8F:AF:D7", "76:18:47:57:BF:54", "7E:2D:46:E2:D8:D2", "82:0F:7D:4A:ED:F1", "82:26:8F:55:B9:92", "82:31:26:8E:82:D9", "82:55:3F:07:15:13", "82:A1:8F:EB:6B:EA", "8A:5E:90:1C:1E:47", "8A:97:52:7D:6E:CC", "8A:EA:19:39:A3:FE", "8E:72:B3:EE:56:93", "8E:BE:AE:5A:D0:AA", "92:54:21:13:FE:7C", "9A:4B:DE:85:CE:73", "9A:8C:73:28:2F:6C", "9A:D4:C9:EC:B3:1F", "A2:1A:D2:FD:5C:66", "A2:4F:3F:10:2C:CB", "A6:A2:EC:4E:B5:DE", "A6:C2:A2:0E:42:70", "A6:DB:BC:98:60:23", "AE:BF:6E:D1:96:89", "B2:4F:95:B4:51:10", "BA:35:1A:0F:21:0E", "BA:A1:F5:B2:90:EF", "BE:6C:E2:6C:A4:F3", "BE:E8:FF:4D:21:57", "C2:57:B2:0A:B8:46", "C2:A1:86:62:6E:9A", "C2:EE:2D:6C:50:B0", "C6:56:58:0C:0A:01", "CA:22:2B:1C:65:51", "CA:C5:B6:BC:46:20", "CA:E0:A6:59:8D:48", "CE:04:97:1B:87:25", "CE:2E:90:7F:2C:E1", "CE:67:16:98:56:2D", "CE:D8:68:6B:1E:A8", "CE:DF:1A:5B:7A:22", "D2:2F:92:EE:01:42", "D2:E2:6F:57:40:AE", "D6:7D:50:EF:0B:59", "D6:86:4A:1F:AF:C6", "D6:A9:F2:BB:87:72", "D6:BA:89:44:EE:BD", "DA:EA:3A:1B:24:02", "DE:05:29:DE:63:35", "DE:41:9F:3F:53:7B", "DE:7A:A6:75:DD:50", "DE:BA:EA:D2:34:A9", "E2:06:EE:AD:12:3E", "E2:C2:9E:6E:67:0B", "E6:4D:80:FF:94:5C", "E6:9A:BF:8E:54:19", "E6:E1:B3:B3:36:F8", "EA:6C:F5:91:5C:1D", "EA:7F:4F:9D:40:DC", "EE:1F:5F:9B:29:9B", "EE:29:E4:12:E7:4F", "EE:66:16:65:79:54", "EE:94:57:F3:10:33", "F2:1C:95:D4:87:32", "F2:8D:B9:6A:A4:22", "F2:D5:50:4B:BC:5A", "F2:F7:CE:E0:71:FB", "F6:E7:25:31:C2:CE", "F6:F4:C4:06:BD:3D"], "vlan": ["2106", "2076", "2062", "2083", "2026", "2001", "2034", "2110", "2102", "2099", "2085", "2111", "2040", "2093", "2064", "2120", "2079", "2015", "2036", "2094", "2045", "2061", "2054", "2037", "2055", "2021", "2107", "2023", "2020", "2063", "2039", "2104", "2108", "2124", "2006", "2018", "2051", "2041", "2068", "2065", "2048", "2030", "2007", "2060", "2118", "2013", "2022", "2005", "2078", "2071", "2112", "2103", "2033", "2098", "2125", "2109", "2069", "2027", "2011", "2114", "2095", "2029", "2067", "2025", "2092", "2066", "2089", "2074", "2075", "2012", "2100", "2101", "2113", "2059", "2086", "2072", "2047", "2052", "2032", "2044", "2082", "2003", "2119", "2046", "2058", "2028", "2035", "2000", "2088", "2056", "2043", "2024", "2053", "2008", "2002", "2081", "2049", "2019", "2016", "2070", "2014", "2097", "2117", "2004", "2042", "2038", "2105", "2084", "2073", "2096", "2122", "2031", "2121", "2087", "2009", "2050", "2123", "2126", "2115", "2090", "2116", "2010", "2091", "2077", "2017", "2057", "2080"]}</data>
+      <data key="d6">{"unit": 4}</data>
+      <data key="d11">{"bdf": ["0000:a1:00.2", "0000:a1:00.3", "0000:a1:00.4", "0000:a1:00.5"], "local_name": ["p1", "p1", "p1", "p1"], "mac": ["04:3F:72:B7:19:8D", "04:3F:72:B7:19:8E", "04:3F:72:B7:19:8F", "04:3F:72:B7:19:8A"], "vlan": ["1001", "1002", "1003", "1004"]}</data>
       <data key="d7">false</data>
-      <data key="d10">{"primary": {"pool_id": "_", "capacities": {"unit": 127}}}</data>
-      <data key="d13">{"primary": {"pool_id": "_", "labels": {"bdf": ["0000:41:0d.4", "0000:41:09.6", "0000:41:08.0", "0000:41:0a.5", "0000:41:03.4", "0000:41:00.3", "0000:41:04.4", "0000:41:0e.0", "0000:41:0d.0", "0000:41:0c.5", "0000:41:0a.7", "0000:41:0e.1", "0000:41:05.2", "0000:41:0b.7", "0000:41:08.2", "0000:41:0f.2", "0000:41:0a.1", "0000:41:02.1", "0000:41:04.6", "0000:41:0c.0", "0000:41:05.7", "0000:41:07.7", "0000:41:07.0", "0000:41:04.7", "0000:41:07.1", "0000:41:02.7", "0000:41:0d.5", "0000:41:03.1", "0000:41:02.6", "0000:41:08.1", "0000:41:05.1", "0000:41:0d.2", "0000:41:0d.6", "0000:41:0f.6", "0000:41:01.0", "0000:41:02.4", "0000:41:06.5", "0000:41:05.3", "0000:41:08.6", "0000:41:08.3", "0000:41:06.2", "0000:41:04.0", "0000:41:01.1", "0000:41:07.6", "0000:41:0f.0", "0000:41:01.7", "0000:41:03.0", "0000:41:00.7", "0000:41:0a.0", "0000:41:09.1", "0000:41:0e.2", "0000:41:0d.1", "0000:41:04.3", "0000:41:0c.4", "0000:41:0f.7", "0000:41:0d.7", "0000:41:08.7", "0000:41:03.5", "0000:41:01.5", "0000:41:0e.4", "0000:41:0c.1", "0000:41:03.7", "0000:41:08.5", "0000:41:03.3", "0000:41:0b.6", "0000:41:08.4", "0000:41:0b.3", "0000:41:09.4", "0000:41:09.5", "0000:41:01.6", "0000:41:0c.6", "0000:41:0c.7", "0000:41:0e.3", "0000:41:07.5", "0000:41:0b.0", "0000:41:09.2", "0000:41:06.1", "0000:41:06.6", "0000:41:04.2", "0000:41:05.6", "0000:41:0a.4", "0000:41:00.5", "0000:41:0f.1", "0000:41:06.0", "0000:41:07.4", "0000:41:03.6", "0000:41:04.5", "0000:41:00.2", "0000:41:0b.2", "0000:41:07.2", "0000:41:05.5", "0000:41:03.2", "0000:41:06.7", "0000:41:01.2", "0000:41:00.4", "0000:41:0a.3", "0000:41:06.3", "0000:41:02.5", "0000:41:02.2", "0000:41:09.0", "0000:41:02.0", "0000:41:0c.3", "0000:41:0e.7", "0000:41:00.6", "0000:41:05.4", "0000:41:05.0", "0000:41:0d.3", "0000:41:0a.6", "0000:41:09.3", "0000:41:0c.2", "0000:41:0f.4", "0000:41:04.1", "0000:41:0f.3", "0000:41:0b.1", "0000:41:01.3", "0000:41:06.4", "0000:41:0f.5", "0000:41:10.0", "0000:41:0e.5", "0000:41:0b.4", "0000:41:0e.6", "0000:41:01.4", "0000:41:0b.5", "0000:41:09.7", "0000:41:02.3", "0000:41:07.3", "0000:41:0a.2"], "mac": ["02:42:55:63:D2:74", "02:44:FF:2F:74:3E", "02:60:FE:FD:E0:83", "02:6D:A3:F4:0F:68", "06:3B:17:94:9E:61", "0A:E0:19:FA:9C:83", "12:5B:A7:A9:18:34", "12:F1:C2:E0:2C:EA", "16:64:F7:09:30:DC", "16:A0:5F:C4:49:AF", "1A:F8:25:3B:89:B9", "1E:86:E6:21:4D:E6", "1E:A3:49:2C:6E:20", "1E:AA:D7:3B:C2:38", "1E:E5:9C:B0:86:A5", "1E:E7:58:1F:80:DA", "22:17:33:6E:CB:87", "22:C8:F2:6D:92:94", "26:5C:B1:D7:C1:89", "26:72:A7:98:CB:B1", "2A:77:66:0D:B2:9C", "2E:4E:3E:15:79:47", "2E:F7:9D:84:5E:BA", "36:12:48:F8:44:16", "36:83:6A:EB:1E:2F", "36:9D:33:05:3F:EC", "36:E1:8C:59:29:49", "3E:A0:4B:AF:3C:C1", "42:18:7E:DD:C2:69", "46:B5:10:4A:74:52", "46:CB:3C:12:37:70", "46:D0:F5:89:67:B7", "46:D2:93:09:B3:DD", "46:D6:FC:3C:A4:77", "46:E3:63:56:98:63", "4A:05:DB:4E:27:6C", "4A:65:61:55:93:DC", "4E:2E:52:E2:CC:EF", "4E:6B:59:96:71:C1", "4E:B1:35:42:6B:46", "4E:C0:04:8B:6C:95", "4E:DD:2C:80:39:8F", "4E:ED:EF:46:EA:29", "52:32:1F:5D:DB:A3", "52:E3:8E:79:09:56", "56:48:BF:BC:A7:8A", "5A:67:39:13:61:21", "5A:A0:C7:F7:D6:81", "5A:EA:6B:20:C9:3B", "5E:F4:AB:23:46:AD", "66:01:9B:E8:6F:7A", "66:36:63:8E:56:96", "66:4C:10:A2:C4:59", "66:87:89:3F:F9:E0", "6A:50:CB:A3:DE:76", "6A:80:F1:63:C8:21", "6A:BB:1F:4C:0C:51", "6E:43:AA:E7:9F:C3", "72:58:65:7E:08:37", "72:CF:B7:8F:AF:D7", "76:18:47:57:BF:54", "7E:2D:46:E2:D8:D2", "82:0F:7D:4A:ED:F1", "82:26:8F:55:B9:92", "82:31:26:8E:82:D9", "82:55:3F:07:15:13", "82:A1:8F:EB:6B:EA", "8A:5E:90:1C:1E:47", "8A:97:52:7D:6E:CC", "8A:EA:19:39:A3:FE", "8E:72:B3:EE:56:93", "8E:BE:AE:5A:D0:AA", "92:54:21:13:FE:7C", "9A:4B:DE:85:CE:73", "9A:8C:73:28:2F:6C", "9A:D4:C9:EC:B3:1F", "A2:1A:D2:FD:5C:66", "A2:4F:3F:10:2C:CB", "A6:A2:EC:4E:B5:DE", "A6:C2:A2:0E:42:70", "A6:DB:BC:98:60:23", "AE:BF:6E:D1:96:89", "B2:4F:95:B4:51:10", "BA:35:1A:0F:21:0E", "BA:A1:F5:B2:90:EF", "BE:6C:E2:6C:A4:F3", "BE:E8:FF:4D:21:57", "C2:57:B2:0A:B8:46", "C2:A1:86:62:6E:9A", "C2:EE:2D:6C:50:B0", "C6:56:58:0C:0A:01", "CA:22:2B:1C:65:51", "CA:C5:B6:BC:46:20", "CA:E0:A6:59:8D:48", "CE:04:97:1B:87:25", "CE:2E:90:7F:2C:E1", "CE:67:16:98:56:2D", "CE:D8:68:6B:1E:A8", "CE:DF:1A:5B:7A:22", "D2:2F:92:EE:01:42", "D2:E2:6F:57:40:AE", "D6:7D:50:EF:0B:59", "D6:86:4A:1F:AF:C6", "D6:A9:F2:BB:87:72", "D6:BA:89:44:EE:BD", "DA:EA:3A:1B:24:02", "DE:05:29:DE:63:35", "DE:41:9F:3F:53:7B", "DE:7A:A6:75:DD:50", "DE:BA:EA:D2:34:A9", "E2:06:EE:AD:12:3E", "E2:C2:9E:6E:67:0B", "E6:4D:80:FF:94:5C", "E6:9A:BF:8E:54:19", "E6:E1:B3:B3:36:F8", "EA:6C:F5:91:5C:1D", "EA:7F:4F:9D:40:DC", "EE:1F:5F:9B:29:9B", "EE:29:E4:12:E7:4F", "EE:66:16:65:79:54", "EE:94:57:F3:10:33", "F2:1C:95:D4:87:32", "F2:8D:B9:6A:A4:22", "F2:D5:50:4B:BC:5A", "F2:F7:CE:E0:71:FB", "F6:E7:25:31:C2:CE", "F6:F4:C4:06:BD:3D"], "vlan": ["2106", "2076", "2062", "2083", "2026", "2001", "2034", "2110", "2102", "2099", "2085", "2111", "2040", "2093", "2064", "2120", "2079", "2015", "2036", "2094", "2045", "2061", "2054", "2037", "2055", "2021", "2107", "2023", "2020", "2063", "2039", "2104", "2108", "2124", "2006", "2018", "2051", "2041", "2068", "2065", "2048", "2030", "2007", "2060", "2118", "2013", "2022", "2005", "2078", "2071", "2112", "2103", "2033", "2098", "2125", "2109", "2069", "2027", "2011", "2114", "2095", "2029", "2067", "2025", "2092", "2066", "2089", "2074", "2075", "2012", "2100", "2101", "2113", "2059", "2086", "2072", "2047", "2052", "2032", "2044", "2082", "2003", "2119", "2046", "2058", "2028", "2035", "2000", "2088", "2056", "2043", "2024", "2053", "2008", "2002", "2081", "2049", "2019", "2016", "2070", "2014", "2097", "2117", "2004", "2042", "2038", "2105", "2084", "2073", "2096", "2122", "2031", "2121", "2087", "2009", "2050", "2123", "2126", "2115", "2090", "2116", "2010", "2091", "2077", "2017", "2057", "2080"], "local_name": ["p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1"]}}}</data>
+      <data key="d10">{"primary": {"pool_id": "_", "capacities": {"unit": 4}}}</data>
+      <data key="d13">{"primary": {"pool_id": "_", "labels": {"bdf": ["0000:a1:00.2", "0000:a1:00.3", "0000:a1:00.4", "0000:a1:00.5"], "mac": ["04:3F:72:B7:19:8D", "04:3F:72:B7:19:8E", "04:3F:72:B7:19:8F", "04:3F:72:B7:19:8A"], "vlan": ["1001", "1002", "1003", "1004"], "local_name": ["p1", "p1", "p1", "p1"]}}}</data>
     </node>
-    <node id="19">
-      <data key="d0">307a43ea-2e59-42c6-8581-71e2a37300f6</data>
+    <node id="625">
+      <data key="d0">feb611c8-5b09-4132-a69c-be9adf894536</data>
       <data key="d1">Component</data>
-      <data key="d2">5B38R53-slot7</data>
-      <data key="d3">lbnl-w2.fabric-testbed.net-slot7</data>
+      <data key="d2">5B38R53-shnic</data>
+      <data key="d3">lbnl-w2-shnic</data>
+      <data key="d4">SharedNIC</data>
+      <data key="d5">ConnectX-6</data>
+      <data key="d6">{"unit": 4}</data>
+      <data key="d11">{"bdf": ["0000:e2:00.2", "0000:e2:00.3", "0000:e2:00.4", "0000:e2:00.5"]}</data>
+      <data key="d12">Shared NIC: Mellanox Technologies MT28908 Family [ConnectX-6]</data>
+      <data key="d7">false</data>
+      <data key="d10">{"primary": {"pool_id": "_", "capacities": {"unit": 4}}}</data>
+      <data key="d13">{"primary": {"pool_id": "_", "labels": {"bdf": ["0000:e2:00.2", "0000:e2:00.3", "0000:e2:00.4", "0000:e2:00.5"]}}}</data>
+    </node>
+    <node id="626">
+      <data key="d0">feb611c8-5b09-4132-a69c-be9adf894536</data>
+      <data key="d1">NetworkService</data>
+      <data key="d2">5B38R53-shnic-sf</data>
+      <data key="d3">lbnl-w2-lbnl-w2-shnic-l2ovs</data>
+      <data key="d4">OVS</data>
+      <data key="d7">false</data>
+      <data key="d14">L2</data>
+    </node>
+    <node id="627">
+      <data key="d0">feb611c8-5b09-4132-a69c-be9adf894536</data>
+      <data key="d1">ConnectionPoint</data>
+      <data key="d2">node_id-04-3F-72-B7-15-8C</data>
+      <data key="d3">lbnl-w2-shnic-p1</data>
+      <data key="d4">SharedPort</data>
+      <data key="d6">{"unit": 4}</data>
+      <data key="d11">{"bdf": ["0000:e2:00.2", "0000:e2:00.3", "0000:e2:00.4", "0000:e2:00.5"], "local_name": ["p1", "p1", "p1", "p1"], "mac": ["04:3F:72:B7:15:8D", "04:3F:72:B7:15:8E", "04:3F:72:B7:15:8F", "04:3F:72:B7:15:8A"], "vlan": ["1001", "1002", "1003", "1004"]}</data>
+      <data key="d7">false</data>
+      <data key="d10">{"primary": {"pool_id": "_", "capacities": {"unit": 4}}}</data>
+      <data key="d13">{"primary": {"pool_id": "_", "labels": {"bdf": ["0000:e2:00.2", "0000:e2:00.3", "0000:e2:00.4", "0000:e2:00.5"], "mac": ["04:3F:72:B7:15:8D", "04:3F:72:B7:15:8E", "04:3F:72:B7:15:8F", "04:3F:72:B7:15:8A"], "vlan": ["1001", "1002", "1003", "1004"], "local_name": ["p1", "p1", "p1", "p1"]}}}</data>
+    </node>
+    <node id="628">
+      <data key="d0">feb611c8-5b09-4132-a69c-be9adf894536</data>
+      <data key="d1">Component</data>
+      <data key="d2">5B39R53-shnic</data>
+      <data key="d3">lbnl-w3-shnic</data>
+      <data key="d4">SharedNIC</data>
+      <data key="d5">ConnectX-6</data>
+      <data key="d6">{"unit": 4}</data>
+      <data key="d11">{"bdf": ["0000:e2:00.2", "0000:e2:00.3", "0000:e2:00.4", "0000:e2:00.5"]}</data>
+      <data key="d12">Shared NIC: Mellanox Technologies MT28908 Family [ConnectX-6]</data>
+      <data key="d7">false</data>
+      <data key="d10">{"primary": {"pool_id": "_", "capacities": {"unit": 4}}}</data>
+      <data key="d13">{"primary": {"pool_id": "_", "labels": {"bdf": ["0000:e2:00.2", "0000:e2:00.3", "0000:e2:00.4", "0000:e2:00.5"]}}}</data>
+    </node>
+    <node id="629">
+      <data key="d0">feb611c8-5b09-4132-a69c-be9adf894536</data>
+      <data key="d1">NetworkService</data>
+      <data key="d2">5B39R53-shnic-sf</data>
+      <data key="d3">lbnl-w3-lbnl-w3-shnic-l2ovs</data>
+      <data key="d4">OVS</data>
+      <data key="d7">false</data>
+      <data key="d14">L2</data>
+    </node>
+    <node id="630">
+      <data key="d0">feb611c8-5b09-4132-a69c-be9adf894536</data>
+      <data key="d1">ConnectionPoint</data>
+      <data key="d2">node_id-04-3F-72-B7-15-7C</data>
+      <data key="d3">lbnl-w3-shnic-p1</data>
+      <data key="d4">SharedPort</data>
+      <data key="d6">{"unit": 4}</data>
+      <data key="d11">{"bdf": ["0000:e2:00.2", "0000:e2:00.3", "0000:e2:00.4", "0000:e2:00.5"], "local_name": ["p1", "p1", "p1", "p1"], "mac": ["04:3F:72:B7:15:7D", "04:3F:72:B7:15:7E", "04:3F:72:B7:15:7F", "04:3F:72:B7:15:7A"], "vlan": ["1001", "1002", "1003", "1004"]}</data>
+      <data key="d7">false</data>
+      <data key="d10">{"primary": {"pool_id": "_", "capacities": {"unit": 4}}}</data>
+      <data key="d13">{"primary": {"pool_id": "_", "labels": {"bdf": ["0000:e2:00.2", "0000:e2:00.3", "0000:e2:00.4", "0000:e2:00.5"], "mac": ["04:3F:72:B7:15:7D", "04:3F:72:B7:15:7E", "04:3F:72:B7:15:7F", "04:3F:72:B7:15:7A"], "vlan": ["1001", "1002", "1003", "1004"], "local_name": ["p1", "p1", "p1", "p1"]}}}</data>
+    </node>
+    <node id="631">
+      <data key="d0">feb611c8-5b09-4132-a69c-be9adf894536</data>
+      <data key="d1">Component</data>
+      <data key="d2">5B38R53-nic1</data>
+      <data key="d3">lbnl-w2-nic1</data>
       <data key="d4">SmartNIC</data>
       <data key="d5">ConnectX-6</data>
       <data key="d6">{"unit": 1}</data>
-      <data key="d11">{"bdf": ["0000:e2:00.0", "0000:e2:00.1"]}</data>
-      <data key="d12">Mellanox Technologies MT28908 Family [ConnectX-6] in PCIe Slot 7 (0000:e2:00.0)</data>
+      <data key="d11">{"bdf": ["0000:41:00.0", "0000:41:00.1"]}</data>
+      <data key="d12">Mellanox Technologies MT28908 Family [ConnectX-6]</data>
       <data key="d7">false</data>
       <data key="d10">{"primary": {"pool_id": "_", "capacities": {"unit": 1}}}</data>
-      <data key="d13">{"primary": {"pool_id": "_", "labels": {"bdf": ["0000:e2:00.0", "0000:e2:00.1"]}}}</data>
+      <data key="d13">{"primary": {"pool_id": "_", "labels": {"bdf": ["0000:41:00.0", "0000:41:00.1"]}}}</data>
     </node>
-    <node id="20">
-      <data key="d0">307a43ea-2e59-42c6-8581-71e2a37300f6</data>
+    <node id="632">
+      <data key="d0">feb611c8-5b09-4132-a69c-be9adf894536</data>
       <data key="d1">NetworkService</data>
-      <data key="d2">5B38R53-slot7-ns</data>
-      <data key="d3">lbnl-w2.fabric-testbed.net-lbnl-w2.fabric-testbed.net-slot7-l2ovs</data>
+      <data key="d2">5B38R53-nic1-sf</data>
+      <data key="d3">lbnl-w2-lbnl-w2-nic1-l2ovs</data>
       <data key="d4">OVS</data>
       <data key="d7">false</data>
       <data key="d14">L2</data>
     </node>
-    <node id="21">
-      <data key="d0">307a43ea-2e59-42c6-8581-71e2a37300f6</data>
+    <node id="633">
+      <data key="d0">feb611c8-5b09-4132-a69c-be9adf894536</data>
       <data key="d1">ConnectionPoint</data>
-      <data key="d2">node_id-04-3F-72-B7-15-8C</data>
-      <data key="d3">lbnl-w2.fabric-testbed.net-slot7-p1</data>
+      <data key="d2">node_id-04-3F-72-B7-15-6C</data>
+      <data key="d3">lbnl-w2-nic1-p1</data>
       <data key="d4">DedicatedPort</data>
       <data key="d6">{"bw": 100, "unit": 1}</data>
-      <data key="d11">{"local_name": "p1", "mac": "04:3F:72:B7:15:8C", "vlan_range": "1-4096"}</data>
+      <data key="d11">{"local_name": "p1", "mac": "04:3F:72:B7:15:6C", "vlan_range": "1-4096"}</data>
       <data key="d7">false</data>
       <data key="d10">{"primary": {"pool_id": "_", "capacities": {"bw": 100, "unit": 1}}}</data>
-      <data key="d13">{"primary": {"pool_id": "_", "labels": {"mac": "04:3F:72:B7:15:8C", "vlan_range": "1-4096", "local_name": "p1"}}}</data>
+      <data key="d13">{"primary": {"pool_id": "_", "labels": {"mac": "04:3F:72:B7:15:6C", "vlan_range": "1-4096", "local_name": "p1"}}}</data>
     </node>
-    <node id="22">
-      <data key="d0">307a43ea-2e59-42c6-8581-71e2a37300f6</data>
+    <node id="634">
+      <data key="d0">feb611c8-5b09-4132-a69c-be9adf894536</data>
       <data key="d1">ConnectionPoint</data>
-      <data key="d2">node_id-04-3F-72-B7-15-8D</data>
-      <data key="d3">lbnl-w2.fabric-testbed.net-slot7-p2</data>
+      <data key="d2">node_id-04-3F-72-B7-15-6D</data>
+      <data key="d3">lbnl-w2-nic1-p2</data>
       <data key="d4">DedicatedPort</data>
       <data key="d6">{"bw": 100, "unit": 1}</data>
-      <data key="d11">{"local_name": "p2", "mac": "04:3F:72:B7:15:8D", "vlan_range": "1-4096"}</data>
+      <data key="d11">{"local_name": "p2", "mac": "04:3F:72:B7:15:6D", "vlan_range": "1-4096"}</data>
       <data key="d7">false</data>
       <data key="d10">{"primary": {"pool_id": "_", "capacities": {"bw": 100, "unit": 1}}}</data>
-      <data key="d13">{"primary": {"pool_id": "_", "labels": {"mac": "04:3F:72:B7:15:8D", "vlan_range": "1-4096", "local_name": "p2"}}}</data>
+      <data key="d13">{"primary": {"pool_id": "_", "labels": {"mac": "04:3F:72:B7:15:6D", "vlan_range": "1-4096", "local_name": "p2"}}}</data>
     </node>
-    <node id="23">
-      <data key="d0">307a43ea-2e59-42c6-8581-71e2a37300f6</data>
+    <node id="635">
+      <data key="d0">feb611c8-5b09-4132-a69c-be9adf894536</data>
       <data key="d1">Component</data>
-      <data key="d2">5B38R53-slot6</data>
-      <data key="d3">lbnl-w2.fabric-testbed.net-slot6</data>
+      <data key="d2">5B38R53-nic2</data>
+      <data key="d3">lbnl-w2-nic2</data>
       <data key="d4">SmartNIC</data>
       <data key="d5">ConnectX-6</data>
       <data key="d6">{"unit": 1}</data>
       <data key="d11">{"bdf": ["0000:a1:00.0", "0000:a1:00.1"]}</data>
-      <data key="d12">Mellanox Technologies MT28908 Family [ConnectX-6] in PCIe Slot 6 (0000:a1:00.0)</data>
+      <data key="d12">Mellanox Technologies MT28908 Family [ConnectX-6]</data>
       <data key="d7">false</data>
       <data key="d10">{"primary": {"pool_id": "_", "capacities": {"unit": 1}}}</data>
       <data key="d13">{"primary": {"pool_id": "_", "labels": {"bdf": ["0000:a1:00.0", "0000:a1:00.1"]}}}</data>
     </node>
-    <node id="24">
-      <data key="d0">307a43ea-2e59-42c6-8581-71e2a37300f6</data>
+    <node id="636">
+      <data key="d0">feb611c8-5b09-4132-a69c-be9adf894536</data>
       <data key="d1">NetworkService</data>
-      <data key="d2">5B38R53-slot6-ns</data>
-      <data key="d3">lbnl-w2.fabric-testbed.net-lbnl-w2.fabric-testbed.net-slot6-l2ovs</data>
+      <data key="d2">5B38R53-nic2-sf</data>
+      <data key="d3">lbnl-w2-lbnl-w2-nic2-l2ovs</data>
       <data key="d4">OVS</data>
       <data key="d7">false</data>
       <data key="d14">L2</data>
     </node>
-    <node id="25">
-      <data key="d0">307a43ea-2e59-42c6-8581-71e2a37300f6</data>
+    <node id="637">
+      <data key="d0">feb611c8-5b09-4132-a69c-be9adf894536</data>
       <data key="d1">ConnectionPoint</data>
       <data key="d2">node_id-04-3F-72-B7-18-AC</data>
-      <data key="d3">lbnl-w2.fabric-testbed.net-slot6-p1</data>
+      <data key="d3">lbnl-w2-nic2-p1</data>
       <data key="d4">DedicatedPort</data>
       <data key="d6">{"bw": 100, "unit": 1}</data>
       <data key="d11">{"local_name": "p1", "mac": "04:3F:72:B7:18:AC", "vlan_range": "1-4096"}</data>
@@ -334,11 +466,11 @@
       <data key="d10">{"primary": {"pool_id": "_", "capacities": {"bw": 100, "unit": 1}}}</data>
       <data key="d13">{"primary": {"pool_id": "_", "labels": {"mac": "04:3F:72:B7:18:AC", "vlan_range": "1-4096", "local_name": "p1"}}}</data>
     </node>
-    <node id="26">
-      <data key="d0">307a43ea-2e59-42c6-8581-71e2a37300f6</data>
+    <node id="638">
+      <data key="d0">feb611c8-5b09-4132-a69c-be9adf894536</data>
       <data key="d1">ConnectionPoint</data>
       <data key="d2">node_id-04-3F-72-B7-18-AD</data>
-      <data key="d3">lbnl-w2.fabric-testbed.net-slot6-p2</data>
+      <data key="d3">lbnl-w2-nic2-p2</data>
       <data key="d4">DedicatedPort</data>
       <data key="d6">{"bw": 100, "unit": 1}</data>
       <data key="d11">{"local_name": "p2", "mac": "04:3F:72:B7:18:AD", "vlan_range": "1-4096"}</data>
@@ -346,213 +478,34 @@
       <data key="d10">{"primary": {"pool_id": "_", "capacities": {"bw": 100, "unit": 1}}}</data>
       <data key="d13">{"primary": {"pool_id": "_", "labels": {"mac": "04:3F:72:B7:18:AD", "vlan_range": "1-4096", "local_name": "p2"}}}</data>
     </node>
-    <node id="27">
-      <data key="d0">307a43ea-2e59-42c6-8581-71e2a37300f6</data>
-      <data key="d1">NetworkNode</data>
-      <data key="d2">5B39R53</data>
-      <data key="d3">lbnl-w3.fabric-testbed.net</data>
-      <data key="d4">Server</data>
-      <data key="d5">R7525</data>
-      <data key="d6">{"core": 64, "cpu": 2, "disk": 4800, "ram": 512, "unit": 1}</data>
-      <data key="d7">false</data>
-      <data key="d8">LBNL</data>
-      <data key="d9">{"postal": "1 Cyclotron Rd,Berkeley, CA 94720"}</data>
-      <data key="d10">{"primary": {"pool_id": "_", "capacities": {"cpu": 2, "core": 64, "ram": 512, "disk": 4800, "unit": 1}}}</data>
-    </node>
-    <node id="28">
-      <data key="d0">307a43ea-2e59-42c6-8581-71e2a37300f6</data>
+    <node id="639">
+      <data key="d0">feb611c8-5b09-4132-a69c-be9adf894536</data>
       <data key="d1">Component</data>
-      <data key="d2">PHLJ015301KV1P0FGN</data>
-      <data key="d3">lbnl-w3.fabric-testbed.net-nvme-1</data>
-      <data key="d4">NVME</data>
-      <data key="d5">P4510</data>
-      <data key="d6">{"disk": 1000, "unit": 1}</data>
-      <data key="d11">{"bdf": "0000:21:00.0"}</data>
-      <data key="d12">Dell Express Flash NVMe P4510 1TB SFF in PCIe SSD Slot 22 in Bay 2 (0000:21:00.0)</data>
-      <data key="d7">false</data>
-      <data key="d10">{"primary": {"pool_id": "_", "capacities": {"disk": 1000, "unit": 1}}}</data>
-      <data key="d13">{"primary": {"pool_id": "_", "labels": {"bdf": "0000:21:00.0"}}}</data>
-    </node>
-    <node id="29">
-      <data key="d0">307a43ea-2e59-42c6-8581-71e2a37300f6</data>
-      <data key="d1">Component</data>
-      <data key="d2">PHLJ015301RL1P0FGN</data>
-      <data key="d3">lbnl-w3.fabric-testbed.net-nvme-2</data>
-      <data key="d4">NVME</data>
-      <data key="d5">P4510</data>
-      <data key="d6">{"disk": 1000, "unit": 1}</data>
-      <data key="d11">{"bdf": "0000:22:00.0"}</data>
-      <data key="d12">Dell Express Flash NVMe P4510 1TB SFF in PCIe SSD Slot 23 in Bay 2 (0000:22:00.0)</data>
-      <data key="d7">false</data>
-      <data key="d10">{"primary": {"pool_id": "_", "capacities": {"disk": 1000, "unit": 1}}}</data>
-      <data key="d13">{"primary": {"pool_id": "_", "labels": {"bdf": "0000:22:00.0"}}}</data>
-    </node>
-    <node id="30">
-      <data key="d0">307a43ea-2e59-42c6-8581-71e2a37300f6</data>
-      <data key="d1">Component</data>
-      <data key="d2">PHLJ015301L91P0FGN</data>
-      <data key="d3">lbnl-w3.fabric-testbed.net-nvme-3</data>
-      <data key="d4">NVME</data>
-      <data key="d5">P4510</data>
-      <data key="d6">{"disk": 1000, "unit": 1}</data>
-      <data key="d11">{"bdf": "0000:23:00.0"}</data>
-      <data key="d12">Dell Express Flash NVMe P4510 1TB SFF in PCIe SSD Slot 20 in Bay 2 (0000:23:00.0)</data>
-      <data key="d7">false</data>
-      <data key="d10">{"primary": {"pool_id": "_", "capacities": {"disk": 1000, "unit": 1}}}</data>
-      <data key="d13">{"primary": {"pool_id": "_", "labels": {"bdf": "0000:23:00.0"}}}</data>
-    </node>
-    <node id="31">
-      <data key="d0">307a43ea-2e59-42c6-8581-71e2a37300f6</data>
-      <data key="d1">Component</data>
-      <data key="d2">PHLJ015301SK1P0FGN</data>
-      <data key="d3">lbnl-w3.fabric-testbed.net-nvme-4</data>
-      <data key="d4">NVME</data>
-      <data key="d5">P4510</data>
-      <data key="d6">{"disk": 1000, "unit": 1}</data>
-      <data key="d11">{"bdf": "0000:24:00.0"}</data>
-      <data key="d12">Dell Express Flash NVMe P4510 1TB SFF in PCIe SSD Slot 21 in Bay 2 (0000:24:00.0)</data>
-      <data key="d7">false</data>
-      <data key="d10">{"primary": {"pool_id": "_", "capacities": {"disk": 1000, "unit": 1}}}</data>
-      <data key="d13">{"primary": {"pool_id": "_", "labels": {"bdf": "0000:24:00.0"}}}</data>
-    </node>
-    <node id="32">
-      <data key="d0">307a43ea-2e59-42c6-8581-71e2a37300f6</data>
-      <data key="d1">Component</data>
-      <data key="d2">5B39R53-gpu-1</data>
-      <data key="d3">lbnl-w3.fabric-testbed.net-gpu-1</data>
-      <data key="d4">GPU</data>
-      <data key="d5">Tesla T4</data>
-      <data key="d6">{"unit": 1}</data>
-      <data key="d11">{"bdf": "0000:25:00.0"}</data>
-      <data key="d12">NVIDIA Corporation TU104GL [Tesla T4] (rev a1)</data>
-      <data key="d7">false</data>
-      <data key="d10">{"primary": {"pool_id": "_", "capacities": {"unit": 1}}}</data>
-      <data key="d13">{"primary": {"pool_id": "_", "labels": {"bdf": "0000:25:00.0"}}}</data>
-    </node>
-    <node id="33">
-      <data key="d0">307a43ea-2e59-42c6-8581-71e2a37300f6</data>
-      <data key="d1">Component</data>
-      <data key="d2">5B39R53-gpu-2</data>
-      <data key="d3">lbnl-w3.fabric-testbed.net-gpu-2</data>
-      <data key="d4">GPU</data>
-      <data key="d5">Tesla T4</data>
-      <data key="d6">{"unit": 1}</data>
-      <data key="d11">{"bdf": "0000:81:00.0"}</data>
-      <data key="d12">NVIDIA Corporation TU104GL [Tesla T4] (rev a1)</data>
-      <data key="d7">false</data>
-      <data key="d10">{"primary": {"pool_id": "_", "capacities": {"unit": 1}}}</data>
-      <data key="d13">{"primary": {"pool_id": "_", "labels": {"bdf": "0000:81:00.0"}}}</data>
-    </node>
-    <node id="34">
-      <data key="d0">307a43ea-2e59-42c6-8581-71e2a37300f6</data>
-      <data key="d1">Component</data>
-      <data key="d2">5B39R53-slot7</data>
-      <data key="d3">lbnl-w3.fabric-testbed.net-slot7</data>
-      <data key="d4">SharedNIC</data>
-      <data key="d5">ConnectX-6</data>
-      <data key="d6">{"unit": 127}</data>
-      <data key="d11">{"bdf": ["0000:e2:1f.6", "0000:e2:17.1", "0000:e2:1b.5", "0000:e2:1d.3", "0000:e2:1f.2", "0000:e2:1b.3", "0000:e2:1a.4", "0000:e2:1d.1", "0000:e2:1c.7", "0000:e2:18.4", "0000:e2:19.1", "0000:e2:1c.0", "0000:e2:17.7", "0000:e2:18.1", "0000:e2:13.6", "0000:e2:17.2", "0000:e2:11.1", "0000:e2:13.0", "0000:e2:10.5", "0000:e2:14.2", "0000:e2:16.1", "0000:e2:10.1", "0000:e2:10.4", "0000:e2:1d.6", "0000:e2:19.4", "0000:e2:1f.0", "0000:e2:12.4", "0000:e2:1c.4", "0000:e2:17.6", "0000:e2:15.7", "0000:e2:13.4", "0000:e2:17.5", "0000:e2:15.6", "0000:e2:14.7", "0000:e2:10.3", "0000:e2:1f.7", "0000:e2:1d.0", "0000:e2:1e.3", "0000:e2:18.7", "0000:e2:1d.2", "0000:e2:16.5", "0000:e2:1b.2", "0000:e2:1f.3", "0000:e2:12.6", "0000:e2:1a.7", "0000:e2:17.4", "0000:e2:10.6", "0000:e2:13.3", "0000:e2:14.6", "0000:e2:12.7", "0000:e2:12.5", "0000:e2:15.2", "0000:e2:1e.0", "0000:e2:12.2", "0000:e2:11.7", "0000:e2:15.5", "0000:e2:18.5", "0000:e2:1b.0", "0000:e2:19.5", "0000:e2:16.7", "0000:e2:1a.0", "0000:e2:1b.4", "0000:e2:16.6", "0000:e2:16.4", "0000:e2:19.3", "0000:e2:16.0", "0000:e2:1e.7", "0000:e2:19.2", "0000:e2:1b.7", "0000:e2:15.0", "0000:e2:1a.1", "0000:e2:1f.1", "0000:e2:1e.6", "0000:e2:18.3", "0000:e2:14.3", "0000:e2:11.2", "0000:e2:1d.5", "0000:e2:16.3", "0000:e2:1d.7", "0000:e2:1e.2", "0000:e2:1a.3", "0000:e2:13.5", "0000:e2:1c.2", "0000:e2:1a.2", "0000:e2:14.1", "0000:e2:11.3", "0000:e2:14.5", "0000:e2:11.4", "0000:e2:1f.5", "0000:e2:11.5", "0000:e2:1e.5", "0000:e2:1c.5", "0000:e2:1e.1", "0000:e2:15.4", "0000:e2:12.3", "0000:e2:15.3", "0000:e2:13.1", "0000:e2:1a.6", "0000:e2:19.0", "0000:e2:1e.4", "0000:e2:15.1", "0000:e2:16.2", "0000:e2:19.6", "0000:e2:18.0", "0000:e2:1c.6", "0000:e2:18.2", "0000:e2:11.0", "0000:e2:1f.4", "0000:e2:14.4", "0000:e2:13.2", "0000:e2:14.0", "0000:e2:17.0", "0000:e2:10.2", "0000:e2:1b.6", "0000:e2:1c.1", "0000:e2:1a.5", "0000:e2:19.7", "0000:e2:1d.4", "0000:e2:12.1", "0000:e2:11.6", "0000:e2:1c.3", "0000:e2:17.3", "0000:e2:13.7", "0000:e2:12.0", "0000:e2:18.6", "0000:e2:1b.1", "0000:e2:10.7"]}</data>
-      <data key="d12">Mellanox Technologies MT28908 Family [ConnectX-6] in PCIe Slot 7 (0000:e2:00.1)</data>
-      <data key="d7">false</data>
-      <data key="d10">{"primary": {"pool_id": "_", "capacities": {"unit": 127}}}</data>
-      <data key="d13">{"primary": {"pool_id": "_", "labels": {"bdf": ["0000:e2:1f.6", "0000:e2:17.1", "0000:e2:1b.5", "0000:e2:1d.3", "0000:e2:1f.2", "0000:e2:1b.3", "0000:e2:1a.4", "0000:e2:1d.1", "0000:e2:1c.7", "0000:e2:18.4", "0000:e2:19.1", "0000:e2:1c.0", "0000:e2:17.7", "0000:e2:18.1", "0000:e2:13.6", "0000:e2:17.2", "0000:e2:11.1", "0000:e2:13.0", "0000:e2:10.5", "0000:e2:14.2", "0000:e2:16.1", "0000:e2:10.1", "0000:e2:10.4", "0000:e2:1d.6", "0000:e2:19.4", "0000:e2:1f.0", "0000:e2:12.4", "0000:e2:1c.4", "0000:e2:17.6", "0000:e2:15.7", "0000:e2:13.4", "0000:e2:17.5", "0000:e2:15.6", "0000:e2:14.7", "0000:e2:10.3", "0000:e2:1f.7", "0000:e2:1d.0", "0000:e2:1e.3", "0000:e2:18.7", "0000:e2:1d.2", "0000:e2:16.5", "0000:e2:1b.2", "0000:e2:1f.3", "0000:e2:12.6", "0000:e2:1a.7", "0000:e2:17.4", "0000:e2:10.6", "0000:e2:13.3", "0000:e2:14.6", "0000:e2:12.7", "0000:e2:12.5", "0000:e2:15.2", "0000:e2:1e.0", "0000:e2:12.2", "0000:e2:11.7", "0000:e2:15.5", "0000:e2:18.5", "0000:e2:1b.0", "0000:e2:19.5", "0000:e2:16.7", "0000:e2:1a.0", "0000:e2:1b.4", "0000:e2:16.6", "0000:e2:16.4", "0000:e2:19.3", "0000:e2:16.0", "0000:e2:1e.7", "0000:e2:19.2", "0000:e2:1b.7", "0000:e2:15.0", "0000:e2:1a.1", "0000:e2:1f.1", "0000:e2:1e.6", "0000:e2:18.3", "0000:e2:14.3", "0000:e2:11.2", "0000:e2:1d.5", "0000:e2:16.3", "0000:e2:1d.7", "0000:e2:1e.2", "0000:e2:1a.3", "0000:e2:13.5", "0000:e2:1c.2", "0000:e2:1a.2", "0000:e2:14.1", "0000:e2:11.3", "0000:e2:14.5", "0000:e2:11.4", "0000:e2:1f.5", "0000:e2:11.5", "0000:e2:1e.5", "0000:e2:1c.5", "0000:e2:1e.1", "0000:e2:15.4", "0000:e2:12.3", "0000:e2:15.3", "0000:e2:13.1", "0000:e2:1a.6", "0000:e2:19.0", "0000:e2:1e.4", "0000:e2:15.1", "0000:e2:16.2", "0000:e2:19.6", "0000:e2:18.0", "0000:e2:1c.6", "0000:e2:18.2", "0000:e2:11.0", "0000:e2:1f.4", "0000:e2:14.4", "0000:e2:13.2", "0000:e2:14.0", "0000:e2:17.0", "0000:e2:10.2", "0000:e2:1b.6", "0000:e2:1c.1", "0000:e2:1a.5", "0000:e2:19.7", "0000:e2:1d.4", "0000:e2:12.1", "0000:e2:11.6", "0000:e2:1c.3", "0000:e2:17.3", "0000:e2:13.7", "0000:e2:12.0", "0000:e2:18.6", "0000:e2:1b.1", "0000:e2:10.7"]}}}</data>
-    </node>
-    <node id="35">
-      <data key="d0">307a43ea-2e59-42c6-8581-71e2a37300f6</data>
-      <data key="d1">NetworkService</data>
-      <data key="d2">5B39R53-slot7-ns</data>
-      <data key="d3">lbnl-w3.fabric-testbed.net-lbnl-w3.fabric-testbed.net-slot7-l2ovs</data>
-      <data key="d4">OVS</data>
-      <data key="d7">false</data>
-      <data key="d14">L2</data>
-    </node>
-    <node id="36">
-      <data key="d0">307a43ea-2e59-42c6-8581-71e2a37300f6</data>
-      <data key="d1">ConnectionPoint</data>
-      <data key="d2">node_id-04-3F-72-B7-15-7D</data>
-      <data key="d3">lbnl-w3.fabric-testbed.net-slot7-p1</data>
-      <data key="d4">SharedPort</data>
-      <data key="d6">{"unit": 127}</data>
-      <data key="d11">{"bdf": ["0000:e2:1f.6", "0000:e2:17.1", "0000:e2:1b.5", "0000:e2:1d.3", "0000:e2:1f.2", "0000:e2:1b.3", "0000:e2:1a.4", "0000:e2:1d.1", "0000:e2:1c.7", "0000:e2:18.4", "0000:e2:19.1", "0000:e2:1c.0", "0000:e2:17.7", "0000:e2:18.1", "0000:e2:13.6", "0000:e2:17.2", "0000:e2:11.1", "0000:e2:13.0", "0000:e2:10.5", "0000:e2:14.2", "0000:e2:16.1", "0000:e2:10.1", "0000:e2:10.4", "0000:e2:1d.6", "0000:e2:19.4", "0000:e2:1f.0", "0000:e2:12.4", "0000:e2:1c.4", "0000:e2:17.6", "0000:e2:15.7", "0000:e2:13.4", "0000:e2:17.5", "0000:e2:15.6", "0000:e2:14.7", "0000:e2:10.3", "0000:e2:1f.7", "0000:e2:1d.0", "0000:e2:1e.3", "0000:e2:18.7", "0000:e2:1d.2", "0000:e2:16.5", "0000:e2:1b.2", "0000:e2:1f.3", "0000:e2:12.6", "0000:e2:1a.7", "0000:e2:17.4", "0000:e2:10.6", "0000:e2:13.3", "0000:e2:14.6", "0000:e2:12.7", "0000:e2:12.5", "0000:e2:15.2", "0000:e2:1e.0", "0000:e2:12.2", "0000:e2:11.7", "0000:e2:15.5", "0000:e2:18.5", "0000:e2:1b.0", "0000:e2:19.5", "0000:e2:16.7", "0000:e2:1a.0", "0000:e2:1b.4", "0000:e2:16.6", "0000:e2:16.4", "0000:e2:19.3", "0000:e2:16.0", "0000:e2:1e.7", "0000:e2:19.2", "0000:e2:1b.7", "0000:e2:15.0", "0000:e2:1a.1", "0000:e2:1f.1", "0000:e2:1e.6", "0000:e2:18.3", "0000:e2:14.3", "0000:e2:11.2", "0000:e2:1d.5", "0000:e2:16.3", "0000:e2:1d.7", "0000:e2:1e.2", "0000:e2:1a.3", "0000:e2:13.5", "0000:e2:1c.2", "0000:e2:1a.2", "0000:e2:14.1", "0000:e2:11.3", "0000:e2:14.5", "0000:e2:11.4", "0000:e2:1f.5", "0000:e2:11.5", "0000:e2:1e.5", "0000:e2:1c.5", "0000:e2:1e.1", "0000:e2:15.4", "0000:e2:12.3", "0000:e2:15.3", "0000:e2:13.1", "0000:e2:1a.6", "0000:e2:19.0", "0000:e2:1e.4", "0000:e2:15.1", "0000:e2:16.2", "0000:e2:19.6", "0000:e2:18.0", "0000:e2:1c.6", "0000:e2:18.2", "0000:e2:11.0", "0000:e2:1f.4", "0000:e2:14.4", "0000:e2:13.2", "0000:e2:14.0", "0000:e2:17.0", "0000:e2:10.2", "0000:e2:1b.6", "0000:e2:1c.1", "0000:e2:1a.5", "0000:e2:19.7", "0000:e2:1d.4", "0000:e2:12.1", "0000:e2:11.6", "0000:e2:1c.3", "0000:e2:17.3", "0000:e2:13.7", "0000:e2:12.0", "0000:e2:18.6", "0000:e2:1b.1", "0000:e2:10.7"], "local_name": ["p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1"], "mac": ["02:15:25:A2:6B:52", "02:6F:CC:3F:D1:5F", "06:39:95:C0:84:24", "06:96:5A:CB:F4:F6", "06:BA:AD:DC:9A:CC", "0A:2A:5D:0F:93:A4", "0A:D2:88:61:5D:47", "0E:5E:E8:EA:F9:9E", "0E:B1:DC:72:14:39", "12:57:AB:62:60:9E", "12:E0:F2:63:B2:8B", "16:52:DC:1C:59:54", "16:B1:C4:59:6C:6D", "16:BF:14:64:50:5F", "1A:57:1B:C2:59:25", "1A:FE:76:8D:F2:4A", "1E:35:99:A7:CA:B2", "26:61:67:D6:29:7E", "2A:63:31:6E:EC:42", "32:CC:6D:72:07:4D", "36:71:BA:C6:27:8E", "3A:25:E6:4C:84:2F", "3E:88:C5:EA:72:E2", "42:8B:45:F5:F9:E3", "42:F6:E5:93:E8:50", "46:06:31:AD:1F:04", "46:0C:3C:D6:D5:3F", "46:40:FB:1F:80:74", "46:50:5B:93:5F:36", "46:92:76:AC:7E:01", "4A:F2:8B:0B:A8:88", "4E:73:D1:A6:89:46", "52:6D:C2:9F:88:ED", "52:97:24:4F:C8:C3", "52:AE:58:7B:AB:14", "52:CD:3A:48:E2:17", "52:FC:AE:E5:72:2E", "56:00:EB:95:3F:0A", "5A:0B:D1:54:73:98", "5E:4E:A8:7B:2E:4B", "62:64:D3:00:7E:E4", "62:6E:AD:C6:46:F8", "62:E0:8C:19:A1:F9", "66:0A:1A:FC:CB:02", "66:59:65:CA:43:AA", "66:65:67:24:60:E7", "66:C4:5D:2F:07:54", "66:E3:B0:C8:A9:1E", "6A:54:67:AC:43:06", "6A:D3:5A:2F:12:65", "6E:00:63:3F:8D:75", "72:AF:3D:51:9F:ED", "72:C3:19:98:74:93", "76:5A:A5:C2:1A:B9", "76:D3:E0:A7:84:D7", "7A:A6:99:83:C0:B3", "7E:0D:18:B4:AA:2A", "82:BD:5F:36:95:48", "82:FB:D3:7D:32:81", "86:96:05:D1:C0:E3", "86:EF:D7:DA:F3:7C", "86:F9:D3:32:6C:88", "8E:39:EA:87:B5:81", "92:75:4F:01:78:53", "92:88:C6:43:54:54", "92:E4:D7:69:54:5A", "96:20:33:14:18:BA", "96:37:2B:5C:80:71", "96:98:0A:1C:88:36", "9A:9D:95:AB:0C:3F", "9A:B5:BA:2E:AD:07", "9E:2E:6B:8A:FA:D3", "9E:BD:3B:67:ED:0D", "9E:F0:9D:F0:0F:C4", "9E:F6:36:D9:C7:A4", "9E:FF:94:B7:4E:EC", "A2:12:12:C1:1A:39", "A2:13:D9:E7:EF:C4", "A2:36:B7:44:53:AB", "A2:38:5A:90:6B:10", "A6:00:23:C0:59:9F", "A6:0F:8D:93:7E:AC", "A6:19:22:D6:49:DF", "A6:34:DD:72:B8:B5", "A6:41:B9:72:FE:05", "A6:72:FA:5A:0C:F2", "A6:AD:FF:D0:67:99", "A6:AF:CC:69:30:44", "AA:67:C8:38:58:07", "AE:67:94:63:9A:FF", "B6:98:F2:AE:02:07", "B6:A6:D2:AF:3B:B4", "BA:3B:8C:65:3B:29", "BE:99:D7:96:96:AE", "BE:DC:4F:83:D2:62", "C2:05:FB:82:30:E0", "C2:1D:72:34:6D:A0", "C2:47:F5:01:3D:A3", "C2:69:63:F1:05:00", "C6:8B:F7:0F:D7:3E", "CA:15:50:FE:CE:22", "CA:24:E0:0B:AA:3F", "CA:26:D6:52:42:F2", "CA:8F:DE:FD:D3:82", "CA:A1:83:16:49:2E", "CE:5A:BE:6B:D6:5F", "D2:AB:2A:D2:F6:DF", "D2:DE:56:37:F6:20", "D6:13:98:C2:C8:88", "DA:51:75:71:1F:55", "DE:93:92:54:6C:0C", "E2:31:43:22:45:B9", "E2:CF:60:0F:A1:04", "E2:F6:8A:70:1C:6C", "E2:FB:28:0B:D7:52", "EA:5F:7B:F0:2A:22", "EA:FD:10:B1:3A:63", "EE:90:B3:4E:83:35", "EE:A5:98:4F:A7:5A", "F2:54:52:50:62:22", "F2:BC:38:72:A1:D1", "F2:DA:2A:31:A1:53", "F2:DA:E6:63:C5:8F", "F6:4C:30:17:00:2B", "FA:B0:DD:AE:EC:DF", "FA:CB:74:4B:0A:60", "FE:0C:E8:FA:9E:E0"], "vlan": ["2125", "2056", "2092", "2106", "2121", "2090", "2083", "2104", "2102", "2067", "2072", "2095", "2062", "2064", "2029", "2057", "2008", "2023", "2004", "2033", "2048", "2000", "2003", "2109", "2075", "2119", "2019", "2099", "2061", "2046", "2027", "2060", "2045", "2038", "2002", "2126", "2103", "2114", "2070", "2105", "2052", "2089", "2122", "2021", "2086", "2059", "2005", "2026", "2037", "2022", "2020", "2041", "2111", "2017", "2014", "2044", "2068", "2087", "2076", "2054", "2079", "2091", "2053", "2051", "2074", "2047", "2118", "2073", "2094", "2039", "2080", "2120", "2117", "2066", "2034", "2009", "2108", "2050", "2110", "2113", "2082", "2028", "2097", "2081", "2032", "2010", "2036", "2011", "2124", "2012", "2116", "2100", "2112", "2043", "2018", "2042", "2024", "2085", "2071", "2115", "2040", "2049", "2077", "2063", "2101", "2065", "2007", "2123", "2035", "2025", "2031", "2055", "2001", "2093", "2096", "2084", "2078", "2107", "2016", "2013", "2098", "2058", "2030", "2015", "2069", "2088", "2006"]}</data>
-      <data key="d7">false</data>
-      <data key="d10">{"primary": {"pool_id": "_", "capacities": {"unit": 127}}}</data>
-      <data key="d13">{"primary": {"pool_id": "_", "labels": {"bdf": ["0000:e2:1f.6", "0000:e2:17.1", "0000:e2:1b.5", "0000:e2:1d.3", "0000:e2:1f.2", "0000:e2:1b.3", "0000:e2:1a.4", "0000:e2:1d.1", "0000:e2:1c.7", "0000:e2:18.4", "0000:e2:19.1", "0000:e2:1c.0", "0000:e2:17.7", "0000:e2:18.1", "0000:e2:13.6", "0000:e2:17.2", "0000:e2:11.1", "0000:e2:13.0", "0000:e2:10.5", "0000:e2:14.2", "0000:e2:16.1", "0000:e2:10.1", "0000:e2:10.4", "0000:e2:1d.6", "0000:e2:19.4", "0000:e2:1f.0", "0000:e2:12.4", "0000:e2:1c.4", "0000:e2:17.6", "0000:e2:15.7", "0000:e2:13.4", "0000:e2:17.5", "0000:e2:15.6", "0000:e2:14.7", "0000:e2:10.3", "0000:e2:1f.7", "0000:e2:1d.0", "0000:e2:1e.3", "0000:e2:18.7", "0000:e2:1d.2", "0000:e2:16.5", "0000:e2:1b.2", "0000:e2:1f.3", "0000:e2:12.6", "0000:e2:1a.7", "0000:e2:17.4", "0000:e2:10.6", "0000:e2:13.3", "0000:e2:14.6", "0000:e2:12.7", "0000:e2:12.5", "0000:e2:15.2", "0000:e2:1e.0", "0000:e2:12.2", "0000:e2:11.7", "0000:e2:15.5", "0000:e2:18.5", "0000:e2:1b.0", "0000:e2:19.5", "0000:e2:16.7", "0000:e2:1a.0", "0000:e2:1b.4", "0000:e2:16.6", "0000:e2:16.4", "0000:e2:19.3", "0000:e2:16.0", "0000:e2:1e.7", "0000:e2:19.2", "0000:e2:1b.7", "0000:e2:15.0", "0000:e2:1a.1", "0000:e2:1f.1", "0000:e2:1e.6", "0000:e2:18.3", "0000:e2:14.3", "0000:e2:11.2", "0000:e2:1d.5", "0000:e2:16.3", "0000:e2:1d.7", "0000:e2:1e.2", "0000:e2:1a.3", "0000:e2:13.5", "0000:e2:1c.2", "0000:e2:1a.2", "0000:e2:14.1", "0000:e2:11.3", "0000:e2:14.5", "0000:e2:11.4", "0000:e2:1f.5", "0000:e2:11.5", "0000:e2:1e.5", "0000:e2:1c.5", "0000:e2:1e.1", "0000:e2:15.4", "0000:e2:12.3", "0000:e2:15.3", "0000:e2:13.1", "0000:e2:1a.6", "0000:e2:19.0", "0000:e2:1e.4", "0000:e2:15.1", "0000:e2:16.2", "0000:e2:19.6", "0000:e2:18.0", "0000:e2:1c.6", "0000:e2:18.2", "0000:e2:11.0", "0000:e2:1f.4", "0000:e2:14.4", "0000:e2:13.2", "0000:e2:14.0", "0000:e2:17.0", "0000:e2:10.2", "0000:e2:1b.6", "0000:e2:1c.1", "0000:e2:1a.5", "0000:e2:19.7", "0000:e2:1d.4", "0000:e2:12.1", "0000:e2:11.6", "0000:e2:1c.3", "0000:e2:17.3", "0000:e2:13.7", "0000:e2:12.0", "0000:e2:18.6", "0000:e2:1b.1", "0000:e2:10.7"], "mac": ["02:15:25:A2:6B:52", "02:6F:CC:3F:D1:5F", "06:39:95:C0:84:24", "06:96:5A:CB:F4:F6", "06:BA:AD:DC:9A:CC", "0A:2A:5D:0F:93:A4", "0A:D2:88:61:5D:47", "0E:5E:E8:EA:F9:9E", "0E:B1:DC:72:14:39", "12:57:AB:62:60:9E", "12:E0:F2:63:B2:8B", "16:52:DC:1C:59:54", "16:B1:C4:59:6C:6D", "16:BF:14:64:50:5F", "1A:57:1B:C2:59:25", "1A:FE:76:8D:F2:4A", "1E:35:99:A7:CA:B2", "26:61:67:D6:29:7E", "2A:63:31:6E:EC:42", "32:CC:6D:72:07:4D", "36:71:BA:C6:27:8E", "3A:25:E6:4C:84:2F", "3E:88:C5:EA:72:E2", "42:8B:45:F5:F9:E3", "42:F6:E5:93:E8:50", "46:06:31:AD:1F:04", "46:0C:3C:D6:D5:3F", "46:40:FB:1F:80:74", "46:50:5B:93:5F:36", "46:92:76:AC:7E:01", "4A:F2:8B:0B:A8:88", "4E:73:D1:A6:89:46", "52:6D:C2:9F:88:ED", "52:97:24:4F:C8:C3", "52:AE:58:7B:AB:14", "52:CD:3A:48:E2:17", "52:FC:AE:E5:72:2E", "56:00:EB:95:3F:0A", "5A:0B:D1:54:73:98", "5E:4E:A8:7B:2E:4B", "62:64:D3:00:7E:E4", "62:6E:AD:C6:46:F8", "62:E0:8C:19:A1:F9", "66:0A:1A:FC:CB:02", "66:59:65:CA:43:AA", "66:65:67:24:60:E7", "66:C4:5D:2F:07:54", "66:E3:B0:C8:A9:1E", "6A:54:67:AC:43:06", "6A:D3:5A:2F:12:65", "6E:00:63:3F:8D:75", "72:AF:3D:51:9F:ED", "72:C3:19:98:74:93", "76:5A:A5:C2:1A:B9", "76:D3:E0:A7:84:D7", "7A:A6:99:83:C0:B3", "7E:0D:18:B4:AA:2A", "82:BD:5F:36:95:48", "82:FB:D3:7D:32:81", "86:96:05:D1:C0:E3", "86:EF:D7:DA:F3:7C", "86:F9:D3:32:6C:88", "8E:39:EA:87:B5:81", "92:75:4F:01:78:53", "92:88:C6:43:54:54", "92:E4:D7:69:54:5A", "96:20:33:14:18:BA", "96:37:2B:5C:80:71", "96:98:0A:1C:88:36", "9A:9D:95:AB:0C:3F", "9A:B5:BA:2E:AD:07", "9E:2E:6B:8A:FA:D3", "9E:BD:3B:67:ED:0D", "9E:F0:9D:F0:0F:C4", "9E:F6:36:D9:C7:A4", "9E:FF:94:B7:4E:EC", "A2:12:12:C1:1A:39", "A2:13:D9:E7:EF:C4", "A2:36:B7:44:53:AB", "A2:38:5A:90:6B:10", "A6:00:23:C0:59:9F", "A6:0F:8D:93:7E:AC", "A6:19:22:D6:49:DF", "A6:34:DD:72:B8:B5", "A6:41:B9:72:FE:05", "A6:72:FA:5A:0C:F2", "A6:AD:FF:D0:67:99", "A6:AF:CC:69:30:44", "AA:67:C8:38:58:07", "AE:67:94:63:9A:FF", "B6:98:F2:AE:02:07", "B6:A6:D2:AF:3B:B4", "BA:3B:8C:65:3B:29", "BE:99:D7:96:96:AE", "BE:DC:4F:83:D2:62", "C2:05:FB:82:30:E0", "C2:1D:72:34:6D:A0", "C2:47:F5:01:3D:A3", "C2:69:63:F1:05:00", "C6:8B:F7:0F:D7:3E", "CA:15:50:FE:CE:22", "CA:24:E0:0B:AA:3F", "CA:26:D6:52:42:F2", "CA:8F:DE:FD:D3:82", "CA:A1:83:16:49:2E", "CE:5A:BE:6B:D6:5F", "D2:AB:2A:D2:F6:DF", "D2:DE:56:37:F6:20", "D6:13:98:C2:C8:88", "DA:51:75:71:1F:55", "DE:93:92:54:6C:0C", "E2:31:43:22:45:B9", "E2:CF:60:0F:A1:04", "E2:F6:8A:70:1C:6C", "E2:FB:28:0B:D7:52", "EA:5F:7B:F0:2A:22", "EA:FD:10:B1:3A:63", "EE:90:B3:4E:83:35", "EE:A5:98:4F:A7:5A", "F2:54:52:50:62:22", "F2:BC:38:72:A1:D1", "F2:DA:2A:31:A1:53", "F2:DA:E6:63:C5:8F", "F6:4C:30:17:00:2B", "FA:B0:DD:AE:EC:DF", "FA:CB:74:4B:0A:60", "FE:0C:E8:FA:9E:E0"], "vlan": ["2125", "2056", "2092", "2106", "2121", "2090", "2083", "2104", "2102", "2067", "2072", "2095", "2062", "2064", "2029", "2057", "2008", "2023", "2004", "2033", "2048", "2000", "2003", "2109", "2075", "2119", "2019", "2099", "2061", "2046", "2027", "2060", "2045", "2038", "2002", "2126", "2103", "2114", "2070", "2105", "2052", "2089", "2122", "2021", "2086", "2059", "2005", "2026", "2037", "2022", "2020", "2041", "2111", "2017", "2014", "2044", "2068", "2087", "2076", "2054", "2079", "2091", "2053", "2051", "2074", "2047", "2118", "2073", "2094", "2039", "2080", "2120", "2117", "2066", "2034", "2009", "2108", "2050", "2110", "2113", "2082", "2028", "2097", "2081", "2032", "2010", "2036", "2011", "2124", "2012", "2116", "2100", "2112", "2043", "2018", "2042", "2024", "2085", "2071", "2115", "2040", "2049", "2077", "2063", "2101", "2065", "2007", "2123", "2035", "2025", "2031", "2055", "2001", "2093", "2096", "2084", "2078", "2107", "2016", "2013", "2098", "2058", "2030", "2015", "2069", "2088", "2006"], "local_name": ["p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1"]}}}</data>
-    </node>
-    <node id="37">
-      <data key="d0">307a43ea-2e59-42c6-8581-71e2a37300f6</data>
-      <data key="d1">Component</data>
-      <data key="d2">5B39R53-slot6</data>
-      <data key="d3">lbnl-w3.fabric-testbed.net-slot6</data>
-      <data key="d4">SmartNIC</data>
-      <data key="d5">ConnectX-5</data>
-      <data key="d6">{"unit": 1}</data>
-      <data key="d11">{"bdf": ["0000:a1:00.0", "0000:a1:00.1"]}</data>
-      <data key="d12">Mellanox Technologies MT27800 Family [ConnectX-5] in PCIe Slot 6 (0000:a1:00.0)</data>
-      <data key="d7">false</data>
-      <data key="d10">{"primary": {"pool_id": "_", "capacities": {"unit": 1}}}</data>
-      <data key="d13">{"primary": {"pool_id": "_", "labels": {"bdf": ["0000:a1:00.0", "0000:a1:00.1"]}}}</data>
-    </node>
-    <node id="38">
-      <data key="d0">307a43ea-2e59-42c6-8581-71e2a37300f6</data>
-      <data key="d1">NetworkService</data>
-      <data key="d2">5B39R53-slot6-ns</data>
-      <data key="d3">lbnl-w3.fabric-testbed.net-lbnl-w3.fabric-testbed.net-slot6-l2ovs</data>
-      <data key="d4">OVS</data>
-      <data key="d7">false</data>
-      <data key="d14">L2</data>
-    </node>
-    <node id="39">
-      <data key="d0">307a43ea-2e59-42c6-8581-71e2a37300f6</data>
-      <data key="d1">ConnectionPoint</data>
-      <data key="d2">node_id-0C-42-A1-91-75-0E</data>
-      <data key="d3">lbnl-w3.fabric-testbed.net-slot6-p1</data>
-      <data key="d4">DedicatedPort</data>
-      <data key="d6">{"bw": 25, "unit": 1}</data>
-      <data key="d11">{"local_name": "p1", "mac": "0C:42:A1:91:75:0E", "vlan_range": "1-4096"}</data>
-      <data key="d7">false</data>
-      <data key="d10">{"primary": {"pool_id": "_", "capacities": {"bw": 25, "unit": 1}}}</data>
-      <data key="d13">{"primary": {"pool_id": "_", "labels": {"mac": "0C:42:A1:91:75:0E", "vlan_range": "1-4096", "local_name": "p1"}}}</data>
-    </node>
-    <node id="40">
-      <data key="d0">307a43ea-2e59-42c6-8581-71e2a37300f6</data>
-      <data key="d1">ConnectionPoint</data>
-      <data key="d2">node_id-0C-42-A1-91-75-0F</data>
-      <data key="d3">lbnl-w3.fabric-testbed.net-slot6-p2</data>
-      <data key="d4">DedicatedPort</data>
-      <data key="d6">{"bw": 25, "unit": 1}</data>
-      <data key="d11">{"local_name": "p2", "mac": "0C:42:A1:91:75:0F", "vlan_range": "1-4096"}</data>
-      <data key="d7">false</data>
-      <data key="d10">{"primary": {"pool_id": "_", "capacities": {"bw": 25, "unit": 1}}}</data>
-      <data key="d13">{"primary": {"pool_id": "_", "labels": {"mac": "0C:42:A1:91:75:0F", "vlan_range": "1-4096", "local_name": "p2"}}}</data>
-    </node>
-    <node id="41">
-      <data key="d0">307a43ea-2e59-42c6-8581-71e2a37300f6</data>
-      <data key="d1">Component</data>
-      <data key="d2">5B39R53-slot3</data>
-      <data key="d3">lbnl-w3.fabric-testbed.net-slot3</data>
+      <data key="d2">5B39R53-nic1</data>
+      <data key="d3">lbnl-w3-nic1</data>
       <data key="d4">SmartNIC</data>
       <data key="d5">ConnectX-5</data>
       <data key="d6">{"unit": 1}</data>
       <data key="d11">{"bdf": ["0000:41:00.0", "0000:41:00.1"]}</data>
-      <data key="d12">Mellanox Technologies MT27800 Family [ConnectX-5] in PCIe Slot 3 (0000:41:00.0)</data>
+      <data key="d12">Mellanox Technologies MT27800 Family [ConnectX-5]</data>
       <data key="d7">false</data>
       <data key="d10">{"primary": {"pool_id": "_", "capacities": {"unit": 1}}}</data>
       <data key="d13">{"primary": {"pool_id": "_", "labels": {"bdf": ["0000:41:00.0", "0000:41:00.1"]}}}</data>
     </node>
-    <node id="42">
-      <data key="d0">307a43ea-2e59-42c6-8581-71e2a37300f6</data>
+    <node id="640">
+      <data key="d0">feb611c8-5b09-4132-a69c-be9adf894536</data>
       <data key="d1">NetworkService</data>
-      <data key="d2">5B39R53-slot3-ns</data>
-      <data key="d3">lbnl-w3.fabric-testbed.net-lbnl-w3.fabric-testbed.net-slot3-l2ovs</data>
+      <data key="d2">5B39R53-nic1-sf</data>
+      <data key="d3">lbnl-w3-lbnl-w3-nic1-l2ovs</data>
       <data key="d4">OVS</data>
       <data key="d7">false</data>
       <data key="d14">L2</data>
     </node>
-    <node id="43">
-      <data key="d0">307a43ea-2e59-42c6-8581-71e2a37300f6</data>
+    <node id="641">
+      <data key="d0">feb611c8-5b09-4132-a69c-be9adf894536</data>
       <data key="d1">ConnectionPoint</data>
       <data key="d2">node_id-0C-42-A1-91-75-12</data>
-      <data key="d3">lbnl-w3.fabric-testbed.net-slot3-p1</data>
+      <data key="d3">lbnl-w3-nic1-p1</data>
       <data key="d4">DedicatedPort</data>
       <data key="d6">{"bw": 25, "unit": 1}</data>
       <data key="d11">{"local_name": "p1", "mac": "0C:42:A1:91:75:12", "vlan_range": "1-4096"}</data>
@@ -560,11 +513,11 @@
       <data key="d10">{"primary": {"pool_id": "_", "capacities": {"bw": 25, "unit": 1}}}</data>
       <data key="d13">{"primary": {"pool_id": "_", "labels": {"mac": "0C:42:A1:91:75:12", "vlan_range": "1-4096", "local_name": "p1"}}}</data>
     </node>
-    <node id="44">
-      <data key="d0">307a43ea-2e59-42c6-8581-71e2a37300f6</data>
+    <node id="642">
+      <data key="d0">feb611c8-5b09-4132-a69c-be9adf894536</data>
       <data key="d1">ConnectionPoint</data>
       <data key="d2">node_id-0C-42-A1-91-75-13</data>
-      <data key="d3">lbnl-w3.fabric-testbed.net-slot3-p2</data>
+      <data key="d3">lbnl-w3-nic1-p2</data>
       <data key="d4">DedicatedPort</data>
       <data key="d6">{"bw": 25, "unit": 1}</data>
       <data key="d11">{"local_name": "p2", "mac": "0C:42:A1:91:75:13", "vlan_range": "1-4096"}</data>
@@ -572,20 +525,67 @@
       <data key="d10">{"primary": {"pool_id": "_", "capacities": {"bw": 25, "unit": 1}}}</data>
       <data key="d13">{"primary": {"pool_id": "_", "labels": {"mac": "0C:42:A1:91:75:13", "vlan_range": "1-4096", "local_name": "p2"}}}</data>
     </node>
-    <node id="45">
-      <data key="d0">307a43ea-2e59-42c6-8581-71e2a37300f6</data>
+    <node id="643">
+      <data key="d0">feb611c8-5b09-4132-a69c-be9adf894536</data>
+      <data key="d1">Component</data>
+      <data key="d2">5B39R53-nic2</data>
+      <data key="d3">lbnl-w3-nic2</data>
+      <data key="d4">SmartNIC</data>
+      <data key="d5">ConnectX-5</data>
+      <data key="d6">{"unit": 1}</data>
+      <data key="d11">{"bdf": ["0000:a1:00.0", "0000:a1:00.1"]}</data>
+      <data key="d12">Mellanox Technologies MT27800 Family [ConnectX-5]</data>
+      <data key="d7">false</data>
+      <data key="d10">{"primary": {"pool_id": "_", "capacities": {"unit": 1}}}</data>
+      <data key="d13">{"primary": {"pool_id": "_", "labels": {"bdf": ["0000:a1:00.0", "0000:a1:00.1"]}}}</data>
+    </node>
+    <node id="644">
+      <data key="d0">feb611c8-5b09-4132-a69c-be9adf894536</data>
+      <data key="d1">NetworkService</data>
+      <data key="d2">5B39R53-nic2-sf</data>
+      <data key="d3">lbnl-w3-lbnl-w3-nic2-l2ovs</data>
+      <data key="d4">OVS</data>
+      <data key="d7">false</data>
+      <data key="d14">L2</data>
+    </node>
+    <node id="645">
+      <data key="d0">feb611c8-5b09-4132-a69c-be9adf894536</data>
+      <data key="d1">ConnectionPoint</data>
+      <data key="d2">node_id-0C-42-A1-91-75-0E</data>
+      <data key="d3">lbnl-w3-nic2-p1</data>
+      <data key="d4">DedicatedPort</data>
+      <data key="d6">{"bw": 25, "unit": 1}</data>
+      <data key="d11">{"local_name": "p1", "mac": "0C:42:A1:91:75:0E", "vlan_range": "1-4096"}</data>
+      <data key="d7">false</data>
+      <data key="d10">{"primary": {"pool_id": "_", "capacities": {"bw": 25, "unit": 1}}}</data>
+      <data key="d13">{"primary": {"pool_id": "_", "labels": {"mac": "0C:42:A1:91:75:0E", "vlan_range": "1-4096", "local_name": "p1"}}}</data>
+    </node>
+    <node id="646">
+      <data key="d0">feb611c8-5b09-4132-a69c-be9adf894536</data>
+      <data key="d1">ConnectionPoint</data>
+      <data key="d2">node_id-0C-42-A1-91-75-0F</data>
+      <data key="d3">lbnl-w3-nic2-p2</data>
+      <data key="d4">DedicatedPort</data>
+      <data key="d6">{"bw": 25, "unit": 1}</data>
+      <data key="d11">{"local_name": "p2", "mac": "0C:42:A1:91:75:0F", "vlan_range": "1-4096"}</data>
+      <data key="d7">false</data>
+      <data key="d10">{"primary": {"pool_id": "_", "capacities": {"bw": 25, "unit": 1}}}</data>
+      <data key="d13">{"primary": {"pool_id": "_", "labels": {"mac": "0C:42:A1:91:75:0F", "vlan_range": "1-4096", "local_name": "p2"}}}</data>
+    </node>
+    <node id="647">
+      <data key="d0">feb611c8-5b09-4132-a69c-be9adf894536</data>
       <data key="d1">NetworkNode</data>
       <data key="d2">3DB2R53</data>
-      <data key="d3">lbnl-storage.fabric-testbed.net</data>
+      <data key="d3">nas</data>
       <data key="d4">NAS</data>
       <data key="d5">ME4084</data>
-      <data key="d6">{"disk": 336000, "unit": 1}</data>
+      <data key="d6">{"disk": 100000, "unit": 1}</data>
       <data key="d7">false</data>
       <data key="d8">LBNL</data>
-      <data key="d10">{"primary": {"pool_id": "_", "capacities": {"disk": 336000, "unit": 1}}}</data>
+      <data key="d10">{"primary": {"pool_id": "_", "capacities": {"disk": 100000, "unit": 1}}}</data>
     </node>
-    <node id="46">
-      <data key="d0">307a43ea-2e59-42c6-8581-71e2a37300f6</data>
+    <node id="648">
+      <data key="d0">feb611c8-5b09-4132-a69c-be9adf894536</data>
       <data key="d1">NetworkNode</data>
       <data key="d2">node+lbnl-data-sw:ip+192.168.13.3</data>
       <data key="d3">lbnl-data-sw</data>
@@ -593,8 +593,8 @@
       <data key="d7">true</data>
       <data key="d8">LBNL</data>
     </node>
-    <node id="47">
-      <data key="d0">307a43ea-2e59-42c6-8581-71e2a37300f6</data>
+    <node id="649">
+      <data key="d0">feb611c8-5b09-4132-a69c-be9adf894536</data>
       <data key="d1">NetworkService</data>
       <data key="d2">node+lbnl-data-sw:ip+192.168.13.3-ns</data>
       <data key="d3">lbnl-data-sw-ns</data>
@@ -602,16 +602,16 @@
       <data key="d7">true</data>
       <data key="d14">L2</data>
     </node>
-    <node id="48">
-      <data key="d0">307a43ea-2e59-42c6-8581-71e2a37300f6</data>
+    <node id="650">
+      <data key="d0">feb611c8-5b09-4132-a69c-be9adf894536</data>
       <data key="d1">ConnectionPoint</data>
       <data key="d2">port+lbnl-data-sw:HundredGigE0/0/0/5</data>
       <data key="d3">HundredGigE0/0/0/5</data>
       <data key="d4">TrunkPort</data>
       <data key="d7">true</data>
     </node>
-    <node id="49">
-      <data key="d0">307a43ea-2e59-42c6-8581-71e2a37300f6</data>
+    <node id="651">
+      <data key="d0">feb611c8-5b09-4132-a69c-be9adf894536</data>
       <data key="d1">Link</data>
       <data key="d2">port+lbnl-data-sw:HundredGigE0/0/0/5-DAC</data>
       <data key="d3">l1</data>
@@ -619,101 +619,101 @@
       <data key="d7">false</data>
       <data key="d14">L2</data>
     </node>
-    <node id="50">
-      <data key="d0">307a43ea-2e59-42c6-8581-71e2a37300f6</data>
-      <data key="d1">ConnectionPoint</data>
-      <data key="d2">port+lbnl-data-sw:HundredGigE0/0/0/9</data>
-      <data key="d3">HundredGigE0/0/0/9</data>
-      <data key="d4">TrunkPort</data>
-      <data key="d7">true</data>
-    </node>
-    <node id="51">
-      <data key="d0">307a43ea-2e59-42c6-8581-71e2a37300f6</data>
-      <data key="d1">Link</data>
-      <data key="d2">port+lbnl-data-sw:HundredGigE0/0/0/9-DAC</data>
-      <data key="d3">l2</data>
-      <data key="d4">Patch</data>
-      <data key="d7">false</data>
-      <data key="d14">L2</data>
-    </node>
-    <node id="52">
-      <data key="d0">307a43ea-2e59-42c6-8581-71e2a37300f6</data>
-      <data key="d1">ConnectionPoint</data>
-      <data key="d2">port+lbnl-data-sw:HundredGigE0/0/0/19</data>
-      <data key="d3">HundredGigE0/0/0/19</data>
-      <data key="d4">TrunkPort</data>
-      <data key="d7">true</data>
-    </node>
-    <node id="53">
-      <data key="d0">307a43ea-2e59-42c6-8581-71e2a37300f6</data>
-      <data key="d1">Link</data>
-      <data key="d2">port+lbnl-data-sw:HundredGigE0/0/0/19-DAC</data>
-      <data key="d3">l3</data>
-      <data key="d4">Patch</data>
-      <data key="d7">false</data>
-      <data key="d14">L2</data>
-    </node>
-    <node id="54">
-      <data key="d0">307a43ea-2e59-42c6-8581-71e2a37300f6</data>
-      <data key="d1">ConnectionPoint</data>
-      <data key="d2">port+lbnl-data-sw:HundredGigE0/0/0/17</data>
-      <data key="d3">HundredGigE0/0/0/17</data>
-      <data key="d4">TrunkPort</data>
-      <data key="d7">true</data>
-    </node>
-    <node id="55">
-      <data key="d0">307a43ea-2e59-42c6-8581-71e2a37300f6</data>
-      <data key="d1">Link</data>
-      <data key="d2">port+lbnl-data-sw:HundredGigE0/0/0/17-DAC</data>
-      <data key="d3">l4</data>
-      <data key="d4">Patch</data>
-      <data key="d7">false</data>
-      <data key="d14">L2</data>
-    </node>
-    <node id="56">
-      <data key="d0">307a43ea-2e59-42c6-8581-71e2a37300f6</data>
-      <data key="d1">ConnectionPoint</data>
-      <data key="d2">port+lbnl-data-sw:HundredGigE0/0/0/15</data>
-      <data key="d3">HundredGigE0/0/0/15</data>
-      <data key="d4">TrunkPort</data>
-      <data key="d7">true</data>
-    </node>
-    <node id="57">
-      <data key="d0">307a43ea-2e59-42c6-8581-71e2a37300f6</data>
-      <data key="d1">Link</data>
-      <data key="d2">port+lbnl-data-sw:HundredGigE0/0/0/15-DAC</data>
-      <data key="d3">l5</data>
-      <data key="d4">Patch</data>
-      <data key="d7">false</data>
-      <data key="d14">L2</data>
-    </node>
-    <node id="58">
-      <data key="d0">307a43ea-2e59-42c6-8581-71e2a37300f6</data>
+    <node id="652">
+      <data key="d0">feb611c8-5b09-4132-a69c-be9adf894536</data>
       <data key="d1">ConnectionPoint</data>
       <data key="d2">port+lbnl-data-sw:HundredGigE0/0/0/13</data>
       <data key="d3">HundredGigE0/0/0/13</data>
       <data key="d4">TrunkPort</data>
       <data key="d7">true</data>
     </node>
-    <node id="59">
-      <data key="d0">307a43ea-2e59-42c6-8581-71e2a37300f6</data>
+    <node id="653">
+      <data key="d0">feb611c8-5b09-4132-a69c-be9adf894536</data>
       <data key="d1">Link</data>
       <data key="d2">port+lbnl-data-sw:HundredGigE0/0/0/13-DAC</data>
+      <data key="d3">l2</data>
+      <data key="d4">Patch</data>
+      <data key="d7">false</data>
+      <data key="d14">L2</data>
+    </node>
+    <node id="654">
+      <data key="d0">feb611c8-5b09-4132-a69c-be9adf894536</data>
+      <data key="d1">ConnectionPoint</data>
+      <data key="d2">port+lbnl-data-sw:HundredGigE0/0/0/15</data>
+      <data key="d3">HundredGigE0/0/0/15</data>
+      <data key="d4">TrunkPort</data>
+      <data key="d7">true</data>
+    </node>
+    <node id="655">
+      <data key="d0">feb611c8-5b09-4132-a69c-be9adf894536</data>
+      <data key="d1">Link</data>
+      <data key="d2">port+lbnl-data-sw:HundredGigE0/0/0/15-DAC</data>
+      <data key="d3">l3</data>
+      <data key="d4">Patch</data>
+      <data key="d7">false</data>
+      <data key="d14">L2</data>
+    </node>
+    <node id="656">
+      <data key="d0">feb611c8-5b09-4132-a69c-be9adf894536</data>
+      <data key="d1">ConnectionPoint</data>
+      <data key="d2">port+lbnl-data-sw:HundredGigE0/0/0/9</data>
+      <data key="d3">HundredGigE0/0/0/9</data>
+      <data key="d4">TrunkPort</data>
+      <data key="d7">true</data>
+    </node>
+    <node id="657">
+      <data key="d0">feb611c8-5b09-4132-a69c-be9adf894536</data>
+      <data key="d1">Link</data>
+      <data key="d2">port+lbnl-data-sw:HundredGigE0/0/0/9-DAC</data>
+      <data key="d3">l4</data>
+      <data key="d4">Patch</data>
+      <data key="d7">false</data>
+      <data key="d14">L2</data>
+    </node>
+    <node id="658">
+      <data key="d0">feb611c8-5b09-4132-a69c-be9adf894536</data>
+      <data key="d1">ConnectionPoint</data>
+      <data key="d2">port+lbnl-data-sw:HundredGigE0/0/0/17</data>
+      <data key="d3">HundredGigE0/0/0/17</data>
+      <data key="d4">TrunkPort</data>
+      <data key="d7">true</data>
+    </node>
+    <node id="659">
+      <data key="d0">feb611c8-5b09-4132-a69c-be9adf894536</data>
+      <data key="d1">Link</data>
+      <data key="d2">port+lbnl-data-sw:HundredGigE0/0/0/17-DAC</data>
+      <data key="d3">l5</data>
+      <data key="d4">Patch</data>
+      <data key="d7">false</data>
+      <data key="d14">L2</data>
+    </node>
+    <node id="660">
+      <data key="d0">feb611c8-5b09-4132-a69c-be9adf894536</data>
+      <data key="d1">ConnectionPoint</data>
+      <data key="d2">port+lbnl-data-sw:HundredGigE0/0/0/19</data>
+      <data key="d3">HundredGigE0/0/0/19</data>
+      <data key="d4">TrunkPort</data>
+      <data key="d7">true</data>
+    </node>
+    <node id="661">
+      <data key="d0">feb611c8-5b09-4132-a69c-be9adf894536</data>
+      <data key="d1">Link</data>
+      <data key="d2">port+lbnl-data-sw:HundredGigE0/0/0/19-DAC</data>
       <data key="d3">l6</data>
       <data key="d4">Patch</data>
       <data key="d7">false</data>
       <data key="d14">L2</data>
     </node>
-    <node id="60">
-      <data key="d0">307a43ea-2e59-42c6-8581-71e2a37300f6</data>
+    <node id="662">
+      <data key="d0">feb611c8-5b09-4132-a69c-be9adf894536</data>
       <data key="d1">ConnectionPoint</data>
       <data key="d2">port+lbnl-data-sw:HundredGigE0/0/0/21</data>
       <data key="d3">HundredGigE0/0/0/21</data>
       <data key="d4">TrunkPort</data>
       <data key="d7">true</data>
     </node>
-    <node id="61">
-      <data key="d0">307a43ea-2e59-42c6-8581-71e2a37300f6</data>
+    <node id="663">
+      <data key="d0">feb611c8-5b09-4132-a69c-be9adf894536</data>
       <data key="d1">Link</data>
       <data key="d2">port+lbnl-data-sw:HundredGigE0/0/0/21-DAC</data>
       <data key="d3">l7</data>
@@ -721,297 +721,297 @@
       <data key="d7">false</data>
       <data key="d14">L2</data>
     </node>
-    <node id="62">
-      <data key="d0">307a43ea-2e59-42c6-8581-71e2a37300f6</data>
+    <node id="664">
+      <data key="d0">feb611c8-5b09-4132-a69c-be9adf894536</data>
       <data key="d1">ConnectionPoint</data>
-      <data key="d2">port+lbnl-data-sw:TwentyFiveGigE0/0/0/23/0</data>
-      <data key="d3">TwentyFiveGigE0/0/0/23/0</data>
+      <data key="d2">port+lbnl-data-sw:HundredGigE0/0/0/25.1</data>
+      <data key="d3">HundredGigE0/0/0/25.1</data>
       <data key="d4">TrunkPort</data>
       <data key="d7">true</data>
     </node>
-    <node id="63">
-      <data key="d0">307a43ea-2e59-42c6-8581-71e2a37300f6</data>
+    <node id="665">
+      <data key="d0">feb611c8-5b09-4132-a69c-be9adf894536</data>
       <data key="d1">Link</data>
-      <data key="d2">port+lbnl-data-sw:TwentyFiveGigE0/0/0/23/0-DAC</data>
+      <data key="d2">port+lbnl-data-sw:HundredGigE0/0/0/25.1-DAC</data>
       <data key="d3">l8</data>
       <data key="d4">Patch</data>
       <data key="d7">false</data>
       <data key="d14">L2</data>
     </node>
-    <node id="64">
-      <data key="d0">307a43ea-2e59-42c6-8581-71e2a37300f6</data>
+    <node id="666">
+      <data key="d0">feb611c8-5b09-4132-a69c-be9adf894536</data>
       <data key="d1">ConnectionPoint</data>
-      <data key="d2">port+lbnl-data-sw:TwentyFiveGigE0/0/0/23/1</data>
-      <data key="d3">TwentyFiveGigE0/0/0/23/1</data>
+      <data key="d2">port+lbnl-data-sw:HundredGigE0/0/0/25.2</data>
+      <data key="d3">HundredGigE0/0/0/25.2</data>
       <data key="d4">TrunkPort</data>
       <data key="d7">true</data>
     </node>
-    <node id="65">
-      <data key="d0">307a43ea-2e59-42c6-8581-71e2a37300f6</data>
+    <node id="667">
+      <data key="d0">feb611c8-5b09-4132-a69c-be9adf894536</data>
       <data key="d1">Link</data>
-      <data key="d2">port+lbnl-data-sw:TwentyFiveGigE0/0/0/23/1-DAC</data>
+      <data key="d2">port+lbnl-data-sw:HundredGigE0/0/0/25.2-DAC</data>
       <data key="d3">l9</data>
       <data key="d4">Patch</data>
       <data key="d7">false</data>
       <data key="d14">L2</data>
     </node>
-    <node id="66">
-      <data key="d0">307a43ea-2e59-42c6-8581-71e2a37300f6</data>
+    <node id="668">
+      <data key="d0">feb611c8-5b09-4132-a69c-be9adf894536</data>
       <data key="d1">ConnectionPoint</data>
-      <data key="d2">port+lbnl-data-sw:TwentyFiveGigE0/0/0/23/2</data>
-      <data key="d3">TwentyFiveGigE0/0/0/23/2</data>
+      <data key="d2">port+lbnl-data-sw:HundredGigE0/0/0/25.3</data>
+      <data key="d3">HundredGigE0/0/0/25.3</data>
       <data key="d4">TrunkPort</data>
       <data key="d7">true</data>
     </node>
-    <node id="67">
-      <data key="d0">307a43ea-2e59-42c6-8581-71e2a37300f6</data>
+    <node id="669">
+      <data key="d0">feb611c8-5b09-4132-a69c-be9adf894536</data>
       <data key="d1">Link</data>
-      <data key="d2">port+lbnl-data-sw:TwentyFiveGigE0/0/0/23/2-DAC</data>
+      <data key="d2">port+lbnl-data-sw:HundredGigE0/0/0/25.3-DAC</data>
       <data key="d3">l10</data>
       <data key="d4">Patch</data>
       <data key="d7">false</data>
       <data key="d14">L2</data>
     </node>
-    <node id="68">
-      <data key="d0">307a43ea-2e59-42c6-8581-71e2a37300f6</data>
+    <node id="670">
+      <data key="d0">feb611c8-5b09-4132-a69c-be9adf894536</data>
       <data key="d1">ConnectionPoint</data>
-      <data key="d2">port+lbnl-data-sw:TwentyFiveGigE0/0/0/23/3</data>
-      <data key="d3">TwentyFiveGigE0/0/0/23/3</data>
+      <data key="d2">port+lbnl-data-sw:HundredGigE0/0/0/25.4</data>
+      <data key="d3">HundredGigE0/0/0/25.4</data>
       <data key="d4">TrunkPort</data>
       <data key="d7">true</data>
     </node>
-    <node id="69">
-      <data key="d0">307a43ea-2e59-42c6-8581-71e2a37300f6</data>
+    <node id="671">
+      <data key="d0">feb611c8-5b09-4132-a69c-be9adf894536</data>
       <data key="d1">Link</data>
-      <data key="d2">port+lbnl-data-sw:TwentyFiveGigE0/0/0/23/3-DAC</data>
+      <data key="d2">port+lbnl-data-sw:HundredGigE0/0/0/25.4-DAC</data>
       <data key="d3">l11</data>
       <data key="d4">Patch</data>
       <data key="d7">false</data>
       <data key="d14">L2</data>
     </node>
-    <edge source="1" target="2">
+    <edge source="603" target="606">
       <data key="d15">has</data>
     </edge>
-    <edge source="1" target="3">
+    <edge source="603" target="607">
       <data key="d15">has</data>
     </edge>
-    <edge source="1" target="4">
+    <edge source="603" target="616">
       <data key="d15">has</data>
     </edge>
-    <edge source="1" target="5">
+    <edge source="603" target="617">
       <data key="d15">has</data>
     </edge>
-    <edge source="1" target="6">
+    <edge source="603" target="622">
       <data key="d15">has</data>
     </edge>
-    <edge source="6" target="7">
+    <edge source="604" target="608">
       <data key="d15">has</data>
     </edge>
-    <edge source="7" target="8">
-      <data key="d15">connects</data>
-    </edge>
-    <edge source="8" target="49">
-      <data key="d15">connects</data>
-    </edge>
-    <edge source="9" target="10">
+    <edge source="604" target="609">
       <data key="d15">has</data>
     </edge>
-    <edge source="9" target="11">
+    <edge source="604" target="610">
       <data key="d15">has</data>
     </edge>
-    <edge source="9" target="12">
+    <edge source="604" target="611">
       <data key="d15">has</data>
     </edge>
-    <edge source="9" target="13">
+    <edge source="604" target="618">
       <data key="d15">has</data>
     </edge>
-    <edge source="9" target="14">
+    <edge source="604" target="619">
       <data key="d15">has</data>
     </edge>
-    <edge source="9" target="15">
+    <edge source="604" target="625">
       <data key="d15">has</data>
     </edge>
-    <edge source="9" target="16">
+    <edge source="604" target="631">
       <data key="d15">has</data>
     </edge>
-    <edge source="9" target="19">
+    <edge source="604" target="635">
       <data key="d15">has</data>
     </edge>
-    <edge source="9" target="23">
+    <edge source="605" target="612">
       <data key="d15">has</data>
     </edge>
-    <edge source="16" target="17">
+    <edge source="605" target="613">
       <data key="d15">has</data>
     </edge>
-    <edge source="17" target="18">
-      <data key="d15">connects</data>
-    </edge>
-    <edge source="18" target="51">
-      <data key="d15">connects</data>
-    </edge>
-    <edge source="19" target="20">
+    <edge source="605" target="614">
       <data key="d15">has</data>
     </edge>
-    <edge source="20" target="21">
-      <data key="d15">connects</data>
-    </edge>
-    <edge source="20" target="22">
-      <data key="d15">connects</data>
-    </edge>
-    <edge source="21" target="53">
-      <data key="d15">connects</data>
-    </edge>
-    <edge source="22" target="55">
-      <data key="d15">connects</data>
-    </edge>
-    <edge source="23" target="24">
+    <edge source="605" target="615">
       <data key="d15">has</data>
     </edge>
-    <edge source="24" target="25">
-      <data key="d15">connects</data>
-    </edge>
-    <edge source="24" target="26">
-      <data key="d15">connects</data>
-    </edge>
-    <edge source="25" target="57">
-      <data key="d15">connects</data>
-    </edge>
-    <edge source="26" target="59">
-      <data key="d15">connects</data>
-    </edge>
-    <edge source="27" target="28">
+    <edge source="605" target="620">
       <data key="d15">has</data>
     </edge>
-    <edge source="27" target="29">
+    <edge source="605" target="621">
       <data key="d15">has</data>
     </edge>
-    <edge source="27" target="30">
+    <edge source="605" target="628">
       <data key="d15">has</data>
     </edge>
-    <edge source="27" target="31">
+    <edge source="605" target="639">
       <data key="d15">has</data>
     </edge>
-    <edge source="27" target="32">
+    <edge source="605" target="643">
       <data key="d15">has</data>
     </edge>
-    <edge source="27" target="33">
+    <edge source="622" target="623">
       <data key="d15">has</data>
     </edge>
-    <edge source="27" target="34">
+    <edge source="623" target="624">
+      <data key="d15">connects</data>
+    </edge>
+    <edge source="624" target="651">
+      <data key="d15">connects</data>
+    </edge>
+    <edge source="625" target="626">
       <data key="d15">has</data>
     </edge>
-    <edge source="27" target="37">
+    <edge source="626" target="627">
+      <data key="d15">connects</data>
+    </edge>
+    <edge source="627" target="653">
+      <data key="d15">connects</data>
+    </edge>
+    <edge source="628" target="629">
       <data key="d15">has</data>
     </edge>
-    <edge source="27" target="41">
+    <edge source="629" target="630">
+      <data key="d15">connects</data>
+    </edge>
+    <edge source="630" target="663">
+      <data key="d15">connects</data>
+    </edge>
+    <edge source="631" target="632">
       <data key="d15">has</data>
     </edge>
-    <edge source="34" target="35">
+    <edge source="632" target="633">
+      <data key="d15">connects</data>
+    </edge>
+    <edge source="632" target="634">
+      <data key="d15">connects</data>
+    </edge>
+    <edge source="633" target="655">
+      <data key="d15">connects</data>
+    </edge>
+    <edge source="634" target="657">
+      <data key="d15">connects</data>
+    </edge>
+    <edge source="635" target="636">
       <data key="d15">has</data>
     </edge>
-    <edge source="35" target="36">
+    <edge source="636" target="637">
       <data key="d15">connects</data>
     </edge>
-    <edge source="36" target="61">
+    <edge source="636" target="638">
       <data key="d15">connects</data>
     </edge>
-    <edge source="37" target="38">
+    <edge source="637" target="659">
+      <data key="d15">connects</data>
+    </edge>
+    <edge source="638" target="661">
+      <data key="d15">connects</data>
+    </edge>
+    <edge source="639" target="640">
       <data key="d15">has</data>
     </edge>
-    <edge source="38" target="39">
+    <edge source="640" target="641">
       <data key="d15">connects</data>
     </edge>
-    <edge source="38" target="40">
+    <edge source="640" target="642">
       <data key="d15">connects</data>
     </edge>
-    <edge source="39" target="65">
+    <edge source="641" target="665">
       <data key="d15">connects</data>
     </edge>
-    <edge source="40" target="63">
+    <edge source="642" target="667">
       <data key="d15">connects</data>
     </edge>
-    <edge source="41" target="42">
+    <edge source="643" target="644">
       <data key="d15">has</data>
     </edge>
-    <edge source="42" target="43">
+    <edge source="644" target="645">
       <data key="d15">connects</data>
     </edge>
-    <edge source="42" target="44">
+    <edge source="644" target="646">
       <data key="d15">connects</data>
     </edge>
-    <edge source="43" target="67">
+    <edge source="645" target="669">
       <data key="d15">connects</data>
     </edge>
-    <edge source="44" target="69">
+    <edge source="646" target="671">
       <data key="d15">connects</data>
     </edge>
-    <edge source="46" target="47">
+    <edge source="648" target="649">
       <data key="d15">has</data>
     </edge>
-    <edge source="47" target="48">
+    <edge source="649" target="650">
       <data key="d15">connects</data>
     </edge>
-    <edge source="47" target="50">
+    <edge source="649" target="652">
       <data key="d15">connects</data>
     </edge>
-    <edge source="47" target="52">
+    <edge source="649" target="654">
       <data key="d15">connects</data>
     </edge>
-    <edge source="47" target="54">
+    <edge source="649" target="656">
       <data key="d15">connects</data>
     </edge>
-    <edge source="47" target="56">
+    <edge source="649" target="658">
       <data key="d15">connects</data>
     </edge>
-    <edge source="47" target="58">
+    <edge source="649" target="660">
       <data key="d15">connects</data>
     </edge>
-    <edge source="47" target="60">
+    <edge source="649" target="662">
       <data key="d15">connects</data>
     </edge>
-    <edge source="47" target="62">
+    <edge source="649" target="664">
       <data key="d15">connects</data>
     </edge>
-    <edge source="47" target="64">
+    <edge source="649" target="666">
       <data key="d15">connects</data>
     </edge>
-    <edge source="47" target="66">
+    <edge source="649" target="668">
       <data key="d15">connects</data>
     </edge>
-    <edge source="47" target="68">
+    <edge source="649" target="670">
       <data key="d15">connects</data>
     </edge>
-    <edge source="48" target="49">
+    <edge source="650" target="651">
       <data key="d15">connects</data>
     </edge>
-    <edge source="50" target="51">
+    <edge source="652" target="653">
       <data key="d15">connects</data>
     </edge>
-    <edge source="52" target="53">
+    <edge source="654" target="655">
       <data key="d15">connects</data>
     </edge>
-    <edge source="54" target="55">
+    <edge source="656" target="657">
       <data key="d15">connects</data>
     </edge>
-    <edge source="56" target="57">
+    <edge source="658" target="659">
       <data key="d15">connects</data>
     </edge>
-    <edge source="58" target="59">
+    <edge source="660" target="661">
       <data key="d15">connects</data>
     </edge>
-    <edge source="60" target="61">
+    <edge source="662" target="663">
       <data key="d15">connects</data>
     </edge>
-    <edge source="62" target="63">
+    <edge source="664" target="665">
       <data key="d15">connects</data>
     </edge>
-    <edge source="64" target="65">
+    <edge source="666" target="667">
       <data key="d15">connects</data>
     </edge>
-    <edge source="66" target="67">
+    <edge source="668" target="669">
       <data key="d15">connects</data>
     </edge>
-    <edge source="68" target="69">
+    <edge source="670" target="671">
       <data key="d15">connects</data>
     </edge>
   </graph>

--- a/neo4j/Network-ad.graphml
+++ b/neo4j/Network-ad.graphml
@@ -1,12 +1,12 @@
 <graphml xmlns="http://graphml.graphdrawing.org/xmlns" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://graphml.graphdrawing.org/xmlns http://graphml.graphdrawing.org/xmlns/1.0/graphml.xsd">
   <key id="d13" for="edge" attr.name="Class" attr.type="string" />
-  <key id="d12" for="node" attr.name="Layer" attr.type="string" />
-  <key id="d11" for="node" attr.name="LabelDelegations" attr.type="string" />
-  <key id="d10" for="node" attr.name="CapacityDelegations" attr.type="string" />
-  <key id="d9" for="node" attr.name="Site" attr.type="string" />
-  <key id="d8" for="node" attr.name="StitchNode" attr.type="string" />
-  <key id="d7" for="node" attr.name="Labels" attr.type="string" />
-  <key id="d6" for="node" attr.name="Capacities" attr.type="string" />
+  <key id="d12" for="node" attr.name="CapacityDelegations" attr.type="string" />
+  <key id="d11" for="node" attr.name="Capacities" attr.type="string" />
+  <key id="d10" for="node" attr.name="LabelDelegations" attr.type="string" />
+  <key id="d9" for="node" attr.name="Layer" attr.type="string" />
+  <key id="d8" for="node" attr.name="Labels" attr.type="string" />
+  <key id="d7" for="node" attr.name="Site" attr.type="string" />
+  <key id="d6" for="node" attr.name="StitchNode" attr.type="string" />
   <key id="d5" for="node" attr.name="Model" attr.type="string" />
   <key id="d4" for="node" attr.name="Type" attr.type="string" />
   <key id="d3" for="node" attr.name="Name" attr.type="string" />
@@ -14,1538 +14,855 @@
   <key id="d1" for="node" attr.name="Class" attr.type="string" />
   <key id="d0" for="node" attr.name="GraphID" attr.type="string" />
   <graph edgedefault="undirected">
-    <node id="1">
-      <data key="d0">4211307c-dcbf-49dc-afe4-3915c820960a</data>
-      <data key="d1">NetworkNode</data>
-      <data key="d2">node+lbnl-data-sw:ip+192.168.13.3</data>
-      <data key="d3">lbnl-data-sw</data>
-      <data key="d4">Switch</data>
-      <data key="d5">NCS 55A1-36H</data>
-      <data key="d6">{"unit": 1}</data>
-      <data key="d7">{"ipv4": "192.168.13.3", "local_name": "lbnl-data-sw"}</data>
-      <data key="d8">false</data>
-      <data key="d9">LBNL</data>
-      <data key="d10">{"primary": {"pool_id": "_", "capacities": {"unit": 1}}}</data>
-      <data key="d11">{"primary": {"pool_id": "_", "labels": {"ipv4": "192.168.13.3", "local_name": "lbnl-data-sw"}}}</data>
-    </node>
-    <node id="2">
-      <data key="d0">4211307c-dcbf-49dc-afe4-3915c820960a</data>
-      <data key="d1">NetworkService</data>
-      <data key="d2">node+lbnl-data-sw:ip+192.168.13.3-ipv4-ns</data>
-      <data key="d3">lbnl-data-sw-ipv4-ns</data>
-      <data key="d4">FABNetv4</data>
-      <data key="d7">{"ipv4_subnet": "10.129.0.0/17"}</data>
-      <data key="d8">false</data>
-      <data key="d12">L3</data>
-      <data key="d11">{"primary": {"pool_id": "_", "labels": {"ipv4_subnet": "10.129.0.0/17"}}}</data>
-    </node>
-    <node id="3">
-      <data key="d0">4211307c-dcbf-49dc-afe4-3915c820960a</data>
-      <data key="d1">NetworkService</data>
-      <data key="d2">node+lbnl-data-sw:ip+192.168.13.3-ipv6-ns</data>
-      <data key="d3">lbnl-data-sw-ipv6-ns</data>
-      <data key="d4">FABNetv6</data>
-      <data key="d7">{"ipv6_subnet": "2602:fcfb:2::/48"}</data>
-      <data key="d8">false</data>
-      <data key="d12">L3</data>
-      <data key="d11">{"primary": {"pool_id": "_", "labels": {"ipv6_subnet": "2602:fcfb:2::/48"}}}</data>
-    </node>
-    <node id="4">
-      <data key="d0">4211307c-dcbf-49dc-afe4-3915c820960a</data>
-      <data key="d1">NetworkService</data>
-      <data key="d2">node+lbnl-data-sw:ip+192.168.13.3-ns</data>
-      <data key="d3">lbnl-data-sw-ns</data>
-      <data key="d4">MPLS</data>
-      <data key="d7" />
-      <data key="d8">false</data>
-      <data key="d12">L2</data>
-    </node>
-    <node id="5">
-      <data key="d0">4211307c-dcbf-49dc-afe4-3915c820960a</data>
-      <data key="d1">ConnectionPoint</data>
-      <data key="d2">port+lbnl-data-sw:HundredGigE0/0/0/0</data>
-      <data key="d3">HundredGigE0/0/0/0</data>
-      <data key="d4">TrunkPort</data>
-      <data key="d6">{"bw": 100}</data>
-      <data key="d7">{"local_name": "HundredGigE0/0/0/0", "mac": "94:ae:f0:dc:a8:00"}</data>
-      <data key="d8">false</data>
-      <data key="d10">{"primary": {"pool_id": "_", "capacities": {"bw": 100}}}</data>
-      <data key="d11">{"primary": {"pool_id": "_", "labels": {"mac": "94:ae:f0:dc:a8:00", "local_name": "HundredGigE0/0/0/0"}}}</data>
-    </node>
-    <node id="6">
-      <data key="d0">4211307c-dcbf-49dc-afe4-3915c820960a</data>
-      <data key="d1">ConnectionPoint</data>
-      <data key="d2">port+lbnl-data-sw:HundredGigE0/0/0/0.2400</data>
-      <data key="d3">HundredGigE0/0/0/0.2400</data>
-      <data key="d4">TrunkPort</data>
-      <data key="d6">{"bw": 100}</data>
-      <data key="d7">{"ipv4": "10.128.0.134", "ipv6": "2602:fcfb:0:1024::6", "local_name": "HundredGigE0/0/0/0.2400", "mac": "94:ae:f0:dc:a8:00"}</data>
-      <data key="d8">false</data>
-      <data key="d10">{"primary": {"pool_id": "_", "capacities": {"bw": 100}}}</data>
-      <data key="d11">{"primary": {"pool_id": "_", "labels": {"mac": "94:ae:f0:dc:a8:00", "ipv4": "10.128.0.134", "ipv6": "2602:fcfb:0:1024::6", "local_name": "HundredGigE0/0/0/0.2400"}}}</data>
-    </node>
-    <node id="7">
-      <data key="d0">4211307c-dcbf-49dc-afe4-3915c820960a</data>
-      <data key="d1">ConnectionPoint</data>
-      <data key="d2">port+lbnl-data-sw:HundredGigE0/0/0/0.2401</data>
-      <data key="d3">HundredGigE0/0/0/0.2401</data>
-      <data key="d4">TrunkPort</data>
-      <data key="d6">{"bw": 100}</data>
-      <data key="d7">{"ipv4": "10.128.128.130", "ipv6": "2602:fcfb:1:1024::2", "local_name": "HundredGigE0/0/0/0.2401", "mac": "94:ae:f0:dc:a8:00"}</data>
-      <data key="d8">false</data>
-      <data key="d10">{"primary": {"pool_id": "_", "capacities": {"bw": 100}}}</data>
-      <data key="d11">{"primary": {"pool_id": "_", "labels": {"mac": "94:ae:f0:dc:a8:00", "ipv4": "10.128.128.130", "ipv6": "2602:fcfb:1:1024::2", "local_name": "HundredGigE0/0/0/0.2401"}}}</data>
-    </node>
-    <node id="8">
-      <data key="d0">4211307c-dcbf-49dc-afe4-3915c820960a</data>
-      <data key="d1">ConnectionPoint</data>
-      <data key="d2">port+lbnl-data-sw:HundredGigE0/0/0/1</data>
-      <data key="d3">HundredGigE0/0/0/1</data>
-      <data key="d4">TrunkPort</data>
-      <data key="d6">{"bw": 100}</data>
-      <data key="d7">{"local_name": "HundredGigE0/0/0/1", "mac": "94:ae:f0:dc:a8:04"}</data>
-      <data key="d8">false</data>
-      <data key="d10">{"primary": {"pool_id": "_", "capacities": {"bw": 100}}}</data>
-      <data key="d11">{"primary": {"pool_id": "_", "labels": {"mac": "94:ae:f0:dc:a8:04", "local_name": "HundredGigE0/0/0/1"}}}</data>
-    </node>
-    <node id="9">
-      <data key="d0">4211307c-dcbf-49dc-afe4-3915c820960a</data>
-      <data key="d1">ConnectionPoint</data>
-      <data key="d2">port+lbnl-data-sw:HundredGigE0/0/0/13</data>
-      <data key="d3">HundredGigE0/0/0/13</data>
-      <data key="d4">TrunkPort</data>
-      <data key="d6">{"bw": 100}</data>
-      <data key="d7">{"local_name": "HundredGigE0/0/0/13", "mac": "94:ae:f0:dc:a8:34"}</data>
-      <data key="d8">false</data>
-      <data key="d10">{"primary": {"pool_id": "_", "capacities": {"bw": 100}}}</data>
-      <data key="d11">{"primary": {"pool_id": "_", "labels": {"mac": "94:ae:f0:dc:a8:34", "local_name": "HundredGigE0/0/0/13"}}}</data>
-    </node>
-    <node id="10">
-      <data key="d0">4211307c-dcbf-49dc-afe4-3915c820960a</data>
-      <data key="d1">ConnectionPoint</data>
-      <data key="d2">port+lbnl-data-sw:HundredGigE0/0/0/15</data>
-      <data key="d3">HundredGigE0/0/0/15</data>
-      <data key="d4">TrunkPort</data>
-      <data key="d6">{"bw": 100}</data>
-      <data key="d7">{"local_name": "HundredGigE0/0/0/15", "mac": "94:ae:f0:dc:a8:3c"}</data>
-      <data key="d8">false</data>
-      <data key="d10">{"primary": {"pool_id": "_", "capacities": {"bw": 100}}}</data>
-      <data key="d11">{"primary": {"pool_id": "_", "labels": {"mac": "94:ae:f0:dc:a8:3c", "local_name": "HundredGigE0/0/0/15"}}}</data>
-    </node>
-    <node id="11">
-      <data key="d0">4211307c-dcbf-49dc-afe4-3915c820960a</data>
-      <data key="d1">ConnectionPoint</data>
-      <data key="d2">port+lbnl-data-sw:HundredGigE0/0/0/17</data>
-      <data key="d3">HundredGigE0/0/0/17</data>
-      <data key="d4">TrunkPort</data>
-      <data key="d6">{"bw": 100}</data>
-      <data key="d7">{"local_name": "HundredGigE0/0/0/17", "mac": "94:ae:f0:dc:a8:44"}</data>
-      <data key="d8">false</data>
-      <data key="d10">{"primary": {"pool_id": "_", "capacities": {"bw": 100}}}</data>
-      <data key="d11">{"primary": {"pool_id": "_", "labels": {"mac": "94:ae:f0:dc:a8:44", "local_name": "HundredGigE0/0/0/17"}}}</data>
-    </node>
-    <node id="12">
-      <data key="d0">4211307c-dcbf-49dc-afe4-3915c820960a</data>
-      <data key="d1">ConnectionPoint</data>
-      <data key="d2">port+lbnl-data-sw:HundredGigE0/0/0/19</data>
-      <data key="d3">HundredGigE0/0/0/19</data>
-      <data key="d4">TrunkPort</data>
-      <data key="d6">{"bw": 100}</data>
-      <data key="d7">{"local_name": "HundredGigE0/0/0/19", "mac": "94:ae:f0:dc:a8:4c"}</data>
-      <data key="d8">false</data>
-      <data key="d10">{"primary": {"pool_id": "_", "capacities": {"bw": 100}}}</data>
-      <data key="d11">{"primary": {"pool_id": "_", "labels": {"mac": "94:ae:f0:dc:a8:4c", "local_name": "HundredGigE0/0/0/19"}}}</data>
-    </node>
-    <node id="13">
-      <data key="d0">4211307c-dcbf-49dc-afe4-3915c820960a</data>
-      <data key="d1">ConnectionPoint</data>
-      <data key="d2">port+lbnl-data-sw:HundredGigE0/0/0/19.0</data>
-      <data key="d3">HundredGigE0/0/0/19.0</data>
-      <data key="d4">TrunkPort</data>
-      <data key="d6">{"bw": 100}</data>
-      <data key="d7">{"local_name": "HundredGigE0/0/0/19.0", "mac": "94:ae:f0:dc:a8:4c"}</data>
-      <data key="d8">false</data>
-      <data key="d10">{"primary": {"pool_id": "_", "capacities": {"bw": 100}}}</data>
-      <data key="d11">{"primary": {"pool_id": "_", "labels": {"mac": "94:ae:f0:dc:a8:4c", "local_name": "HundredGigE0/0/0/19.0"}}}</data>
-    </node>
-    <node id="14">
-      <data key="d0">4211307c-dcbf-49dc-afe4-3915c820960a</data>
-      <data key="d1">ConnectionPoint</data>
-      <data key="d2">port+lbnl-data-sw:HundredGigE0/0/0/21</data>
-      <data key="d3">HundredGigE0/0/0/21</data>
-      <data key="d4">TrunkPort</data>
-      <data key="d6">{"bw": 100}</data>
-      <data key="d7">{"local_name": "HundredGigE0/0/0/21", "mac": "94:ae:f0:dc:a8:54"}</data>
-      <data key="d8">false</data>
-      <data key="d10">{"primary": {"pool_id": "_", "capacities": {"bw": 100}}}</data>
-      <data key="d11">{"primary": {"pool_id": "_", "labels": {"mac": "94:ae:f0:dc:a8:54", "local_name": "HundredGigE0/0/0/21"}}}</data>
-    </node>
-    <node id="15">
-      <data key="d0">4211307c-dcbf-49dc-afe4-3915c820960a</data>
-      <data key="d1">ConnectionPoint</data>
-      <data key="d2">port+lbnl-data-sw:HundredGigE0/0/0/3</data>
-      <data key="d3">HundredGigE0/0/0/3</data>
-      <data key="d4">TrunkPort</data>
-      <data key="d6">{"bw": 100}</data>
-      <data key="d7">{"local_name": "HundredGigE0/0/0/3", "mac": "94:ae:f0:dc:a8:0c"}</data>
-      <data key="d8">false</data>
-      <data key="d10">{"primary": {"pool_id": "_", "capacities": {"bw": 100}}}</data>
-      <data key="d11">{"primary": {"pool_id": "_", "labels": {"mac": "94:ae:f0:dc:a8:0c", "local_name": "HundredGigE0/0/0/3"}}}</data>
-    </node>
-    <node id="16">
-      <data key="d0">4211307c-dcbf-49dc-afe4-3915c820960a</data>
-      <data key="d1">ConnectionPoint</data>
-      <data key="d2">port+lbnl-data-sw:HundredGigE0/0/0/5</data>
-      <data key="d3">HundredGigE0/0/0/5</data>
-      <data key="d4">TrunkPort</data>
-      <data key="d6">{"bw": 100}</data>
-      <data key="d7">{"local_name": "HundredGigE0/0/0/5", "mac": "94:ae:f0:dc:a8:14"}</data>
-      <data key="d8">false</data>
-      <data key="d10">{"primary": {"pool_id": "_", "capacities": {"bw": 100}}}</data>
-      <data key="d11">{"primary": {"pool_id": "_", "labels": {"mac": "94:ae:f0:dc:a8:14", "local_name": "HundredGigE0/0/0/5"}}}</data>
-    </node>
-    <node id="17">
-      <data key="d0">4211307c-dcbf-49dc-afe4-3915c820960a</data>
-      <data key="d1">ConnectionPoint</data>
-      <data key="d2">port+lbnl-data-sw:HundredGigE0/0/0/5.2034</data>
-      <data key="d3">HundredGigE0/0/0/5.2034</data>
-      <data key="d4">TrunkPort</data>
-      <data key="d6">{"bw": 100}</data>
-      <data key="d7">{"local_name": "HundredGigE0/0/0/5.2034", "mac": "94:ae:f0:dc:a8:14"}</data>
-      <data key="d8">false</data>
-      <data key="d10">{"primary": {"pool_id": "_", "capacities": {"bw": 100}}}</data>
-      <data key="d11">{"primary": {"pool_id": "_", "labels": {"mac": "94:ae:f0:dc:a8:14", "local_name": "HundredGigE0/0/0/5.2034"}}}</data>
-    </node>
-    <node id="18">
-      <data key="d0">4211307c-dcbf-49dc-afe4-3915c820960a</data>
-      <data key="d1">ConnectionPoint</data>
-      <data key="d2">port+lbnl-data-sw:HundredGigE0/0/0/5.2044</data>
-      <data key="d3">HundredGigE0/0/0/5.2044</data>
-      <data key="d4">TrunkPort</data>
-      <data key="d6">{"bw": 100}</data>
-      <data key="d7">{"local_name": "HundredGigE0/0/0/5.2044", "mac": "94:ae:f0:dc:a8:14"}</data>
-      <data key="d8">false</data>
-      <data key="d10">{"primary": {"pool_id": "_", "capacities": {"bw": 100}}}</data>
-      <data key="d11">{"primary": {"pool_id": "_", "labels": {"mac": "94:ae:f0:dc:a8:14", "local_name": "HundredGigE0/0/0/5.2044"}}}</data>
-    </node>
-    <node id="19">
-      <data key="d0">4211307c-dcbf-49dc-afe4-3915c820960a</data>
-      <data key="d1">ConnectionPoint</data>
-      <data key="d2">port+lbnl-data-sw:HundredGigE0/0/0/5.2097</data>
-      <data key="d3">HundredGigE0/0/0/5.2097</data>
-      <data key="d4">TrunkPort</data>
-      <data key="d6">{"bw": 100}</data>
-      <data key="d7">{"local_name": "HundredGigE0/0/0/5.2097", "mac": "94:ae:f0:dc:a8:14"}</data>
-      <data key="d8">false</data>
-      <data key="d10">{"primary": {"pool_id": "_", "capacities": {"bw": 100}}}</data>
-      <data key="d11">{"primary": {"pool_id": "_", "labels": {"mac": "94:ae:f0:dc:a8:14", "local_name": "HundredGigE0/0/0/5.2097"}}}</data>
-    </node>
-    <node id="20">
-      <data key="d0">4211307c-dcbf-49dc-afe4-3915c820960a</data>
-      <data key="d1">ConnectionPoint</data>
-      <data key="d2">port+lbnl-data-sw:HundredGigE0/0/0/5.2120</data>
-      <data key="d3">HundredGigE0/0/0/5.2120</data>
-      <data key="d4">TrunkPort</data>
-      <data key="d6">{"bw": 100}</data>
-      <data key="d7">{"local_name": "HundredGigE0/0/0/5.2120", "mac": "94:ae:f0:dc:a8:14"}</data>
-      <data key="d8">false</data>
-      <data key="d10">{"primary": {"pool_id": "_", "capacities": {"bw": 100}}}</data>
-      <data key="d11">{"primary": {"pool_id": "_", "labels": {"mac": "94:ae:f0:dc:a8:14", "local_name": "HundredGigE0/0/0/5.2120"}}}</data>
-    </node>
-    <node id="21">
-      <data key="d0">4211307c-dcbf-49dc-afe4-3915c820960a</data>
-      <data key="d1">ConnectionPoint</data>
-      <data key="d2">port+lbnl-data-sw:HundredGigE0/0/0/5.2122</data>
-      <data key="d3">HundredGigE0/0/0/5.2122</data>
-      <data key="d4">TrunkPort</data>
-      <data key="d6">{"bw": 100}</data>
-      <data key="d7">{"local_name": "HundredGigE0/0/0/5.2122", "mac": "94:ae:f0:dc:a8:14"}</data>
-      <data key="d8">false</data>
-      <data key="d10">{"primary": {"pool_id": "_", "capacities": {"bw": 100}}}</data>
-      <data key="d11">{"primary": {"pool_id": "_", "labels": {"mac": "94:ae:f0:dc:a8:14", "local_name": "HundredGigE0/0/0/5.2122"}}}</data>
-    </node>
-    <node id="22">
-      <data key="d0">4211307c-dcbf-49dc-afe4-3915c820960a</data>
-      <data key="d1">ConnectionPoint</data>
-      <data key="d2">port+lbnl-data-sw:HundredGigE0/0/0/9</data>
-      <data key="d3">HundredGigE0/0/0/9</data>
-      <data key="d4">TrunkPort</data>
-      <data key="d6">{"bw": 100}</data>
-      <data key="d7">{"local_name": "HundredGigE0/0/0/9", "mac": "94:ae:f0:dc:a8:24"}</data>
-      <data key="d8">false</data>
-      <data key="d10">{"primary": {"pool_id": "_", "capacities": {"bw": 100}}}</data>
-      <data key="d11">{"primary": {"pool_id": "_", "labels": {"mac": "94:ae:f0:dc:a8:24", "local_name": "HundredGigE0/0/0/9"}}}</data>
-    </node>
-    <node id="23">
-      <data key="d0">4211307c-dcbf-49dc-afe4-3915c820960a</data>
-      <data key="d1">ConnectionPoint</data>
-      <data key="d2">port+lbnl-data-sw:HundredGigE0/0/0/9.1003</data>
-      <data key="d3">HundredGigE0/0/0/9.1003</data>
-      <data key="d4">TrunkPort</data>
-      <data key="d6">{"bw": 100}</data>
-      <data key="d7">{"local_name": "HundredGigE0/0/0/9.1003", "mac": "94:ae:f0:dc:a8:24"}</data>
-      <data key="d8">false</data>
-      <data key="d10">{"primary": {"pool_id": "_", "capacities": {"bw": 100}}}</data>
-      <data key="d11">{"primary": {"pool_id": "_", "labels": {"mac": "94:ae:f0:dc:a8:24", "local_name": "HundredGigE0/0/0/9.1003"}}}</data>
-    </node>
-    <node id="24">
-      <data key="d0">4211307c-dcbf-49dc-afe4-3915c820960a</data>
-      <data key="d1">ConnectionPoint</data>
-      <data key="d2">port+lbnl-data-sw:TwentyFiveGigE0/0/0/23/0</data>
-      <data key="d3">TwentyFiveGigE0/0/0/23/0</data>
-      <data key="d4">TrunkPort</data>
-      <data key="d6">{"bw": 25}</data>
-      <data key="d7">{"local_name": "TwentyFiveGigE0/0/0/23/0", "mac": "94:ae:f0:dc:a8:5c"}</data>
-      <data key="d8">false</data>
-      <data key="d10">{"primary": {"pool_id": "_", "capacities": {"bw": 25}}}</data>
-      <data key="d11">{"primary": {"pool_id": "_", "labels": {"mac": "94:ae:f0:dc:a8:5c", "local_name": "TwentyFiveGigE0/0/0/23/0"}}}</data>
-    </node>
-    <node id="25">
-      <data key="d0">4211307c-dcbf-49dc-afe4-3915c820960a</data>
-      <data key="d1">ConnectionPoint</data>
-      <data key="d2">port+lbnl-data-sw:TwentyFiveGigE0/0/0/23/1</data>
-      <data key="d3">TwentyFiveGigE0/0/0/23/1</data>
-      <data key="d4">TrunkPort</data>
-      <data key="d6">{"bw": 25}</data>
-      <data key="d7">{"local_name": "TwentyFiveGigE0/0/0/23/1", "mac": "94:ae:f0:dc:a8:5d"}</data>
-      <data key="d8">false</data>
-      <data key="d10">{"primary": {"pool_id": "_", "capacities": {"bw": 25}}}</data>
-      <data key="d11">{"primary": {"pool_id": "_", "labels": {"mac": "94:ae:f0:dc:a8:5d", "local_name": "TwentyFiveGigE0/0/0/23/1"}}}</data>
-    </node>
-    <node id="26">
-      <data key="d0">4211307c-dcbf-49dc-afe4-3915c820960a</data>
-      <data key="d1">ConnectionPoint</data>
-      <data key="d2">port+lbnl-data-sw:TwentyFiveGigE0/0/0/23/2</data>
-      <data key="d3">TwentyFiveGigE0/0/0/23/2</data>
-      <data key="d4">TrunkPort</data>
-      <data key="d6">{"bw": 25}</data>
-      <data key="d7">{"local_name": "TwentyFiveGigE0/0/0/23/2", "mac": "94:ae:f0:dc:a8:5e"}</data>
-      <data key="d8">false</data>
-      <data key="d10">{"primary": {"pool_id": "_", "capacities": {"bw": 25}}}</data>
-      <data key="d11">{"primary": {"pool_id": "_", "labels": {"mac": "94:ae:f0:dc:a8:5e", "local_name": "TwentyFiveGigE0/0/0/23/2"}}}</data>
-    </node>
-    <node id="27">
-      <data key="d0">4211307c-dcbf-49dc-afe4-3915c820960a</data>
-      <data key="d1">ConnectionPoint</data>
-      <data key="d2">port+lbnl-data-sw:TwentyFiveGigE0/0/0/23/2.0</data>
-      <data key="d3">TwentyFiveGigE0/0/0/23/2.0</data>
-      <data key="d4">TrunkPort</data>
-      <data key="d6">{"bw": 25}</data>
-      <data key="d7">{"local_name": "TwentyFiveGigE0/0/0/23/2.0", "mac": "94:ae:f0:dc:a8:5e"}</data>
-      <data key="d8">false</data>
-      <data key="d10">{"primary": {"pool_id": "_", "capacities": {"bw": 25}}}</data>
-      <data key="d11">{"primary": {"pool_id": "_", "labels": {"mac": "94:ae:f0:dc:a8:5e", "local_name": "TwentyFiveGigE0/0/0/23/2.0"}}}</data>
-    </node>
-    <node id="28">
-      <data key="d0">4211307c-dcbf-49dc-afe4-3915c820960a</data>
-      <data key="d1">ConnectionPoint</data>
-      <data key="d2">port+lbnl-data-sw:TwentyFiveGigE0/0/0/23/3</data>
-      <data key="d3">TwentyFiveGigE0/0/0/23/3</data>
-      <data key="d4">TrunkPort</data>
-      <data key="d6">{"bw": 25}</data>
-      <data key="d7">{"local_name": "TwentyFiveGigE0/0/0/23/3", "mac": "94:ae:f0:dc:a8:5f"}</data>
-      <data key="d8">false</data>
-      <data key="d10">{"primary": {"pool_id": "_", "capacities": {"bw": 25}}}</data>
-      <data key="d11">{"primary": {"pool_id": "_", "labels": {"mac": "94:ae:f0:dc:a8:5f", "local_name": "TwentyFiveGigE0/0/0/23/3"}}}</data>
-    </node>
-    <node id="29">
-      <data key="d0">4211307c-dcbf-49dc-afe4-3915c820960a</data>
-      <data key="d1">NetworkNode</data>
-      <data key="d2">node+ncsa-data-sw:ip+192.168.20.3</data>
-      <data key="d3">ncsa-data-sw</data>
-      <data key="d4">Switch</data>
-      <data key="d5">NCS 55A1-36H</data>
-      <data key="d6">{"unit": 1}</data>
-      <data key="d7">{"ipv4": "192.168.20.3", "local_name": "ncsa-data-sw"}</data>
-      <data key="d8">false</data>
-      <data key="d9">NCSA</data>
-      <data key="d10">{"primary": {"pool_id": "_", "capacities": {"unit": 1}}}</data>
-      <data key="d11">{"primary": {"pool_id": "_", "labels": {"ipv4": "192.168.20.3", "local_name": "ncsa-data-sw"}}}</data>
-    </node>
-    <node id="30">
-      <data key="d0">4211307c-dcbf-49dc-afe4-3915c820960a</data>
-      <data key="d1">NetworkService</data>
-      <data key="d2">node+ncsa-data-sw:ip+192.168.20.3-ipv4-ns</data>
-      <data key="d3">ncsa-data-sw-ipv4-ns</data>
-      <data key="d4">FABNetv4</data>
-      <data key="d7">{"ipv4_subnet": "10.132.128.0/17", "vlan_range": "201-400"}</data>
-      <data key="d8">false</data>
-      <data key="d12">L3</data>
-      <data key="d11">{"primary": {"pool_id": "_", "labels": {"ipv4_subnet": "10.132.128.0/17", "vlan_range": "201-400"}}}</data>
-    </node>
-    <node id="31">
-      <data key="d0">4211307c-dcbf-49dc-afe4-3915c820960a</data>
-      <data key="d1">NetworkService</data>
-      <data key="d2">node+ncsa-data-sw:ip+192.168.20.3-ipv6-ns</data>
-      <data key="d3">ncsa-data-sw-ipv6-ns</data>
-      <data key="d4">FABNetv6</data>
-      <data key="d7">{"ipv6_subnet": "2602:fcfb:9::/48", "vlan_range": "201-400"}</data>
-      <data key="d8">false</data>
-      <data key="d12">L3</data>
-      <data key="d11">{"primary": {"pool_id": "_", "labels": {"ipv6_subnet": "2602:fcfb:9::/48", "vlan_range": "201-400"}}}</data>
-    </node>
-    <node id="32">
-      <data key="d0">4211307c-dcbf-49dc-afe4-3915c820960a</data>
-      <data key="d1">NetworkService</data>
-      <data key="d2">node+ncsa-data-sw:ip+192.168.20.3-ns</data>
-      <data key="d3">ncsa-data-sw-ns</data>
-      <data key="d4">MPLS</data>
-      <data key="d7">{"vlan_range": "100-200"}</data>
-      <data key="d8">false</data>
-      <data key="d12">L2</data>
-      <data key="d11">{"primary": {"pool_id": "_", "labels": {"vlan_range": "100-200"}}}</data>
-    </node>
-    <node id="33">
-      <data key="d0">4211307c-dcbf-49dc-afe4-3915c820960a</data>
-      <data key="d1">ConnectionPoint</data>
-      <data key="d2">port+ncsa-data-sw:HundredGigE0/0/0/0</data>
-      <data key="d3">HundredGigE0/0/0/0</data>
-      <data key="d4">TrunkPort</data>
-      <data key="d6">{"bw": 100}</data>
-      <data key="d7">{"local_name": "HundredGigE0/0/0/0", "mac": "7c:f8:80:4e:85:04"}</data>
-      <data key="d8">false</data>
-      <data key="d10">{"primary": {"pool_id": "_", "capacities": {"bw": 100}}}</data>
-      <data key="d11">{"primary": {"pool_id": "_", "labels": {"mac": "7c:f8:80:4e:85:04", "local_name": "HundredGigE0/0/0/0"}}}</data>
-    </node>
-    <node id="34">
-      <data key="d0">4211307c-dcbf-49dc-afe4-3915c820960a</data>
-      <data key="d1">ConnectionPoint</data>
-      <data key="d2">port+ncsa-data-sw:HundredGigE0/0/0/1</data>
-      <data key="d3">HundredGigE0/0/0/1</data>
-      <data key="d4">TrunkPort</data>
-      <data key="d6">{"bw": 100}</data>
-      <data key="d7">{"local_name": "HundredGigE0/0/0/1", "mac": "7c:f8:80:4e:85:08"}</data>
-      <data key="d8">false</data>
-      <data key="d10">{"primary": {"pool_id": "_", "capacities": {"bw": 100}}}</data>
-      <data key="d11">{"primary": {"pool_id": "_", "labels": {"mac": "7c:f8:80:4e:85:08", "local_name": "HundredGigE0/0/0/1"}}}</data>
-    </node>
-    <node id="35">
-      <data key="d0">4211307c-dcbf-49dc-afe4-3915c820960a</data>
-      <data key="d1">ConnectionPoint</data>
-      <data key="d2">port+ncsa-data-sw:HundredGigE0/0/0/13</data>
-      <data key="d3">HundredGigE0/0/0/13</data>
-      <data key="d4">TrunkPort</data>
-      <data key="d6">{"bw": 100}</data>
-      <data key="d7">{"local_name": "HundredGigE0/0/0/13", "mac": "7c:f8:80:4e:85:38"}</data>
-      <data key="d8">false</data>
-      <data key="d10">{"primary": {"pool_id": "_", "capacities": {"bw": 100}}}</data>
-      <data key="d11">{"primary": {"pool_id": "_", "labels": {"mac": "7c:f8:80:4e:85:38", "local_name": "HundredGigE0/0/0/13"}}}</data>
-    </node>
-    <node id="36">
-      <data key="d0">4211307c-dcbf-49dc-afe4-3915c820960a</data>
-      <data key="d1">ConnectionPoint</data>
-      <data key="d2">port+ncsa-data-sw:HundredGigE0/0/0/13.200</data>
-      <data key="d3">HundredGigE0/0/0/13.200</data>
-      <data key="d4">TrunkPort</data>
-      <data key="d6">{"bw": 100}</data>
-      <data key="d7">{"local_name": "HundredGigE0/0/0/13.200", "mac": "7c:f8:80:4e:85:38"}</data>
-      <data key="d8">false</data>
-      <data key="d10">{"primary": {"pool_id": "_", "capacities": {"bw": 100}}}</data>
-      <data key="d11">{"primary": {"pool_id": "_", "labels": {"mac": "7c:f8:80:4e:85:38", "local_name": "HundredGigE0/0/0/13.200"}}}</data>
-    </node>
-    <node id="37">
-      <data key="d0">4211307c-dcbf-49dc-afe4-3915c820960a</data>
-      <data key="d1">ConnectionPoint</data>
-      <data key="d2">port+ncsa-data-sw:HundredGigE0/0/0/13.2030</data>
-      <data key="d3">HundredGigE0/0/0/13.2030</data>
-      <data key="d4">TrunkPort</data>
-      <data key="d6">{"bw": 100}</data>
-      <data key="d7">{"local_name": "HundredGigE0/0/0/13.2030", "mac": "7c:f8:80:4e:85:38"}</data>
-      <data key="d8">false</data>
-      <data key="d10">{"primary": {"pool_id": "_", "capacities": {"bw": 100}}}</data>
-      <data key="d11">{"primary": {"pool_id": "_", "labels": {"mac": "7c:f8:80:4e:85:38", "local_name": "HundredGigE0/0/0/13.2030"}}}</data>
-    </node>
-    <node id="38">
-      <data key="d0">4211307c-dcbf-49dc-afe4-3915c820960a</data>
-      <data key="d1">ConnectionPoint</data>
-      <data key="d2">port+ncsa-data-sw:HundredGigE0/0/0/13.2092</data>
-      <data key="d3">HundredGigE0/0/0/13.2092</data>
-      <data key="d4">TrunkPort</data>
-      <data key="d6">{"bw": 100}</data>
-      <data key="d7">{"local_name": "HundredGigE0/0/0/13.2092", "mac": "7c:f8:80:4e:85:38"}</data>
-      <data key="d8">false</data>
-      <data key="d10">{"primary": {"pool_id": "_", "capacities": {"bw": 100}}}</data>
-      <data key="d11">{"primary": {"pool_id": "_", "labels": {"mac": "7c:f8:80:4e:85:38", "local_name": "HundredGigE0/0/0/13.2092"}}}</data>
-    </node>
-    <node id="39">
-      <data key="d0">4211307c-dcbf-49dc-afe4-3915c820960a</data>
-      <data key="d1">ConnectionPoint</data>
-      <data key="d2">port+ncsa-data-sw:HundredGigE0/0/0/13.2104</data>
-      <data key="d3">HundredGigE0/0/0/13.2104</data>
-      <data key="d4">TrunkPort</data>
-      <data key="d6">{"bw": 100}</data>
-      <data key="d7">{"local_name": "HundredGigE0/0/0/13.2104", "mac": "7c:f8:80:4e:85:38"}</data>
-      <data key="d8">false</data>
-      <data key="d10">{"primary": {"pool_id": "_", "capacities": {"bw": 100}}}</data>
-      <data key="d11">{"primary": {"pool_id": "_", "labels": {"mac": "7c:f8:80:4e:85:38", "local_name": "HundredGigE0/0/0/13.2104"}}}</data>
-    </node>
-    <node id="40">
-      <data key="d0">4211307c-dcbf-49dc-afe4-3915c820960a</data>
-      <data key="d1">ConnectionPoint</data>
-      <data key="d2">port+ncsa-data-sw:HundredGigE0/0/0/2</data>
-      <data key="d3">HundredGigE0/0/0/2</data>
-      <data key="d4">TrunkPort</data>
-      <data key="d6">{"bw": 100}</data>
-      <data key="d7">{"local_name": "HundredGigE0/0/0/2", "mac": "7c:f8:80:4e:85:0c"}</data>
-      <data key="d8">false</data>
-      <data key="d10">{"primary": {"pool_id": "_", "capacities": {"bw": 100}}}</data>
-      <data key="d11">{"primary": {"pool_id": "_", "labels": {"mac": "7c:f8:80:4e:85:0c", "local_name": "HundredGigE0/0/0/2"}}}</data>
-    </node>
-    <node id="41">
-      <data key="d0">4211307c-dcbf-49dc-afe4-3915c820960a</data>
-      <data key="d1">ConnectionPoint</data>
-      <data key="d2">port+ncsa-data-sw:HundredGigE0/0/0/2:facility+NCSA-HPC1</data>
-      <data key="d3">NCSA-HPC1</data>
-      <data key="d4">FacilityPort</data>
-      <data key="d6" />
-      <data key="d7">{"ipv4_subnet": "123.1.2.0/24", "vlan_range": "100-200"}</data>
-      <data key="d8">false</data>
-      <data key="d11">{"primary": {"pool_id": "_", "labels": {"ipv4_subnet": "123.1.2.0/24", "vlan_range": "100-200"}}}</data>
-    </node>
-    <node id="42">
-      <data key="d0">4211307c-dcbf-49dc-afe4-3915c820960a</data>
-      <data key="d1">Link</data>
-      <data key="d2">port+ncsa-data-sw:HundredGigE0/0/0/2:facility+NCSA-HPC1-Link</data>
-      <data key="d3">NCSA-HPC1-Link</data>
-      <data key="d4">L2Path</data>
-      <data key="d8">false</data>
-      <data key="d12">L2</data>
-    </node>
-    <node id="43">
-      <data key="d0">4211307c-dcbf-49dc-afe4-3915c820960a</data>
-      <data key="d1">ConnectionPoint</data>
-      <data key="d2">port+ncsa-data-sw:HundredGigE0/0/0/22</data>
-      <data key="d3">HundredGigE0/0/0/22</data>
-      <data key="d4">TrunkPort</data>
-      <data key="d6">{"bw": 100}</data>
-      <data key="d7">{"local_name": "HundredGigE0/0/0/22", "mac": "7c:f8:80:4e:85:5c"}</data>
-      <data key="d8">false</data>
-      <data key="d10">{"primary": {"pool_id": "_", "capacities": {"bw": 100}}}</data>
-      <data key="d11">{"primary": {"pool_id": "_", "labels": {"mac": "7c:f8:80:4e:85:5c", "local_name": "HundredGigE0/0/0/22"}}}</data>
-    </node>
-    <node id="44">
-      <data key="d0">4211307c-dcbf-49dc-afe4-3915c820960a</data>
-      <data key="d1">ConnectionPoint</data>
-      <data key="d2">port+ncsa-data-sw:HundredGigE0/0/0/22.3000</data>
-      <data key="d3">HundredGigE0/0/0/22.3000</data>
-      <data key="d4">TrunkPort</data>
-      <data key="d6">{"bw": 100}</data>
-      <data key="d7">{"ipv4": "10.129.128.134", "ipv6": "2602:fcfb:3:1024::6", "local_name": "HundredGigE0/0/0/22.3000", "mac": "7c:f8:80:4e:85:5c"}</data>
-      <data key="d8">false</data>
-      <data key="d10">{"primary": {"pool_id": "_", "capacities": {"bw": 100}}}</data>
-      <data key="d11">{"primary": {"pool_id": "_", "labels": {"mac": "7c:f8:80:4e:85:5c", "ipv4": "10.129.128.134", "ipv6": "2602:fcfb:3:1024::6", "local_name": "HundredGigE0/0/0/22.3000"}}}</data>
-    </node>
-    <node id="45">
-      <data key="d0">4211307c-dcbf-49dc-afe4-3915c820960a</data>
-      <data key="d1">ConnectionPoint</data>
-      <data key="d2">port+ncsa-data-sw:HundredGigE0/0/0/23</data>
-      <data key="d3">HundredGigE0/0/0/23</data>
-      <data key="d4">TrunkPort</data>
-      <data key="d6">{"bw": 100}</data>
-      <data key="d7">{"local_name": "HundredGigE0/0/0/23", "mac": "7c:f8:80:4e:85:60"}</data>
-      <data key="d8">false</data>
-      <data key="d10">{"primary": {"pool_id": "_", "capacities": {"bw": 100}}}</data>
-      <data key="d11">{"primary": {"pool_id": "_", "labels": {"mac": "7c:f8:80:4e:85:60", "local_name": "HundredGigE0/0/0/23"}}}</data>
-    </node>
-    <node id="46">
-      <data key="d0">4211307c-dcbf-49dc-afe4-3915c820960a</data>
-      <data key="d1">ConnectionPoint</data>
-      <data key="d2">port+ncsa-data-sw:HundredGigE0/0/0/23.3710</data>
-      <data key="d3">HundredGigE0/0/0/23.3710</data>
-      <data key="d4">TrunkPort</data>
-      <data key="d6">{"bw": 100}</data>
-      <data key="d7">{"ipv4": "10.129.128.146", "local_name": "HundredGigE0/0/0/23.3710", "mac": "7c:f8:80:4e:85:60"}</data>
-      <data key="d8">false</data>
-      <data key="d10">{"primary": {"pool_id": "_", "capacities": {"bw": 100}}}</data>
-      <data key="d11">{"primary": {"pool_id": "_", "labels": {"mac": "7c:f8:80:4e:85:60", "ipv4": "10.129.128.146", "local_name": "HundredGigE0/0/0/23.3710"}}}</data>
-    </node>
-    <node id="47">
-      <data key="d0">4211307c-dcbf-49dc-afe4-3915c820960a</data>
-      <data key="d1">ConnectionPoint</data>
-      <data key="d2">port+ncsa-data-sw:HundredGigE0/0/0/3</data>
-      <data key="d3">HundredGigE0/0/0/3</data>
-      <data key="d4">TrunkPort</data>
-      <data key="d6">{"bw": 100}</data>
-      <data key="d7">{"local_name": "HundredGigE0/0/0/3", "mac": "7c:f8:80:4e:85:10"}</data>
-      <data key="d8">false</data>
-      <data key="d10">{"primary": {"pool_id": "_", "capacities": {"bw": 100}}}</data>
-      <data key="d11">{"primary": {"pool_id": "_", "labels": {"mac": "7c:f8:80:4e:85:10", "local_name": "HundredGigE0/0/0/3"}}}</data>
-    </node>
-    <node id="48">
-      <data key="d0">4211307c-dcbf-49dc-afe4-3915c820960a</data>
-      <data key="d1">ConnectionPoint</data>
-      <data key="d2">port+ncsa-data-sw:HundredGigE0/0/0/4</data>
-      <data key="d3">HundredGigE0/0/0/4</data>
-      <data key="d4">TrunkPort</data>
-      <data key="d6">{"bw": 100}</data>
-      <data key="d7">{"local_name": "HundredGigE0/0/0/4", "mac": "7c:f8:80:4e:85:14"}</data>
-      <data key="d8">false</data>
-      <data key="d10">{"primary": {"pool_id": "_", "capacities": {"bw": 100}}}</data>
-      <data key="d11">{"primary": {"pool_id": "_", "labels": {"mac": "7c:f8:80:4e:85:14", "local_name": "HundredGigE0/0/0/4"}}}</data>
-    </node>
-    <node id="49">
-      <data key="d0">4211307c-dcbf-49dc-afe4-3915c820960a</data>
-      <data key="d1">ConnectionPoint</data>
-      <data key="d2">port+ncsa-data-sw:HundredGigE0/0/0/5</data>
-      <data key="d3">HundredGigE0/0/0/5</data>
-      <data key="d4">TrunkPort</data>
-      <data key="d6">{"bw": 100}</data>
-      <data key="d7">{"local_name": "HundredGigE0/0/0/5", "mac": "7c:f8:80:4e:85:18"}</data>
-      <data key="d8">false</data>
-      <data key="d10">{"primary": {"pool_id": "_", "capacities": {"bw": 100}}}</data>
-      <data key="d11">{"primary": {"pool_id": "_", "labels": {"mac": "7c:f8:80:4e:85:18", "local_name": "HundredGigE0/0/0/5"}}}</data>
-    </node>
-    <node id="50">
-      <data key="d0">4211307c-dcbf-49dc-afe4-3915c820960a</data>
-      <data key="d1">ConnectionPoint</data>
-      <data key="d2">port+ncsa-data-sw:HundredGigE0/0/0/6</data>
-      <data key="d3">HundredGigE0/0/0/6</data>
-      <data key="d4">TrunkPort</data>
-      <data key="d6">{"bw": 100}</data>
-      <data key="d7">{"local_name": "HundredGigE0/0/0/6", "mac": "7c:f8:80:4e:85:1c"}</data>
-      <data key="d8">false</data>
-      <data key="d10">{"primary": {"pool_id": "_", "capacities": {"bw": 100}}}</data>
-      <data key="d11">{"primary": {"pool_id": "_", "labels": {"mac": "7c:f8:80:4e:85:1c", "local_name": "HundredGigE0/0/0/6"}}}</data>
-    </node>
-    <node id="51">
-      <data key="d0">4211307c-dcbf-49dc-afe4-3915c820960a</data>
-      <data key="d1">ConnectionPoint</data>
-      <data key="d2">port+ncsa-data-sw:HundredGigE0/0/0/9</data>
-      <data key="d3">HundredGigE0/0/0/9</data>
-      <data key="d4">TrunkPort</data>
-      <data key="d6">{"bw": 100}</data>
-      <data key="d7">{"local_name": "HundredGigE0/0/0/9", "mac": "7c:f8:80:4e:85:28"}</data>
-      <data key="d8">false</data>
-      <data key="d10">{"primary": {"pool_id": "_", "capacities": {"bw": 100}}}</data>
-      <data key="d11">{"primary": {"pool_id": "_", "labels": {"mac": "7c:f8:80:4e:85:28", "local_name": "HundredGigE0/0/0/9"}}}</data>
-    </node>
-    <node id="52">
-      <data key="d0">4211307c-dcbf-49dc-afe4-3915c820960a</data>
-      <data key="d1">ConnectionPoint</data>
-      <data key="d2">port+ncsa-data-sw:HundredGigE0/0/0/9.200</data>
-      <data key="d3">HundredGigE0/0/0/9.200</data>
-      <data key="d4">TrunkPort</data>
-      <data key="d6">{"bw": 100}</data>
-      <data key="d7">{"local_name": "HundredGigE0/0/0/9.200", "mac": "7c:f8:80:4e:85:28"}</data>
-      <data key="d8">false</data>
-      <data key="d10">{"primary": {"pool_id": "_", "capacities": {"bw": 100}}}</data>
-      <data key="d11">{"primary": {"pool_id": "_", "labels": {"mac": "7c:f8:80:4e:85:28", "local_name": "HundredGigE0/0/0/9.200"}}}</data>
-    </node>
-    <node id="53">
-      <data key="d0">4211307c-dcbf-49dc-afe4-3915c820960a</data>
-      <data key="d1">ConnectionPoint</data>
-      <data key="d2">port+ncsa-data-sw:TwentyFiveGigE0/0/0/10/0</data>
-      <data key="d3">TwentyFiveGigE0/0/0/10/0</data>
-      <data key="d4">TrunkPort</data>
-      <data key="d6">{"bw": 25}</data>
-      <data key="d7">{"local_name": "TwentyFiveGigE0/0/0/10/0", "mac": "7c:f8:80:4e:85:2c"}</data>
-      <data key="d8">false</data>
-      <data key="d10">{"primary": {"pool_id": "_", "capacities": {"bw": 25}}}</data>
-      <data key="d11">{"primary": {"pool_id": "_", "labels": {"mac": "7c:f8:80:4e:85:2c", "local_name": "TwentyFiveGigE0/0/0/10/0"}}}</data>
-    </node>
-    <node id="54">
-      <data key="d0">4211307c-dcbf-49dc-afe4-3915c820960a</data>
-      <data key="d1">ConnectionPoint</data>
-      <data key="d2">port+ncsa-data-sw:TwentyFiveGigE0/0/0/10/1</data>
-      <data key="d3">TwentyFiveGigE0/0/0/10/1</data>
-      <data key="d4">TrunkPort</data>
-      <data key="d6">{"bw": 25}</data>
-      <data key="d7">{"local_name": "TwentyFiveGigE0/0/0/10/1", "mac": "7c:f8:80:4e:85:2d"}</data>
-      <data key="d8">false</data>
-      <data key="d10">{"primary": {"pool_id": "_", "capacities": {"bw": 25}}}</data>
-      <data key="d11">{"primary": {"pool_id": "_", "labels": {"mac": "7c:f8:80:4e:85:2d", "local_name": "TwentyFiveGigE0/0/0/10/1"}}}</data>
-    </node>
-    <node id="55">
-      <data key="d0">4211307c-dcbf-49dc-afe4-3915c820960a</data>
-      <data key="d1">ConnectionPoint</data>
-      <data key="d2">port+ncsa-data-sw:TwentyFiveGigE0/0/0/10/2</data>
-      <data key="d3">TwentyFiveGigE0/0/0/10/2</data>
-      <data key="d4">TrunkPort</data>
-      <data key="d6">{"bw": 25}</data>
-      <data key="d7">{"local_name": "TwentyFiveGigE0/0/0/10/2", "mac": "7c:f8:80:4e:85:2e"}</data>
-      <data key="d8">false</data>
-      <data key="d10">{"primary": {"pool_id": "_", "capacities": {"bw": 25}}}</data>
-      <data key="d11">{"primary": {"pool_id": "_", "labels": {"mac": "7c:f8:80:4e:85:2e", "local_name": "TwentyFiveGigE0/0/0/10/2"}}}</data>
-    </node>
-    <node id="56">
-      <data key="d0">4211307c-dcbf-49dc-afe4-3915c820960a</data>
-      <data key="d1">ConnectionPoint</data>
-      <data key="d2">port+ncsa-data-sw:TwentyFiveGigE0/0/0/10/3</data>
-      <data key="d3">TwentyFiveGigE0/0/0/10/3</data>
-      <data key="d4">TrunkPort</data>
-      <data key="d6">{"bw": 25}</data>
-      <data key="d7">{"local_name": "TwentyFiveGigE0/0/0/10/3", "mac": "7c:f8:80:4e:85:2f"}</data>
-      <data key="d8">false</data>
-      <data key="d10">{"primary": {"pool_id": "_", "capacities": {"bw": 25}}}</data>
-      <data key="d11">{"primary": {"pool_id": "_", "labels": {"mac": "7c:f8:80:4e:85:2f", "local_name": "TwentyFiveGigE0/0/0/10/3"}}}</data>
-    </node>
-    <node id="57">
-      <data key="d0">4211307c-dcbf-49dc-afe4-3915c820960a</data>
+    <node id="672">
+      <data key="d0">e0bd5e07-fa2b-4aa7-9ccf-e1e1965db808</data>
       <data key="d1">NetworkNode</data>
       <data key="d2">node+renc-data-sw:ip+192.168.11.3</data>
       <data key="d3">renc-data-sw</data>
       <data key="d4">Switch</data>
       <data key="d5">NCS 55A1-36H</data>
-      <data key="d6">{"unit": 1}</data>
-      <data key="d7">{"ipv4": "192.168.11.3", "local_name": "renc-data-sw"}</data>
-      <data key="d8">false</data>
-      <data key="d9">RENC</data>
-      <data key="d10">{"primary": {"pool_id": "_", "capacities": {"unit": 1}}}</data>
-      <data key="d11">{"primary": {"pool_id": "_", "labels": {"ipv4": "192.168.11.3", "local_name": "renc-data-sw"}}}</data>
+      <data key="d6">false</data>
+      <data key="d7">RENC</data>
     </node>
-    <node id="58">
-      <data key="d0">4211307c-dcbf-49dc-afe4-3915c820960a</data>
-      <data key="d1">NetworkService</data>
-      <data key="d2">node+renc-data-sw:ip+192.168.11.3-ipv4-ns</data>
-      <data key="d3">renc-data-sw-ipv4-ns</data>
-      <data key="d4">FABNetv4</data>
-      <data key="d7">{"ipv4_subnet": "10.128.0.0/17", "vlan_range": "201-400"}</data>
-      <data key="d8">false</data>
-      <data key="d12">L3</data>
-      <data key="d11">{"primary": {"pool_id": "_", "labels": {"ipv4_subnet": "10.128.0.0/17", "vlan_range": "201-400"}}}</data>
-    </node>
-    <node id="59">
-      <data key="d0">4211307c-dcbf-49dc-afe4-3915c820960a</data>
-      <data key="d1">NetworkService</data>
-      <data key="d2">node+renc-data-sw:ip+192.168.11.3-ipv6-ns</data>
-      <data key="d3">renc-data-sw-ipv6-ns</data>
-      <data key="d4">FABNetv6</data>
-      <data key="d7">{"ipv6_subnet": "2602:fcfb::/48", "vlan_range": "201-400"}</data>
-      <data key="d8">false</data>
-      <data key="d12">L3</data>
-      <data key="d11">{"primary": {"pool_id": "_", "labels": {"ipv6_subnet": "2602:fcfb::/48", "vlan_range": "201-400"}}}</data>
-    </node>
-    <node id="60">
-      <data key="d0">4211307c-dcbf-49dc-afe4-3915c820960a</data>
+    <node id="673">
+      <data key="d0">e0bd5e07-fa2b-4aa7-9ccf-e1e1965db808</data>
       <data key="d1">NetworkService</data>
       <data key="d2">node+renc-data-sw:ip+192.168.11.3-ns</data>
       <data key="d3">renc-data-sw-ns</data>
       <data key="d4">MPLS</data>
-      <data key="d7">{"vlan_range": "100-200"}</data>
-      <data key="d8">false</data>
-      <data key="d12">L2</data>
-      <data key="d11">{"primary": {"pool_id": "_", "labels": {"vlan_range": "100-200"}}}</data>
+      <data key="d8">{"vlan_range": "1-100"}</data>
+      <data key="d6">false</data>
+      <data key="d9">L2</data>
+      <data key="d10">{"primary": {"pool_id": "_", "labels": {"vlan_range": "1-100"}}}</data>
     </node>
-    <node id="61">
-      <data key="d0">4211307c-dcbf-49dc-afe4-3915c820960a</data>
-      <data key="d1">ConnectionPoint</data>
-      <data key="d2">port+renc-data-sw:HundredGigE0/0/0/1</data>
-      <data key="d3">HundredGigE0/0/0/1</data>
-      <data key="d4">TrunkPort</data>
-      <data key="d6">{"bw": 100}</data>
-      <data key="d7">{"local_name": "HundredGigE0/0/0/1", "mac": "94:ae:f0:dd:9c:04"}</data>
-      <data key="d8">false</data>
-      <data key="d10">{"primary": {"pool_id": "_", "capacities": {"bw": 100}}}</data>
-      <data key="d11">{"primary": {"pool_id": "_", "labels": {"mac": "94:ae:f0:dd:9c:04", "local_name": "HundredGigE0/0/0/1"}}}</data>
+    <node id="674">
+      <data key="d0">e0bd5e07-fa2b-4aa7-9ccf-e1e1965db808</data>
+      <data key="d1">NetworkService</data>
+      <data key="d2">node+renc-data-sw:ip+192.168.11.3-l3ns</data>
+      <data key="d3">renc-data-sw-l3ns</data>
+      <data key="d4">FABNetv4</data>
+      <data key="d8">{"ipv4_range": "192.168.1.1-192.168.1.255", "vlan_range": "100-200"}</data>
+      <data key="d6">false</data>
+      <data key="d9">L3</data>
+      <data key="d10">{"primary": {"pool_id": "_", "labels": {"ipv4_range": "192.168.1.1-192.168.1.255", "vlan_range": "100-200"}}}</data>
     </node>
-    <node id="62">
-      <data key="d0">4211307c-dcbf-49dc-afe4-3915c820960a</data>
-      <data key="d1">ConnectionPoint</data>
-      <data key="d2">port+renc-data-sw:HundredGigE0/0/0/1:facility+RENC-HPC1</data>
-      <data key="d3">RENC-HPC1</data>
-      <data key="d4">FacilityPort</data>
-      <data key="d6" />
-      <data key="d7">{"ipv4_subnet": "123.1.2.0/24", "vlan_range": "100-200"}</data>
-      <data key="d8">false</data>
-      <data key="d11">{"primary": {"pool_id": "_", "labels": {"ipv4_subnet": "123.1.2.0/24", "vlan_range": "100-200"}}}</data>
-    </node>
-    <node id="63">
-      <data key="d0">4211307c-dcbf-49dc-afe4-3915c820960a</data>
-      <data key="d1">Link</data>
-      <data key="d2">port+renc-data-sw:HundredGigE0/0/0/1:facility+RENC-HPC1-Link</data>
-      <data key="d3">RENC-HPC1-Link</data>
-      <data key="d4">L2Path</data>
-      <data key="d8">false</data>
-      <data key="d12">L2</data>
-    </node>
-    <node id="64">
-      <data key="d0">4211307c-dcbf-49dc-afe4-3915c820960a</data>
-      <data key="d1">ConnectionPoint</data>
-      <data key="d2">port+renc-data-sw:HundredGigE0/0/0/13</data>
-      <data key="d3">HundredGigE0/0/0/13</data>
-      <data key="d4">TrunkPort</data>
-      <data key="d6">{"bw": 100}</data>
-      <data key="d7">{"local_name": "HundredGigE0/0/0/13", "mac": "94:ae:f0:dd:9c:34"}</data>
-      <data key="d8">false</data>
-      <data key="d10">{"primary": {"pool_id": "_", "capacities": {"bw": 100}}}</data>
-      <data key="d11">{"primary": {"pool_id": "_", "labels": {"mac": "94:ae:f0:dd:9c:34", "local_name": "HundredGigE0/0/0/13"}}}</data>
-    </node>
-    <node id="65">
-      <data key="d0">4211307c-dcbf-49dc-afe4-3915c820960a</data>
-      <data key="d1">ConnectionPoint</data>
-      <data key="d2">port+renc-data-sw:HundredGigE0/0/0/15</data>
-      <data key="d3">HundredGigE0/0/0/15</data>
-      <data key="d4">TrunkPort</data>
-      <data key="d6">{"bw": 100}</data>
-      <data key="d7">{"local_name": "HundredGigE0/0/0/15", "mac": "94:ae:f0:dd:9c:3c"}</data>
-      <data key="d8">false</data>
-      <data key="d10">{"primary": {"pool_id": "_", "capacities": {"bw": 100}}}</data>
-      <data key="d11">{"primary": {"pool_id": "_", "labels": {"mac": "94:ae:f0:dd:9c:3c", "local_name": "HundredGigE0/0/0/15"}}}</data>
-    </node>
-    <node id="66">
-      <data key="d0">4211307c-dcbf-49dc-afe4-3915c820960a</data>
-      <data key="d1">ConnectionPoint</data>
-      <data key="d2">port+renc-data-sw:HundredGigE0/0/0/17</data>
-      <data key="d3">HundredGigE0/0/0/17</data>
-      <data key="d4">TrunkPort</data>
-      <data key="d6">{"bw": 100}</data>
-      <data key="d7">{"local_name": "HundredGigE0/0/0/17", "mac": "94:ae:f0:dd:9c:44"}</data>
-      <data key="d8">false</data>
-      <data key="d10">{"primary": {"pool_id": "_", "capacities": {"bw": 100}}}</data>
-      <data key="d11">{"primary": {"pool_id": "_", "labels": {"mac": "94:ae:f0:dd:9c:44", "local_name": "HundredGigE0/0/0/17"}}}</data>
-    </node>
-    <node id="67">
-      <data key="d0">4211307c-dcbf-49dc-afe4-3915c820960a</data>
-      <data key="d1">ConnectionPoint</data>
-      <data key="d2">port+renc-data-sw:HundredGigE0/0/0/19</data>
-      <data key="d3">HundredGigE0/0/0/19</data>
-      <data key="d4">TrunkPort</data>
-      <data key="d6">{"bw": 100}</data>
-      <data key="d7">{"local_name": "HundredGigE0/0/0/19", "mac": "94:ae:f0:dd:9c:4c"}</data>
-      <data key="d8">false</data>
-      <data key="d10">{"primary": {"pool_id": "_", "capacities": {"bw": 100}}}</data>
-      <data key="d11">{"primary": {"pool_id": "_", "labels": {"mac": "94:ae:f0:dd:9c:4c", "local_name": "HundredGigE0/0/0/19"}}}</data>
-    </node>
-    <node id="68">
-      <data key="d0">4211307c-dcbf-49dc-afe4-3915c820960a</data>
-      <data key="d1">ConnectionPoint</data>
-      <data key="d2">port+renc-data-sw:HundredGigE0/0/0/21</data>
-      <data key="d3">HundredGigE0/0/0/21</data>
-      <data key="d4">TrunkPort</data>
-      <data key="d6">{"bw": 100}</data>
-      <data key="d7">{"local_name": "HundredGigE0/0/0/21", "mac": "94:ae:f0:dd:9c:54"}</data>
-      <data key="d8">false</data>
-      <data key="d10">{"primary": {"pool_id": "_", "capacities": {"bw": 100}}}</data>
-      <data key="d11">{"primary": {"pool_id": "_", "labels": {"mac": "94:ae:f0:dd:9c:54", "local_name": "HundredGigE0/0/0/21"}}}</data>
-    </node>
-    <node id="69">
-      <data key="d0">4211307c-dcbf-49dc-afe4-3915c820960a</data>
-      <data key="d1">ConnectionPoint</data>
-      <data key="d2">port+renc-data-sw:HundredGigE0/0/0/3</data>
-      <data key="d3">HundredGigE0/0/0/3</data>
-      <data key="d4">TrunkPort</data>
-      <data key="d6">{"bw": 100}</data>
-      <data key="d7">{"local_name": "HundredGigE0/0/0/3", "mac": "94:ae:f0:dd:9c:0c"}</data>
-      <data key="d8">false</data>
-      <data key="d10">{"primary": {"pool_id": "_", "capacities": {"bw": 100}}}</data>
-      <data key="d11">{"primary": {"pool_id": "_", "labels": {"mac": "94:ae:f0:dd:9c:0c", "local_name": "HundredGigE0/0/0/3"}}}</data>
-    </node>
-    <node id="70">
-      <data key="d0">4211307c-dcbf-49dc-afe4-3915c820960a</data>
+    <node id="675">
+      <data key="d0">e0bd5e07-fa2b-4aa7-9ccf-e1e1965db808</data>
       <data key="d1">ConnectionPoint</data>
       <data key="d2">port+renc-data-sw:HundredGigE0/0/0/5</data>
       <data key="d3">HundredGigE0/0/0/5</data>
       <data key="d4">TrunkPort</data>
-      <data key="d6">{"bw": 100}</data>
-      <data key="d7">{"local_name": "HundredGigE0/0/0/5", "mac": "94:ae:f0:dd:9c:14"}</data>
-      <data key="d8">false</data>
-      <data key="d10">{"primary": {"pool_id": "_", "capacities": {"bw": 100}}}</data>
-      <data key="d11">{"primary": {"pool_id": "_", "labels": {"mac": "94:ae:f0:dd:9c:14", "local_name": "HundredGigE0/0/0/5"}}}</data>
+      <data key="d11">{"bw": 100}</data>
+      <data key="d8">{"vlan_range": "1-4096"}</data>
+      <data key="d6">false</data>
+      <data key="d12">{"primary": {"pool_id": "_", "capacities": {"bw": 100}}}</data>
+      <data key="d10">{"primary": {"pool_id": "_", "labels": {"vlan_range": "1-4096"}}}</data>
     </node>
-    <node id="71">
-      <data key="d0">4211307c-dcbf-49dc-afe4-3915c820960a</data>
+    <node id="676">
+      <data key="d0">e0bd5e07-fa2b-4aa7-9ccf-e1e1965db808</data>
+      <data key="d1">ConnectionPoint</data>
+      <data key="d2">port+renc-data-sw:HundredGigE0/0/0/13</data>
+      <data key="d3">HundredGigE0/0/0/13</data>
+      <data key="d4">TrunkPort</data>
+      <data key="d11">{"bw": 100}</data>
+      <data key="d8">{"vlan_range": "1-4096"}</data>
+      <data key="d6">false</data>
+      <data key="d12">{"primary": {"pool_id": "_", "capacities": {"bw": 100}}}</data>
+      <data key="d10">{"primary": {"pool_id": "_", "labels": {"vlan_range": "1-4096"}}}</data>
+    </node>
+    <node id="677">
+      <data key="d0">e0bd5e07-fa2b-4aa7-9ccf-e1e1965db808</data>
+      <data key="d1">ConnectionPoint</data>
+      <data key="d2">port+renc-data-sw:HundredGigE0/0/0/15</data>
+      <data key="d3">HundredGigE0/0/0/15</data>
+      <data key="d4">TrunkPort</data>
+      <data key="d11">{"bw": 100}</data>
+      <data key="d8">{"vlan_range": "1-4096"}</data>
+      <data key="d6">false</data>
+      <data key="d12">{"primary": {"pool_id": "_", "capacities": {"bw": 100}}}</data>
+      <data key="d10">{"primary": {"pool_id": "_", "labels": {"vlan_range": "1-4096"}}}</data>
+    </node>
+    <node id="678">
+      <data key="d0">e0bd5e07-fa2b-4aa7-9ccf-e1e1965db808</data>
       <data key="d1">ConnectionPoint</data>
       <data key="d2">port+renc-data-sw:HundredGigE0/0/0/9</data>
       <data key="d3">HundredGigE0/0/0/9</data>
       <data key="d4">TrunkPort</data>
-      <data key="d6">{"bw": 100}</data>
-      <data key="d7">{"local_name": "HundredGigE0/0/0/9", "mac": "94:ae:f0:dd:9c:24"}</data>
-      <data key="d8">false</data>
-      <data key="d10">{"primary": {"pool_id": "_", "capacities": {"bw": 100}}}</data>
-      <data key="d11">{"primary": {"pool_id": "_", "labels": {"mac": "94:ae:f0:dd:9c:24", "local_name": "HundredGigE0/0/0/9"}}}</data>
+      <data key="d11">{"bw": 100}</data>
+      <data key="d8">{"vlan_range": "1-4096"}</data>
+      <data key="d6">false</data>
+      <data key="d12">{"primary": {"pool_id": "_", "capacities": {"bw": 100}}}</data>
+      <data key="d10">{"primary": {"pool_id": "_", "labels": {"vlan_range": "1-4096"}}}</data>
     </node>
-    <node id="72">
-      <data key="d0">4211307c-dcbf-49dc-afe4-3915c820960a</data>
+    <node id="679">
+      <data key="d0">e0bd5e07-fa2b-4aa7-9ccf-e1e1965db808</data>
       <data key="d1">ConnectionPoint</data>
-      <data key="d2">port+renc-data-sw:HundredGigE0/0/0/9.2092</data>
-      <data key="d3">HundredGigE0/0/0/9.2092</data>
+      <data key="d2">port+renc-data-sw:HundredGigE0/0/0/17</data>
+      <data key="d3">HundredGigE0/0/0/17</data>
       <data key="d4">TrunkPort</data>
-      <data key="d6">{"bw": 100}</data>
-      <data key="d7">{"local_name": "HundredGigE0/0/0/9.2092", "mac": "94:ae:f0:dd:9c:24"}</data>
-      <data key="d8">false</data>
-      <data key="d10">{"primary": {"pool_id": "_", "capacities": {"bw": 100}}}</data>
-      <data key="d11">{"primary": {"pool_id": "_", "labels": {"mac": "94:ae:f0:dd:9c:24", "local_name": "HundredGigE0/0/0/9.2092"}}}</data>
+      <data key="d11">{"bw": 100}</data>
+      <data key="d8">{"vlan_range": "1-4096"}</data>
+      <data key="d6">false</data>
+      <data key="d12">{"primary": {"pool_id": "_", "capacities": {"bw": 100}}}</data>
+      <data key="d10">{"primary": {"pool_id": "_", "labels": {"vlan_range": "1-4096"}}}</data>
     </node>
-    <node id="73">
-      <data key="d0">4211307c-dcbf-49dc-afe4-3915c820960a</data>
+    <node id="680">
+      <data key="d0">e0bd5e07-fa2b-4aa7-9ccf-e1e1965db808</data>
       <data key="d1">ConnectionPoint</data>
-      <data key="d2">port+renc-data-sw:HundredGigE0/0/0/9.2095</data>
-      <data key="d3">HundredGigE0/0/0/9.2095</data>
+      <data key="d2">port+renc-data-sw:HundredGigE0/0/0/19</data>
+      <data key="d3">HundredGigE0/0/0/19</data>
       <data key="d4">TrunkPort</data>
-      <data key="d6">{"bw": 100}</data>
-      <data key="d7">{"local_name": "HundredGigE0/0/0/9.2095", "mac": "94:ae:f0:dd:9c:24"}</data>
-      <data key="d8">false</data>
-      <data key="d10">{"primary": {"pool_id": "_", "capacities": {"bw": 100}}}</data>
-      <data key="d11">{"primary": {"pool_id": "_", "labels": {"mac": "94:ae:f0:dd:9c:24", "local_name": "HundredGigE0/0/0/9.2095"}}}</data>
+      <data key="d11">{"bw": 100}</data>
+      <data key="d8">{"vlan_range": "1-4096"}</data>
+      <data key="d6">false</data>
+      <data key="d12">{"primary": {"pool_id": "_", "capacities": {"bw": 100}}}</data>
+      <data key="d10">{"primary": {"pool_id": "_", "labels": {"vlan_range": "1-4096"}}}</data>
     </node>
-    <node id="74">
-      <data key="d0">4211307c-dcbf-49dc-afe4-3915c820960a</data>
+    <node id="681">
+      <data key="d0">e0bd5e07-fa2b-4aa7-9ccf-e1e1965db808</data>
       <data key="d1">ConnectionPoint</data>
-      <data key="d2">port+renc-data-sw:TenGigE0/0/0/2/0</data>
-      <data key="d3">TenGigE0/0/0/2/0</data>
+      <data key="d2">port+renc-data-sw:HundredGigE0/0/0/21</data>
+      <data key="d3">HundredGigE0/0/0/21</data>
       <data key="d4">TrunkPort</data>
-      <data key="d6">{"bw": 10}</data>
-      <data key="d7">{"local_name": "TenGigE0/0/0/2/0", "mac": "94:ae:f0:dd:9c:08"}</data>
-      <data key="d8">false</data>
-      <data key="d10">{"primary": {"pool_id": "_", "capacities": {"bw": 10}}}</data>
-      <data key="d11">{"primary": {"pool_id": "_", "labels": {"mac": "94:ae:f0:dd:9c:08", "local_name": "TenGigE0/0/0/2/0"}}}</data>
+      <data key="d11">{"bw": 100}</data>
+      <data key="d8">{"vlan_range": "1-4096"}</data>
+      <data key="d6">false</data>
+      <data key="d12">{"primary": {"pool_id": "_", "capacities": {"bw": 100}}}</data>
+      <data key="d10">{"primary": {"pool_id": "_", "labels": {"vlan_range": "1-4096"}}}</data>
     </node>
-    <node id="75">
-      <data key="d0">4211307c-dcbf-49dc-afe4-3915c820960a</data>
+    <node id="682">
+      <data key="d0">e0bd5e07-fa2b-4aa7-9ccf-e1e1965db808</data>
       <data key="d1">ConnectionPoint</data>
-      <data key="d2">port+renc-data-sw:TenGigE0/0/0/2/0.3981</data>
-      <data key="d3">TenGigE0/0/0/2/0.3981</data>
+      <data key="d2">port+renc-data-sw:HundredDigE0/0/0/99</data>
+      <data key="d3">HundredDigE0/0/0/99</data>
       <data key="d4">TrunkPort</data>
-      <data key="d6">{"bw": 10}</data>
-      <data key="d7">{"ipv4": "10.128.0.133", "ipv6": "2602:fcfb:0:1024::5", "local_name": "TenGigE0/0/0/2/0.3981", "mac": "94:ae:f0:dd:9c:08"}</data>
-      <data key="d8">false</data>
-      <data key="d10">{"primary": {"pool_id": "_", "capacities": {"bw": 10}}}</data>
-      <data key="d11">{"primary": {"pool_id": "_", "labels": {"mac": "94:ae:f0:dd:9c:08", "ipv4": "10.128.0.133", "ipv6": "2602:fcfb:0:1024::5", "local_name": "TenGigE0/0/0/2/0.3981"}}}</data>
+      <data key="d11">{"bw": 100}</data>
+      <data key="d8">{"vlan_range": "1-4096"}</data>
+      <data key="d6">false</data>
+      <data key="d12">{"primary": {"pool_id": "_", "capacities": {"bw": 100}}}</data>
+      <data key="d10">{"primary": {"pool_id": "_", "labels": {"vlan_range": "1-4096"}}}</data>
     </node>
-    <node id="76">
-      <data key="d0">4211307c-dcbf-49dc-afe4-3915c820960a</data>
+    <node id="683">
+      <data key="d0">e0bd5e07-fa2b-4aa7-9ccf-e1e1965db808</data>
       <data key="d1">ConnectionPoint</data>
-      <data key="d2">port+renc-data-sw:TenGigE0/0/0/2/0.3999</data>
-      <data key="d3">TenGigE0/0/0/2/0.3999</data>
+      <data key="d2">port+renc-data-sw:HundredGigE0/0/0/25.1</data>
+      <data key="d3">HundredGigE0/0/0/25.1</data>
       <data key="d4">TrunkPort</data>
-      <data key="d6">{"bw": 10}</data>
-      <data key="d7">{"ipv4": "10.128.0.129", "ipv6": "2602:fcfb:0:1024::1", "local_name": "TenGigE0/0/0/2/0.3999", "mac": "94:ae:f0:dd:9c:08"}</data>
-      <data key="d8">false</data>
-      <data key="d10">{"primary": {"pool_id": "_", "capacities": {"bw": 10}}}</data>
-      <data key="d11">{"primary": {"pool_id": "_", "labels": {"mac": "94:ae:f0:dd:9c:08", "ipv4": "10.128.0.129", "ipv6": "2602:fcfb:0:1024::1", "local_name": "TenGigE0/0/0/2/0.3999"}}}</data>
+      <data key="d11">{"bw": 25}</data>
+      <data key="d8">{"vlan_range": "1-4096"}</data>
+      <data key="d6">false</data>
+      <data key="d12">{"primary": {"pool_id": "_", "capacities": {"bw": 25}}}</data>
+      <data key="d10">{"primary": {"pool_id": "_", "labels": {"vlan_range": "1-4096"}}}</data>
     </node>
-    <node id="77">
-      <data key="d0">4211307c-dcbf-49dc-afe4-3915c820960a</data>
+    <node id="684">
+      <data key="d0">e0bd5e07-fa2b-4aa7-9ccf-e1e1965db808</data>
+      <data key="d1">ConnectionPoint</data>
+      <data key="d2">port+renc-data-sw:HundredGigE0/0/0/25.2</data>
+      <data key="d3">HundredGigE0/0/0/25.2</data>
+      <data key="d4">TrunkPort</data>
+      <data key="d11">{"bw": 25}</data>
+      <data key="d8">{"vlan_range": "1-4096"}</data>
+      <data key="d6">false</data>
+      <data key="d12">{"primary": {"pool_id": "_", "capacities": {"bw": 25}}}</data>
+      <data key="d10">{"primary": {"pool_id": "_", "labels": {"vlan_range": "1-4096"}}}</data>
+    </node>
+    <node id="685">
+      <data key="d0">e0bd5e07-fa2b-4aa7-9ccf-e1e1965db808</data>
+      <data key="d1">ConnectionPoint</data>
+      <data key="d2">port+renc-data-sw:HundredGigE0/0/0/25.3</data>
+      <data key="d3">HundredGigE0/0/0/25.3</data>
+      <data key="d4">TrunkPort</data>
+      <data key="d11">{"bw": 25}</data>
+      <data key="d8">{"vlan_range": "1-4096"}</data>
+      <data key="d6">false</data>
+      <data key="d12">{"primary": {"pool_id": "_", "capacities": {"bw": 25}}}</data>
+      <data key="d10">{"primary": {"pool_id": "_", "labels": {"vlan_range": "1-4096"}}}</data>
+    </node>
+    <node id="686">
+      <data key="d0">e0bd5e07-fa2b-4aa7-9ccf-e1e1965db808</data>
+      <data key="d1">ConnectionPoint</data>
+      <data key="d2">port+renc-data-sw:HundredGigE0/0/0/25.4</data>
+      <data key="d3">HundredGigE0/0/0/25.4</data>
+      <data key="d4">TrunkPort</data>
+      <data key="d11">{"bw": 25}</data>
+      <data key="d8">{"vlan_range": "1-4096"}</data>
+      <data key="d6">false</data>
+      <data key="d12">{"primary": {"pool_id": "_", "capacities": {"bw": 25}}}</data>
+      <data key="d10">{"primary": {"pool_id": "_", "labels": {"vlan_range": "1-4096"}}}</data>
+    </node>
+    <node id="687">
+      <data key="d0">e0bd5e07-fa2b-4aa7-9ccf-e1e1965db808</data>
+      <data key="d1">ConnectionPoint</data>
+      <data key="d2">port+renc-data-sw:HundredGigE0/0/0/26</data>
+      <data key="d3">HundredGigE0/0/0/26</data>
+      <data key="d4">TrunkPort</data>
+      <data key="d11">{"bw": 100}</data>
+      <data key="d6">false</data>
+      <data key="d12">{"primary": {"pool_id": "_", "capacities": {"bw": 100}}}</data>
+    </node>
+    <node id="688">
+      <data key="d0">e0bd5e07-fa2b-4aa7-9ccf-e1e1965db808</data>
+      <data key="d1">ConnectionPoint</data>
+      <data key="d2">port+renc-data-sw:HundredGigE0/0/0/27</data>
+      <data key="d3">HundredGigE0/0/0/27</data>
+      <data key="d4">TrunkPort</data>
+      <data key="d11">{"bw": 100}</data>
+      <data key="d6">false</data>
+      <data key="d12">{"primary": {"pool_id": "_", "capacities": {"bw": 100}}}</data>
+    </node>
+    <node id="689">
+      <data key="d0">e0bd5e07-fa2b-4aa7-9ccf-e1e1965db808</data>
       <data key="d1">NetworkNode</data>
       <data key="d2">node+uky-data-sw:ip+192.168.12.3</data>
       <data key="d3">uky-data-sw</data>
       <data key="d4">Switch</data>
       <data key="d5">NCS 55A1-36H</data>
-      <data key="d6">{"unit": 1}</data>
-      <data key="d7">{"ipv4": "192.168.12.3", "local_name": "uky-data-sw"}</data>
-      <data key="d8">false</data>
-      <data key="d9">UKY</data>
-      <data key="d10">{"primary": {"pool_id": "_", "capacities": {"unit": 1}}}</data>
-      <data key="d11">{"primary": {"pool_id": "_", "labels": {"ipv4": "192.168.12.3", "local_name": "uky-data-sw"}}}</data>
+      <data key="d6">false</data>
+      <data key="d7">UKY</data>
     </node>
-    <node id="78">
-      <data key="d0">4211307c-dcbf-49dc-afe4-3915c820960a</data>
-      <data key="d1">NetworkService</data>
-      <data key="d2">node+uky-data-sw:ip+192.168.12.3-ipv4-ns</data>
-      <data key="d3">uky-data-sw-ipv4-ns</data>
-      <data key="d4">FABNetv4</data>
-      <data key="d7">{"ipv4_subnet": "10.128.128.0/17"}</data>
-      <data key="d8">false</data>
-      <data key="d12">L3</data>
-      <data key="d11">{"primary": {"pool_id": "_", "labels": {"ipv4_subnet": "10.128.128.0/17"}}}</data>
-    </node>
-    <node id="79">
-      <data key="d0">4211307c-dcbf-49dc-afe4-3915c820960a</data>
-      <data key="d1">NetworkService</data>
-      <data key="d2">node+uky-data-sw:ip+192.168.12.3-ipv6-ns</data>
-      <data key="d3">uky-data-sw-ipv6-ns</data>
-      <data key="d4">FABNetv6</data>
-      <data key="d7">{"ipv6_subnet": "2602:fcfb:1::/48"}</data>
-      <data key="d8">false</data>
-      <data key="d12">L3</data>
-      <data key="d11">{"primary": {"pool_id": "_", "labels": {"ipv6_subnet": "2602:fcfb:1::/48"}}}</data>
-    </node>
-    <node id="80">
-      <data key="d0">4211307c-dcbf-49dc-afe4-3915c820960a</data>
+    <node id="690">
+      <data key="d0">e0bd5e07-fa2b-4aa7-9ccf-e1e1965db808</data>
       <data key="d1">NetworkService</data>
       <data key="d2">node+uky-data-sw:ip+192.168.12.3-ns</data>
       <data key="d3">uky-data-sw-ns</data>
       <data key="d4">MPLS</data>
-      <data key="d7" />
-      <data key="d8">false</data>
-      <data key="d12">L2</data>
+      <data key="d8">{"vlan_range": "1-100"}</data>
+      <data key="d6">false</data>
+      <data key="d9">L2</data>
+      <data key="d10">{"primary": {"pool_id": "_", "labels": {"vlan_range": "1-100"}}}</data>
     </node>
-    <node id="81">
-      <data key="d0">4211307c-dcbf-49dc-afe4-3915c820960a</data>
-      <data key="d1">ConnectionPoint</data>
-      <data key="d2">port+uky-data-sw:HundredGigE0/0/0/0</data>
-      <data key="d3">HundredGigE0/0/0/0</data>
-      <data key="d4">TrunkPort</data>
-      <data key="d6">{"bw": 100}</data>
-      <data key="d7">{"local_name": "HundredGigE0/0/0/0", "mac": "94:ae:f0:e3:58:00"}</data>
-      <data key="d8">false</data>
-      <data key="d10">{"primary": {"pool_id": "_", "capacities": {"bw": 100}}}</data>
-      <data key="d11">{"primary": {"pool_id": "_", "labels": {"mac": "94:ae:f0:e3:58:00", "local_name": "HundredGigE0/0/0/0"}}}</data>
+    <node id="691">
+      <data key="d0">e0bd5e07-fa2b-4aa7-9ccf-e1e1965db808</data>
+      <data key="d1">NetworkService</data>
+      <data key="d2">node+uky-data-sw:ip+192.168.12.3-l3ns</data>
+      <data key="d3">uky-data-sw-l3ns</data>
+      <data key="d4">FABNetv4</data>
+      <data key="d8">{"ipv4_range": "192.168.2.1-192.168.2.255", "vlan_range": "100-200"}</data>
+      <data key="d6">false</data>
+      <data key="d9">L3</data>
+      <data key="d10">{"primary": {"pool_id": "_", "labels": {"ipv4_range": "192.168.2.1-192.168.2.255", "vlan_range": "100-200"}}}</data>
     </node>
-    <node id="82">
-      <data key="d0">4211307c-dcbf-49dc-afe4-3915c820960a</data>
-      <data key="d1">ConnectionPoint</data>
-      <data key="d2">port+uky-data-sw:HundredGigE0/0/0/0.851</data>
-      <data key="d3">HundredGigE0/0/0/0.851</data>
-      <data key="d4">TrunkPort</data>
-      <data key="d6">{"bw": 100}</data>
-      <data key="d7">{"ipv4": "10.128.128.129", "ipv6": "2602:fcfb:1:1024::1", "local_name": "HundredGigE0/0/0/0.851", "mac": "94:ae:f0:e3:58:00"}</data>
-      <data key="d8">false</data>
-      <data key="d10">{"primary": {"pool_id": "_", "capacities": {"bw": 100}}}</data>
-      <data key="d11">{"primary": {"pool_id": "_", "labels": {"mac": "94:ae:f0:e3:58:00", "ipv4": "10.128.128.129", "ipv6": "2602:fcfb:1:1024::1", "local_name": "HundredGigE0/0/0/0.851"}}}</data>
-    </node>
-    <node id="83">
-      <data key="d0">4211307c-dcbf-49dc-afe4-3915c820960a</data>
-      <data key="d1">ConnectionPoint</data>
-      <data key="d2">port+uky-data-sw:HundredGigE0/0/0/0.859</data>
-      <data key="d3">HundredGigE0/0/0/0.859</data>
-      <data key="d4">TrunkPort</data>
-      <data key="d6">{"bw": 100}</data>
-      <data key="d7">{"ipv4": "10.128.0.130", "ipv6": "2602:fcfb:0:1024::2", "local_name": "HundredGigE0/0/0/0.859", "mac": "94:ae:f0:e3:58:00"}</data>
-      <data key="d8">false</data>
-      <data key="d10">{"primary": {"pool_id": "_", "capacities": {"bw": 100}}}</data>
-      <data key="d11">{"primary": {"pool_id": "_", "labels": {"mac": "94:ae:f0:e3:58:00", "ipv4": "10.128.0.130", "ipv6": "2602:fcfb:0:1024::2", "local_name": "HundredGigE0/0/0/0.859"}}}</data>
-    </node>
-    <node id="84">
-      <data key="d0">4211307c-dcbf-49dc-afe4-3915c820960a</data>
-      <data key="d1">ConnectionPoint</data>
-      <data key="d2">port+uky-data-sw:HundredGigE0/0/0/0.999</data>
-      <data key="d3">HundredGigE0/0/0/0.999</data>
-      <data key="d4">TrunkPort</data>
-      <data key="d6">{"bw": 100}</data>
-      <data key="d7">{"ipv4": "10.128.128.133", "ipv6": "2602:fcfb:1:1024::5", "local_name": "HundredGigE0/0/0/0.999", "mac": "94:ae:f0:e3:58:00"}</data>
-      <data key="d8">false</data>
-      <data key="d10">{"primary": {"pool_id": "_", "capacities": {"bw": 100}}}</data>
-      <data key="d11">{"primary": {"pool_id": "_", "labels": {"mac": "94:ae:f0:e3:58:00", "ipv4": "10.128.128.133", "ipv6": "2602:fcfb:1:1024::5", "local_name": "HundredGigE0/0/0/0.999"}}}</data>
-    </node>
-    <node id="85">
-      <data key="d0">4211307c-dcbf-49dc-afe4-3915c820960a</data>
-      <data key="d1">ConnectionPoint</data>
-      <data key="d2">port+uky-data-sw:HundredGigE0/0/0/1</data>
-      <data key="d3">HundredGigE0/0/0/1</data>
-      <data key="d4">TrunkPort</data>
-      <data key="d6">{"bw": 100}</data>
-      <data key="d7">{"local_name": "HundredGigE0/0/0/1", "mac": "94:ae:f0:e3:58:04"}</data>
-      <data key="d8">false</data>
-      <data key="d10">{"primary": {"pool_id": "_", "capacities": {"bw": 100}}}</data>
-      <data key="d11">{"primary": {"pool_id": "_", "labels": {"mac": "94:ae:f0:e3:58:04", "local_name": "HundredGigE0/0/0/1"}}}</data>
-    </node>
-    <node id="86">
-      <data key="d0">4211307c-dcbf-49dc-afe4-3915c820960a</data>
-      <data key="d1">ConnectionPoint</data>
-      <data key="d2">port+uky-data-sw:HundredGigE0/0/0/13</data>
-      <data key="d3">HundredGigE0/0/0/13</data>
-      <data key="d4">TrunkPort</data>
-      <data key="d6">{"bw": 100}</data>
-      <data key="d7">{"local_name": "HundredGigE0/0/0/13", "mac": "94:ae:f0:e3:58:34"}</data>
-      <data key="d8">false</data>
-      <data key="d10">{"primary": {"pool_id": "_", "capacities": {"bw": 100}}}</data>
-      <data key="d11">{"primary": {"pool_id": "_", "labels": {"mac": "94:ae:f0:e3:58:34", "local_name": "HundredGigE0/0/0/13"}}}</data>
-    </node>
-    <node id="87">
-      <data key="d0">4211307c-dcbf-49dc-afe4-3915c820960a</data>
-      <data key="d1">ConnectionPoint</data>
-      <data key="d2">port+uky-data-sw:HundredGigE0/0/0/13.210</data>
-      <data key="d3">HundredGigE0/0/0/13.210</data>
-      <data key="d4">TrunkPort</data>
-      <data key="d6">{"bw": 100}</data>
-      <data key="d7">{"local_name": "HundredGigE0/0/0/13.210", "mac": "94:ae:f0:e3:58:34"}</data>
-      <data key="d8">false</data>
-      <data key="d10">{"primary": {"pool_id": "_", "capacities": {"bw": 100}}}</data>
-      <data key="d11">{"primary": {"pool_id": "_", "labels": {"mac": "94:ae:f0:e3:58:34", "local_name": "HundredGigE0/0/0/13.210"}}}</data>
-    </node>
-    <node id="88">
-      <data key="d0">4211307c-dcbf-49dc-afe4-3915c820960a</data>
-      <data key="d1">ConnectionPoint</data>
-      <data key="d2">port+uky-data-sw:HundredGigE0/0/0/13.212</data>
-      <data key="d3">HundredGigE0/0/0/13.212</data>
-      <data key="d4">TrunkPort</data>
-      <data key="d6">{"bw": 100}</data>
-      <data key="d7">{"local_name": "HundredGigE0/0/0/13.212", "mac": "94:ae:f0:e3:58:34"}</data>
-      <data key="d8">false</data>
-      <data key="d10">{"primary": {"pool_id": "_", "capacities": {"bw": 100}}}</data>
-      <data key="d11">{"primary": {"pool_id": "_", "labels": {"mac": "94:ae:f0:e3:58:34", "local_name": "HundredGigE0/0/0/13.212"}}}</data>
-    </node>
-    <node id="89">
-      <data key="d0">4211307c-dcbf-49dc-afe4-3915c820960a</data>
-      <data key="d1">ConnectionPoint</data>
-      <data key="d2">port+uky-data-sw:HundredGigE0/0/0/15</data>
-      <data key="d3">HundredGigE0/0/0/15</data>
-      <data key="d4">TrunkPort</data>
-      <data key="d6">{"bw": 100}</data>
-      <data key="d7">{"local_name": "HundredGigE0/0/0/15", "mac": "94:ae:f0:e3:58:3c"}</data>
-      <data key="d8">false</data>
-      <data key="d10">{"primary": {"pool_id": "_", "capacities": {"bw": 100}}}</data>
-      <data key="d11">{"primary": {"pool_id": "_", "labels": {"mac": "94:ae:f0:e3:58:3c", "local_name": "HundredGigE0/0/0/15"}}}</data>
-    </node>
-    <node id="90">
-      <data key="d0">4211307c-dcbf-49dc-afe4-3915c820960a</data>
-      <data key="d1">ConnectionPoint</data>
-      <data key="d2">port+uky-data-sw:HundredGigE0/0/0/17</data>
-      <data key="d3">HundredGigE0/0/0/17</data>
-      <data key="d4">TrunkPort</data>
-      <data key="d6">{"bw": 100}</data>
-      <data key="d7">{"local_name": "HundredGigE0/0/0/17", "mac": "94:ae:f0:e3:58:44"}</data>
-      <data key="d8">false</data>
-      <data key="d10">{"primary": {"pool_id": "_", "capacities": {"bw": 100}}}</data>
-      <data key="d11">{"primary": {"pool_id": "_", "labels": {"mac": "94:ae:f0:e3:58:44", "local_name": "HundredGigE0/0/0/17"}}}</data>
-    </node>
-    <node id="91">
-      <data key="d0">4211307c-dcbf-49dc-afe4-3915c820960a</data>
-      <data key="d1">ConnectionPoint</data>
-      <data key="d2">port+uky-data-sw:HundredGigE0/0/0/19</data>
-      <data key="d3">HundredGigE0/0/0/19</data>
-      <data key="d4">TrunkPort</data>
-      <data key="d6">{"bw": 100}</data>
-      <data key="d7">{"local_name": "HundredGigE0/0/0/19", "mac": "94:ae:f0:e3:58:4c"}</data>
-      <data key="d8">false</data>
-      <data key="d10">{"primary": {"pool_id": "_", "capacities": {"bw": 100}}}</data>
-      <data key="d11">{"primary": {"pool_id": "_", "labels": {"mac": "94:ae:f0:e3:58:4c", "local_name": "HundredGigE0/0/0/19"}}}</data>
-    </node>
-    <node id="92">
-      <data key="d0">4211307c-dcbf-49dc-afe4-3915c820960a</data>
-      <data key="d1">ConnectionPoint</data>
-      <data key="d2">port+uky-data-sw:HundredGigE0/0/0/21</data>
-      <data key="d3">HundredGigE0/0/0/21</data>
-      <data key="d4">TrunkPort</data>
-      <data key="d6">{"bw": 100}</data>
-      <data key="d7">{"local_name": "HundredGigE0/0/0/21", "mac": "94:ae:f0:e3:58:54"}</data>
-      <data key="d8">false</data>
-      <data key="d10">{"primary": {"pool_id": "_", "capacities": {"bw": 100}}}</data>
-      <data key="d11">{"primary": {"pool_id": "_", "labels": {"mac": "94:ae:f0:e3:58:54", "local_name": "HundredGigE0/0/0/21"}}}</data>
-    </node>
-    <node id="93">
-      <data key="d0">4211307c-dcbf-49dc-afe4-3915c820960a</data>
-      <data key="d1">ConnectionPoint</data>
-      <data key="d2">port+uky-data-sw:HundredGigE0/0/0/3</data>
-      <data key="d3">HundredGigE0/0/0/3</data>
-      <data key="d4">TrunkPort</data>
-      <data key="d6">{"bw": 100}</data>
-      <data key="d7">{"local_name": "HundredGigE0/0/0/3", "mac": "94:ae:f0:e3:58:0c"}</data>
-      <data key="d8">false</data>
-      <data key="d10">{"primary": {"pool_id": "_", "capacities": {"bw": 100}}}</data>
-      <data key="d11">{"primary": {"pool_id": "_", "labels": {"mac": "94:ae:f0:e3:58:0c", "local_name": "HundredGigE0/0/0/3"}}}</data>
-    </node>
-    <node id="94">
-      <data key="d0">4211307c-dcbf-49dc-afe4-3915c820960a</data>
+    <node id="692">
+      <data key="d0">e0bd5e07-fa2b-4aa7-9ccf-e1e1965db808</data>
       <data key="d1">ConnectionPoint</data>
       <data key="d2">port+uky-data-sw:HundredGigE0/0/0/5</data>
       <data key="d3">HundredGigE0/0/0/5</data>
       <data key="d4">TrunkPort</data>
-      <data key="d6">{"bw": 100}</data>
-      <data key="d7">{"local_name": "HundredGigE0/0/0/5", "mac": "94:ae:f0:e3:58:14"}</data>
-      <data key="d8">false</data>
-      <data key="d10">{"primary": {"pool_id": "_", "capacities": {"bw": 100}}}</data>
-      <data key="d11">{"primary": {"pool_id": "_", "labels": {"mac": "94:ae:f0:e3:58:14", "local_name": "HundredGigE0/0/0/5"}}}</data>
+      <data key="d11">{"bw": 100}</data>
+      <data key="d8">{"vlan_range": "1-4096"}</data>
+      <data key="d6">false</data>
+      <data key="d12">{"primary": {"pool_id": "_", "capacities": {"bw": 100}}}</data>
+      <data key="d10">{"primary": {"pool_id": "_", "labels": {"vlan_range": "1-4096"}}}</data>
     </node>
-    <node id="95">
-      <data key="d0">4211307c-dcbf-49dc-afe4-3915c820960a</data>
+    <node id="693">
+      <data key="d0">e0bd5e07-fa2b-4aa7-9ccf-e1e1965db808</data>
+      <data key="d1">ConnectionPoint</data>
+      <data key="d2">port+uky-data-sw:HundredGigE0/0/0/13</data>
+      <data key="d3">HundredGigE0/0/0/13</data>
+      <data key="d4">TrunkPort</data>
+      <data key="d11">{"bw": 100}</data>
+      <data key="d8">{"vlan_range": "1-4096"}</data>
+      <data key="d6">false</data>
+      <data key="d12">{"primary": {"pool_id": "_", "capacities": {"bw": 100}}}</data>
+      <data key="d10">{"primary": {"pool_id": "_", "labels": {"vlan_range": "1-4096"}}}</data>
+    </node>
+    <node id="694">
+      <data key="d0">e0bd5e07-fa2b-4aa7-9ccf-e1e1965db808</data>
+      <data key="d1">ConnectionPoint</data>
+      <data key="d2">port+uky-data-sw:HundredGigE0/0/0/15</data>
+      <data key="d3">HundredGigE0/0/0/15</data>
+      <data key="d4">TrunkPort</data>
+      <data key="d11">{"bw": 100}</data>
+      <data key="d8">{"vlan_range": "1-4096"}</data>
+      <data key="d6">false</data>
+      <data key="d12">{"primary": {"pool_id": "_", "capacities": {"bw": 100}}}</data>
+      <data key="d10">{"primary": {"pool_id": "_", "labels": {"vlan_range": "1-4096"}}}</data>
+    </node>
+    <node id="695">
+      <data key="d0">e0bd5e07-fa2b-4aa7-9ccf-e1e1965db808</data>
       <data key="d1">ConnectionPoint</data>
       <data key="d2">port+uky-data-sw:HundredGigE0/0/0/9</data>
       <data key="d3">HundredGigE0/0/0/9</data>
       <data key="d4">TrunkPort</data>
-      <data key="d6">{"bw": 100}</data>
-      <data key="d7">{"local_name": "HundredGigE0/0/0/9", "mac": "94:ae:f0:e3:58:24"}</data>
-      <data key="d8">false</data>
-      <data key="d10">{"primary": {"pool_id": "_", "capacities": {"bw": 100}}}</data>
-      <data key="d11">{"primary": {"pool_id": "_", "labels": {"mac": "94:ae:f0:e3:58:24", "local_name": "HundredGigE0/0/0/9"}}}</data>
+      <data key="d11">{"bw": 100}</data>
+      <data key="d8">{"vlan_range": "1-4096"}</data>
+      <data key="d6">false</data>
+      <data key="d12">{"primary": {"pool_id": "_", "capacities": {"bw": 100}}}</data>
+      <data key="d10">{"primary": {"pool_id": "_", "labels": {"vlan_range": "1-4096"}}}</data>
     </node>
-    <node id="96">
-      <data key="d0">4211307c-dcbf-49dc-afe4-3915c820960a</data>
+    <node id="696">
+      <data key="d0">e0bd5e07-fa2b-4aa7-9ccf-e1e1965db808</data>
       <data key="d1">ConnectionPoint</data>
-      <data key="d2">port+uky-data-sw:HundredGigE0/0/0/9.1001</data>
-      <data key="d3">HundredGigE0/0/0/9.1001</data>
+      <data key="d2">port+uky-data-sw:HundredGigE0/0/0/17</data>
+      <data key="d3">HundredGigE0/0/0/17</data>
       <data key="d4">TrunkPort</data>
-      <data key="d6">{"bw": 100}</data>
-      <data key="d7">{"local_name": "HundredGigE0/0/0/9.1001", "mac": "94:ae:f0:e3:58:24"}</data>
-      <data key="d8">false</data>
-      <data key="d10">{"primary": {"pool_id": "_", "capacities": {"bw": 100}}}</data>
-      <data key="d11">{"primary": {"pool_id": "_", "labels": {"mac": "94:ae:f0:e3:58:24", "local_name": "HundredGigE0/0/0/9.1001"}}}</data>
+      <data key="d11">{"bw": 100}</data>
+      <data key="d8">{"vlan_range": "1-4096"}</data>
+      <data key="d6">false</data>
+      <data key="d12">{"primary": {"pool_id": "_", "capacities": {"bw": 100}}}</data>
+      <data key="d10">{"primary": {"pool_id": "_", "labels": {"vlan_range": "1-4096"}}}</data>
     </node>
-    <node id="97">
-      <data key="d0">4211307c-dcbf-49dc-afe4-3915c820960a</data>
+    <node id="697">
+      <data key="d0">e0bd5e07-fa2b-4aa7-9ccf-e1e1965db808</data>
       <data key="d1">ConnectionPoint</data>
-      <data key="d2">port+uky-data-sw:HundredGigE0/0/0/9.1002</data>
-      <data key="d3">HundredGigE0/0/0/9.1002</data>
+      <data key="d2">port+uky-data-sw:HundredGigE0/0/0/19</data>
+      <data key="d3">HundredGigE0/0/0/19</data>
       <data key="d4">TrunkPort</data>
-      <data key="d6">{"bw": 100}</data>
-      <data key="d7">{"local_name": "HundredGigE0/0/0/9.1002", "mac": "94:ae:f0:e3:58:24"}</data>
-      <data key="d8">false</data>
-      <data key="d10">{"primary": {"pool_id": "_", "capacities": {"bw": 100}}}</data>
-      <data key="d11">{"primary": {"pool_id": "_", "labels": {"mac": "94:ae:f0:e3:58:24", "local_name": "HundredGigE0/0/0/9.1002"}}}</data>
+      <data key="d11">{"bw": 100}</data>
+      <data key="d8">{"vlan_range": "1-4096"}</data>
+      <data key="d6">false</data>
+      <data key="d12">{"primary": {"pool_id": "_", "capacities": {"bw": 100}}}</data>
+      <data key="d10">{"primary": {"pool_id": "_", "labels": {"vlan_range": "1-4096"}}}</data>
     </node>
-    <node id="98">
-      <data key="d0">4211307c-dcbf-49dc-afe4-3915c820960a</data>
+    <node id="698">
+      <data key="d0">e0bd5e07-fa2b-4aa7-9ccf-e1e1965db808</data>
       <data key="d1">ConnectionPoint</data>
-      <data key="d2">port+uky-data-sw:TwentyFiveGigE0/0/0/23/0</data>
-      <data key="d3">TwentyFiveGigE0/0/0/23/0</data>
+      <data key="d2">port+uky-data-sw:HundredGigE0/0/0/21</data>
+      <data key="d3">HundredGigE0/0/0/21</data>
       <data key="d4">TrunkPort</data>
-      <data key="d6">{"bw": 25}</data>
-      <data key="d7">{"local_name": "TwentyFiveGigE0/0/0/23/0", "mac": "94:ae:f0:e3:58:5c"}</data>
-      <data key="d8">false</data>
-      <data key="d10">{"primary": {"pool_id": "_", "capacities": {"bw": 25}}}</data>
-      <data key="d11">{"primary": {"pool_id": "_", "labels": {"mac": "94:ae:f0:e3:58:5c", "local_name": "TwentyFiveGigE0/0/0/23/0"}}}</data>
+      <data key="d11">{"bw": 100}</data>
+      <data key="d8">{"vlan_range": "1-4096"}</data>
+      <data key="d6">false</data>
+      <data key="d12">{"primary": {"pool_id": "_", "capacities": {"bw": 100}}}</data>
+      <data key="d10">{"primary": {"pool_id": "_", "labels": {"vlan_range": "1-4096"}}}</data>
     </node>
-    <node id="99">
-      <data key="d0">4211307c-dcbf-49dc-afe4-3915c820960a</data>
+    <node id="699">
+      <data key="d0">e0bd5e07-fa2b-4aa7-9ccf-e1e1965db808</data>
       <data key="d1">ConnectionPoint</data>
-      <data key="d2">port+uky-data-sw:TwentyFiveGigE0/0/0/23/1</data>
-      <data key="d3">TwentyFiveGigE0/0/0/23/1</data>
+      <data key="d2">port+uky-data-sw:HundredGigE0/0/0/25.1</data>
+      <data key="d3">HundredGigE0/0/0/25.1</data>
       <data key="d4">TrunkPort</data>
-      <data key="d6">{"bw": 25}</data>
-      <data key="d7">{"local_name": "TwentyFiveGigE0/0/0/23/1", "mac": "94:ae:f0:e3:58:5d"}</data>
-      <data key="d8">false</data>
-      <data key="d10">{"primary": {"pool_id": "_", "capacities": {"bw": 25}}}</data>
-      <data key="d11">{"primary": {"pool_id": "_", "labels": {"mac": "94:ae:f0:e3:58:5d", "local_name": "TwentyFiveGigE0/0/0/23/1"}}}</data>
+      <data key="d11">{"bw": 25}</data>
+      <data key="d8">{"vlan_range": "1-4096"}</data>
+      <data key="d6">false</data>
+      <data key="d12">{"primary": {"pool_id": "_", "capacities": {"bw": 25}}}</data>
+      <data key="d10">{"primary": {"pool_id": "_", "labels": {"vlan_range": "1-4096"}}}</data>
     </node>
-    <node id="100">
-      <data key="d0">4211307c-dcbf-49dc-afe4-3915c820960a</data>
+    <node id="700">
+      <data key="d0">e0bd5e07-fa2b-4aa7-9ccf-e1e1965db808</data>
       <data key="d1">ConnectionPoint</data>
-      <data key="d2">port+uky-data-sw:TwentyFiveGigE0/0/0/23/2</data>
-      <data key="d3">TwentyFiveGigE0/0/0/23/2</data>
+      <data key="d2">port+uky-data-sw:HundredGigE0/0/0/25.2</data>
+      <data key="d3">HundredGigE0/0/0/25.2</data>
       <data key="d4">TrunkPort</data>
-      <data key="d6">{"bw": 25}</data>
-      <data key="d7">{"local_name": "TwentyFiveGigE0/0/0/23/2", "mac": "94:ae:f0:e3:58:5e"}</data>
-      <data key="d8">false</data>
-      <data key="d10">{"primary": {"pool_id": "_", "capacities": {"bw": 25}}}</data>
-      <data key="d11">{"primary": {"pool_id": "_", "labels": {"mac": "94:ae:f0:e3:58:5e", "local_name": "TwentyFiveGigE0/0/0/23/2"}}}</data>
+      <data key="d11">{"bw": 25}</data>
+      <data key="d8">{"vlan_range": "1-4096"}</data>
+      <data key="d6">false</data>
+      <data key="d12">{"primary": {"pool_id": "_", "capacities": {"bw": 25}}}</data>
+      <data key="d10">{"primary": {"pool_id": "_", "labels": {"vlan_range": "1-4096"}}}</data>
     </node>
-    <node id="101">
-      <data key="d0">4211307c-dcbf-49dc-afe4-3915c820960a</data>
+    <node id="701">
+      <data key="d0">e0bd5e07-fa2b-4aa7-9ccf-e1e1965db808</data>
       <data key="d1">ConnectionPoint</data>
-      <data key="d2">port+uky-data-sw:TwentyFiveGigE0/0/0/23/3</data>
-      <data key="d3">TwentyFiveGigE0/0/0/23/3</data>
+      <data key="d2">port+uky-data-sw:HundredGigE0/0/0/25.3</data>
+      <data key="d3">HundredGigE0/0/0/25.3</data>
       <data key="d4">TrunkPort</data>
-      <data key="d6">{"bw": 25}</data>
-      <data key="d7">{"local_name": "TwentyFiveGigE0/0/0/23/3", "mac": "94:ae:f0:e3:58:5f"}</data>
-      <data key="d8">false</data>
-      <data key="d10">{"primary": {"pool_id": "_", "capacities": {"bw": 25}}}</data>
-      <data key="d11">{"primary": {"pool_id": "_", "labels": {"mac": "94:ae:f0:e3:58:5f", "local_name": "TwentyFiveGigE0/0/0/23/3"}}}</data>
+      <data key="d11">{"bw": 25}</data>
+      <data key="d8">{"vlan_range": "1-4096"}</data>
+      <data key="d6">false</data>
+      <data key="d12">{"primary": {"pool_id": "_", "capacities": {"bw": 25}}}</data>
+      <data key="d10">{"primary": {"pool_id": "_", "labels": {"vlan_range": "1-4096"}}}</data>
     </node>
-    <node id="102">
-      <data key="d0">4211307c-dcbf-49dc-afe4-3915c820960a</data>
+    <node id="702">
+      <data key="d0">e0bd5e07-fa2b-4aa7-9ccf-e1e1965db808</data>
+      <data key="d1">ConnectionPoint</data>
+      <data key="d2">port+uky-data-sw:HundredGigE0/0/0/25.4</data>
+      <data key="d3">HundredGigE0/0/0/25.4</data>
+      <data key="d4">TrunkPort</data>
+      <data key="d11">{"bw": 25}</data>
+      <data key="d8">{"vlan_range": "1-4096"}</data>
+      <data key="d6">false</data>
+      <data key="d12">{"primary": {"pool_id": "_", "capacities": {"bw": 25}}}</data>
+      <data key="d10">{"primary": {"pool_id": "_", "labels": {"vlan_range": "1-4096"}}}</data>
+    </node>
+    <node id="703">
+      <data key="d0">e0bd5e07-fa2b-4aa7-9ccf-e1e1965db808</data>
+      <data key="d1">ConnectionPoint</data>
+      <data key="d2">port+uky-data-sw:HundredGigE0/0/0/26</data>
+      <data key="d3">HundredGigE0/0/0/26</data>
+      <data key="d4">TrunkPort</data>
+      <data key="d11">{"bw": 100}</data>
+      <data key="d6">false</data>
+      <data key="d12">{"primary": {"pool_id": "_", "capacities": {"bw": 100}}}</data>
+    </node>
+    <node id="704">
+      <data key="d0">e0bd5e07-fa2b-4aa7-9ccf-e1e1965db808</data>
+      <data key="d1">ConnectionPoint</data>
+      <data key="d2">port+uky-data-sw:HundredGigE0/0/0/27</data>
+      <data key="d3">HundredGigE0/0/0/27</data>
+      <data key="d4">TrunkPort</data>
+      <data key="d11">{"bw": 100}</data>
+      <data key="d6">false</data>
+      <data key="d12">{"primary": {"pool_id": "_", "capacities": {"bw": 100}}}</data>
+    </node>
+    <node id="705">
+      <data key="d0">e0bd5e07-fa2b-4aa7-9ccf-e1e1965db808</data>
+      <data key="d1">NetworkNode</data>
+      <data key="d2">node+lbnl-data-sw:ip+192.168.13.3</data>
+      <data key="d3">lbnl-data-sw</data>
+      <data key="d4">Switch</data>
+      <data key="d5">NCS 55A1-36H</data>
+      <data key="d6">false</data>
+      <data key="d7">LBNL</data>
+    </node>
+    <node id="706">
+      <data key="d0">e0bd5e07-fa2b-4aa7-9ccf-e1e1965db808</data>
+      <data key="d1">NetworkService</data>
+      <data key="d2">node+lbnl-data-sw:ip+192.168.13.3-ns</data>
+      <data key="d3">lbnl-data-sw-ns</data>
+      <data key="d4">MPLS</data>
+      <data key="d8">{"vlan_range": "1-100"}</data>
+      <data key="d6">false</data>
+      <data key="d9">L2</data>
+      <data key="d10">{"primary": {"pool_id": "_", "labels": {"vlan_range": "1-100"}}}</data>
+    </node>
+    <node id="707">
+      <data key="d0">e0bd5e07-fa2b-4aa7-9ccf-e1e1965db808</data>
+      <data key="d1">NetworkService</data>
+      <data key="d2">node+lbnl-data-sw:ip+192.168.13.3-l3ns</data>
+      <data key="d3">lbnl-data-sw-l3ns</data>
+      <data key="d4">FABNetv4</data>
+      <data key="d8">{"ipv4_range": "192.168.2.1-192.168.2.255", "vlan_range": "100-200"}</data>
+      <data key="d6">false</data>
+      <data key="d9">L3</data>
+      <data key="d10">{"primary": {"pool_id": "_", "labels": {"ipv4_range": "192.168.2.1-192.168.2.255", "vlan_range": "100-200"}}}</data>
+    </node>
+    <node id="708">
+      <data key="d0">e0bd5e07-fa2b-4aa7-9ccf-e1e1965db808</data>
+      <data key="d1">ConnectionPoint</data>
+      <data key="d2">port+lbnl-data-sw:HundredGigE0/0/0/5</data>
+      <data key="d3">HundredGigE0/0/0/5</data>
+      <data key="d4">TrunkPort</data>
+      <data key="d11">{"bw": 100}</data>
+      <data key="d8">{"vlan_range": "1-4096"}</data>
+      <data key="d6">false</data>
+      <data key="d12">{"primary": {"pool_id": "_", "capacities": {"bw": 100}}}</data>
+      <data key="d10">{"primary": {"pool_id": "_", "labels": {"vlan_range": "1-4096"}}}</data>
+    </node>
+    <node id="709">
+      <data key="d0">e0bd5e07-fa2b-4aa7-9ccf-e1e1965db808</data>
+      <data key="d1">ConnectionPoint</data>
+      <data key="d2">port+lbnl-data-sw:HundredGigE0/0/0/13</data>
+      <data key="d3">HundredGigE0/0/0/13</data>
+      <data key="d4">TrunkPort</data>
+      <data key="d11">{"bw": 100}</data>
+      <data key="d8">{"vlan_range": "1-4096"}</data>
+      <data key="d6">false</data>
+      <data key="d12">{"primary": {"pool_id": "_", "capacities": {"bw": 100}}}</data>
+      <data key="d10">{"primary": {"pool_id": "_", "labels": {"vlan_range": "1-4096"}}}</data>
+    </node>
+    <node id="710">
+      <data key="d0">e0bd5e07-fa2b-4aa7-9ccf-e1e1965db808</data>
+      <data key="d1">ConnectionPoint</data>
+      <data key="d2">port+lbnl-data-sw:HundredGigE0/0/0/15</data>
+      <data key="d3">HundredGigE0/0/0/15</data>
+      <data key="d4">TrunkPort</data>
+      <data key="d11">{"bw": 100}</data>
+      <data key="d8">{"vlan_range": "1-4096"}</data>
+      <data key="d6">false</data>
+      <data key="d12">{"primary": {"pool_id": "_", "capacities": {"bw": 100}}}</data>
+      <data key="d10">{"primary": {"pool_id": "_", "labels": {"vlan_range": "1-4096"}}}</data>
+    </node>
+    <node id="711">
+      <data key="d0">e0bd5e07-fa2b-4aa7-9ccf-e1e1965db808</data>
+      <data key="d1">ConnectionPoint</data>
+      <data key="d2">port+lbnl-data-sw:HundredGigE0/0/0/9</data>
+      <data key="d3">HundredGigE0/0/0/9</data>
+      <data key="d4">TrunkPort</data>
+      <data key="d11">{"bw": 100}</data>
+      <data key="d8">{"vlan_range": "1-4096"}</data>
+      <data key="d6">false</data>
+      <data key="d12">{"primary": {"pool_id": "_", "capacities": {"bw": 100}}}</data>
+      <data key="d10">{"primary": {"pool_id": "_", "labels": {"vlan_range": "1-4096"}}}</data>
+    </node>
+    <node id="712">
+      <data key="d0">e0bd5e07-fa2b-4aa7-9ccf-e1e1965db808</data>
+      <data key="d1">ConnectionPoint</data>
+      <data key="d2">port+lbnl-data-sw:HundredGigE0/0/0/17</data>
+      <data key="d3">HundredGigE0/0/0/17</data>
+      <data key="d4">TrunkPort</data>
+      <data key="d11">{"bw": 100}</data>
+      <data key="d8">{"vlan_range": "1-4096"}</data>
+      <data key="d6">false</data>
+      <data key="d12">{"primary": {"pool_id": "_", "capacities": {"bw": 100}}}</data>
+      <data key="d10">{"primary": {"pool_id": "_", "labels": {"vlan_range": "1-4096"}}}</data>
+    </node>
+    <node id="713">
+      <data key="d0">e0bd5e07-fa2b-4aa7-9ccf-e1e1965db808</data>
+      <data key="d1">ConnectionPoint</data>
+      <data key="d2">port+lbnl-data-sw:HundredGigE0/0/0/19</data>
+      <data key="d3">HundredGigE0/0/0/19</data>
+      <data key="d4">TrunkPort</data>
+      <data key="d11">{"bw": 100}</data>
+      <data key="d8">{"vlan_range": "1-4096"}</data>
+      <data key="d6">false</data>
+      <data key="d12">{"primary": {"pool_id": "_", "capacities": {"bw": 100}}}</data>
+      <data key="d10">{"primary": {"pool_id": "_", "labels": {"vlan_range": "1-4096"}}}</data>
+    </node>
+    <node id="714">
+      <data key="d0">e0bd5e07-fa2b-4aa7-9ccf-e1e1965db808</data>
+      <data key="d1">ConnectionPoint</data>
+      <data key="d2">port+lbnl-data-sw:HundredGigE0/0/0/21</data>
+      <data key="d3">HundredGigE0/0/0/21</data>
+      <data key="d4">TrunkPort</data>
+      <data key="d11">{"bw": 100}</data>
+      <data key="d8">{"vlan_range": "1-4096"}</data>
+      <data key="d6">false</data>
+      <data key="d12">{"primary": {"pool_id": "_", "capacities": {"bw": 100}}}</data>
+      <data key="d10">{"primary": {"pool_id": "_", "labels": {"vlan_range": "1-4096"}}}</data>
+    </node>
+    <node id="715">
+      <data key="d0">e0bd5e07-fa2b-4aa7-9ccf-e1e1965db808</data>
+      <data key="d1">ConnectionPoint</data>
+      <data key="d2">port+lbnl-data-sw:HundredGigE0/0/0/25.1</data>
+      <data key="d3">HundredGigE0/0/0/25.1</data>
+      <data key="d4">TrunkPort</data>
+      <data key="d11">{"bw": 25}</data>
+      <data key="d8">{"vlan_range": "1-4096"}</data>
+      <data key="d6">false</data>
+      <data key="d12">{"primary": {"pool_id": "_", "capacities": {"bw": 25}}}</data>
+      <data key="d10">{"primary": {"pool_id": "_", "labels": {"vlan_range": "1-4096"}}}</data>
+    </node>
+    <node id="716">
+      <data key="d0">e0bd5e07-fa2b-4aa7-9ccf-e1e1965db808</data>
+      <data key="d1">ConnectionPoint</data>
+      <data key="d2">port+lbnl-data-sw:HundredGigE0/0/0/25.2</data>
+      <data key="d3">HundredGigE0/0/0/25.2</data>
+      <data key="d4">TrunkPort</data>
+      <data key="d11">{"bw": 25}</data>
+      <data key="d8">{"vlan_range": "1-4096"}</data>
+      <data key="d6">false</data>
+      <data key="d12">{"primary": {"pool_id": "_", "capacities": {"bw": 25}}}</data>
+      <data key="d10">{"primary": {"pool_id": "_", "labels": {"vlan_range": "1-4096"}}}</data>
+    </node>
+    <node id="717">
+      <data key="d0">e0bd5e07-fa2b-4aa7-9ccf-e1e1965db808</data>
+      <data key="d1">ConnectionPoint</data>
+      <data key="d2">port+lbnl-data-sw:HundredGigE0/0/0/25.3</data>
+      <data key="d3">HundredGigE0/0/0/25.3</data>
+      <data key="d4">TrunkPort</data>
+      <data key="d11">{"bw": 25}</data>
+      <data key="d8">{"vlan_range": "1-4096"}</data>
+      <data key="d6">false</data>
+      <data key="d12">{"primary": {"pool_id": "_", "capacities": {"bw": 25}}}</data>
+      <data key="d10">{"primary": {"pool_id": "_", "labels": {"vlan_range": "1-4096"}}}</data>
+    </node>
+    <node id="718">
+      <data key="d0">e0bd5e07-fa2b-4aa7-9ccf-e1e1965db808</data>
+      <data key="d1">ConnectionPoint</data>
+      <data key="d2">port+lbnl-data-sw:HundredGigE0/0/0/25.4</data>
+      <data key="d3">HundredGigE0/0/0/25.4</data>
+      <data key="d4">TrunkPort</data>
+      <data key="d11">{"bw": 25}</data>
+      <data key="d8">{"vlan_range": "1-4096"}</data>
+      <data key="d6">false</data>
+      <data key="d12">{"primary": {"pool_id": "_", "capacities": {"bw": 25}}}</data>
+      <data key="d10">{"primary": {"pool_id": "_", "labels": {"vlan_range": "1-4096"}}}</data>
+    </node>
+    <node id="719">
+      <data key="d0">e0bd5e07-fa2b-4aa7-9ccf-e1e1965db808</data>
+      <data key="d1">ConnectionPoint</data>
+      <data key="d2">port+lbnl-data-sw:HundredGigE0/0/0/26</data>
+      <data key="d3">HundredGigE0/0/0/26</data>
+      <data key="d4">TrunkPort</data>
+      <data key="d11">{"bw": 100}</data>
+      <data key="d8">{"local_name": "HundredGigE 0/0/0/26", "mac": "20:00:00:00:00:10"}</data>
+      <data key="d6">false</data>
+      <data key="d12">{"primary": {"pool_id": "_", "capacities": {"bw": 100}}}</data>
+      <data key="d10">{"primary": {"pool_id": "_", "labels": {"mac": "20:00:00:00:00:10", "local_name": "HundredGigE 0/0/0/26"}}}</data>
+    </node>
+    <node id="720">
+      <data key="d0">e0bd5e07-fa2b-4aa7-9ccf-e1e1965db808</data>
+      <data key="d1">ConnectionPoint</data>
+      <data key="d2">port+lbnl-data-sw:HundredGigE0/0/0/27</data>
+      <data key="d3">HundredGigE 0/0/0/27</data>
+      <data key="d4">TrunkPort</data>
+      <data key="d11">{"bw": 100}</data>
+      <data key="d8">{"local_name": "HundredGigE 0/0/0/27", "mac": "20:00:00:00:00:11"}</data>
+      <data key="d6">false</data>
+      <data key="d12">{"primary": {"pool_id": "_", "capacities": {"bw": 100}}}</data>
+      <data key="d10">{"primary": {"pool_id": "_", "labels": {"mac": "20:00:00:00:00:11", "local_name": "HundredGigE 0/0/0/27"}}}</data>
+    </node>
+    <node id="721">
+      <data key="d0">e0bd5e07-fa2b-4aa7-9ccf-e1e1965db808</data>
       <data key="d1">Link</data>
-      <data key="d2">link:local-port+lbnl-data-sw:HundredGigE0/0/0/0.2400:remote-port+renc-data-sw:TenGigE0/0/0/2/0.3981</data>
-      <data key="d3">TwentyFiveGigE0/0/0/23/3 to peer facilities</data>
+      <data key="d2">port+renc-data-sw:HundredGigE0/0/0/26-Wave</data>
+      <data key="d3">l1</data>
       <data key="d4">L2Path</data>
-      <data key="d8">false</data>
-      <data key="d12">L2</data>
+      <data key="d6">false</data>
+      <data key="d9">L2</data>
     </node>
-    <node id="103">
-      <data key="d0">4211307c-dcbf-49dc-afe4-3915c820960a</data>
+    <node id="722">
+      <data key="d0">e0bd5e07-fa2b-4aa7-9ccf-e1e1965db808</data>
       <data key="d1">Link</data>
-      <data key="d2">link:local-port+lbnl-data-sw:HundredGigE0/0/0/0.2401:remote-port+uky-data-sw:HundredGigE0/0/0/0.851</data>
-      <data key="d3">TwentyFiveGigE0/0/0/23/3 to peer facilities</data>
+      <data key="d2">port+uky-data-sw:HundredGigE0/0/0/27-Wave</data>
+      <data key="d3">l2</data>
       <data key="d4">L2Path</data>
-      <data key="d8">false</data>
-      <data key="d12">L2</data>
+      <data key="d6">false</data>
+      <data key="d9">L2</data>
     </node>
-    <node id="104">
-      <data key="d0">4211307c-dcbf-49dc-afe4-3915c820960a</data>
+    <node id="723">
+      <data key="d0">e0bd5e07-fa2b-4aa7-9ccf-e1e1965db808</data>
       <data key="d1">Link</data>
-      <data key="d2">link:local-port+renc-data-sw:TenGigE0/0/0/2/0.3999:remote-port+uky-data-sw:HundredGigE0/0/0/0.859</data>
-      <data key="d3">TwentyFiveGigE0/0/0/23/3 to peer facilities</data>
+      <data key="d2">port+renc-data-sw:HundredGigE0/0/0/27-Wave</data>
+      <data key="d3">l3</data>
       <data key="d4">L2Path</data>
-      <data key="d8">false</data>
-      <data key="d12">L2</data>
+      <data key="d6">false</data>
+      <data key="d9">L2</data>
     </node>
-    <edge source="1" target="2">
+    <node id="724">
+      <data key="d0">e0bd5e07-fa2b-4aa7-9ccf-e1e1965db808</data>
+      <data key="d1">NetworkNode</data>
+      <data key="d2">RENCI-DTN-id</data>
+      <data key="d3">RENCI-DTN</data>
+      <data key="d4">Facility</data>
+      <data key="d6">false</data>
+      <data key="d7">RENC</data>
+    </node>
+    <node id="725">
+      <data key="d0">e0bd5e07-fa2b-4aa7-9ccf-e1e1965db808</data>
+      <data key="d1">NetworkService</data>
+      <data key="d2">RENCI-DTN-id-ns</data>
+      <data key="d3">RENCI-DTN-ns</data>
+      <data key="d4">VLAN</data>
+      <data key="d6">false</data>
+      <data key="d9">L2</data>
+    </node>
+    <node id="726">
+      <data key="d0">e0bd5e07-fa2b-4aa7-9ccf-e1e1965db808</data>
+      <data key="d1">ConnectionPoint</data>
+      <data key="d2">RENCI-DTN-id-int</data>
+      <data key="d3">RENCI-DTN-int</data>
+      <data key="d4">FacilityPort</data>
+      <data key="d11">{"bw": 10, "mtu": 1500}</data>
+      <data key="d6">false</data>
+      <data key="d12">{"primary": {"pool_id": "_", "capacities": {"bw": 10, "mtu": 1500}}}</data>
+    </node>
+    <node id="727">
+      <data key="d0">e0bd5e07-fa2b-4aa7-9ccf-e1e1965db808</data>
+      <data key="d1">NetworkNode</data>
+      <data key="d2">RENCI-BEN-id</data>
+      <data key="d3">RENCI-BEN</data>
+      <data key="d4">Facility</data>
+      <data key="d6">false</data>
+      <data key="d7">RENC</data>
+    </node>
+    <node id="728">
+      <data key="d0">e0bd5e07-fa2b-4aa7-9ccf-e1e1965db808</data>
+      <data key="d1">NetworkService</data>
+      <data key="d2">RENCI-BEN-id-ns</data>
+      <data key="d3">RENCI-BEN-ns</data>
+      <data key="d4">VLAN</data>
+      <data key="d6">false</data>
+      <data key="d9">L2</data>
+    </node>
+    <node id="729">
+      <data key="d0">e0bd5e07-fa2b-4aa7-9ccf-e1e1965db808</data>
+      <data key="d1">ConnectionPoint</data>
+      <data key="d2">RENCI-BEN-id-int</data>
+      <data key="d3">RENCI-BEN-int</data>
+      <data key="d4">FacilityPort</data>
+      <data key="d11">{"mtu": 9000}</data>
+      <data key="d8">{"ipv4_range": "192.168.1.1-192.168.1.10", "vlan_range": "1-100"}</data>
+      <data key="d6">false</data>
+      <data key="d12">{"primary": {"pool_id": "_", "capacities": {"mtu": 9000}}}</data>
+      <data key="d10">{"primary": {"pool_id": "_", "labels": {"ipv4_range": "192.168.1.1-192.168.1.10", "vlan_range": "1-100"}}}</data>
+    </node>
+    <node id="730">
+      <data key="d0">e0bd5e07-fa2b-4aa7-9ccf-e1e1965db808</data>
+      <data key="d1">Link</data>
+      <data key="d2">RENCI-DC-link1-id</data>
+      <data key="d3">RENCI-DC-link1</data>
+      <data key="d4">L2Path</data>
+      <data key="d6">false</data>
+      <data key="d9">L2</data>
+    </node>
+    <node id="731">
+      <data key="d0">e0bd5e07-fa2b-4aa7-9ccf-e1e1965db808</data>
+      <data key="d1">Link</data>
+      <data key="d2">RENCI-DC-link2-id</data>
+      <data key="d3">RENCI-DC-link2</data>
+      <data key="d4">L2Path</data>
+      <data key="d6">false</data>
+      <data key="d9">L2</data>
+    </node>
+    <edge source="672" target="673">
       <data key="d13">has</data>
     </edge>
-    <edge source="1" target="3">
+    <edge source="672" target="674">
       <data key="d13">has</data>
     </edge>
-    <edge source="1" target="4">
+    <edge source="673" target="675">
+      <data key="d13">connects</data>
+    </edge>
+    <edge source="673" target="676">
+      <data key="d13">connects</data>
+    </edge>
+    <edge source="673" target="677">
+      <data key="d13">connects</data>
+    </edge>
+    <edge source="673" target="678">
+      <data key="d13">connects</data>
+    </edge>
+    <edge source="673" target="679">
+      <data key="d13">connects</data>
+    </edge>
+    <edge source="673" target="680">
+      <data key="d13">connects</data>
+    </edge>
+    <edge source="673" target="681">
+      <data key="d13">connects</data>
+    </edge>
+    <edge source="673" target="682">
+      <data key="d13">connects</data>
+    </edge>
+    <edge source="673" target="683">
+      <data key="d13">connects</data>
+    </edge>
+    <edge source="673" target="684">
+      <data key="d13">connects</data>
+    </edge>
+    <edge source="673" target="685">
+      <data key="d13">connects</data>
+    </edge>
+    <edge source="673" target="686">
+      <data key="d13">connects</data>
+    </edge>
+    <edge source="673" target="687">
+      <data key="d13">connects</data>
+    </edge>
+    <edge source="673" target="688">
+      <data key="d13">connects</data>
+    </edge>
+    <edge source="682" target="730">
+      <data key="d13">connects</data>
+    </edge>
+    <edge source="682" target="731">
+      <data key="d13">connects</data>
+    </edge>
+    <edge source="687" target="721">
+      <data key="d13">connects</data>
+    </edge>
+    <edge source="688" target="723">
+      <data key="d13">connects</data>
+    </edge>
+    <edge source="689" target="690">
       <data key="d13">has</data>
     </edge>
-    <edge source="4" target="5">
-      <data key="d13">connects</data>
-    </edge>
-    <edge source="4" target="6">
-      <data key="d13">connects</data>
-    </edge>
-    <edge source="4" target="7">
-      <data key="d13">connects</data>
-    </edge>
-    <edge source="4" target="8">
-      <data key="d13">connects</data>
-    </edge>
-    <edge source="4" target="9">
-      <data key="d13">connects</data>
-    </edge>
-    <edge source="4" target="10">
-      <data key="d13">connects</data>
-    </edge>
-    <edge source="4" target="11">
-      <data key="d13">connects</data>
-    </edge>
-    <edge source="4" target="12">
-      <data key="d13">connects</data>
-    </edge>
-    <edge source="4" target="13">
-      <data key="d13">connects</data>
-    </edge>
-    <edge source="4" target="14">
-      <data key="d13">connects</data>
-    </edge>
-    <edge source="4" target="15">
-      <data key="d13">connects</data>
-    </edge>
-    <edge source="4" target="16">
-      <data key="d13">connects</data>
-    </edge>
-    <edge source="4" target="17">
-      <data key="d13">connects</data>
-    </edge>
-    <edge source="4" target="18">
-      <data key="d13">connects</data>
-    </edge>
-    <edge source="4" target="19">
-      <data key="d13">connects</data>
-    </edge>
-    <edge source="4" target="20">
-      <data key="d13">connects</data>
-    </edge>
-    <edge source="4" target="21">
-      <data key="d13">connects</data>
-    </edge>
-    <edge source="4" target="22">
-      <data key="d13">connects</data>
-    </edge>
-    <edge source="4" target="23">
-      <data key="d13">connects</data>
-    </edge>
-    <edge source="4" target="24">
-      <data key="d13">connects</data>
-    </edge>
-    <edge source="4" target="25">
-      <data key="d13">connects</data>
-    </edge>
-    <edge source="4" target="26">
-      <data key="d13">connects</data>
-    </edge>
-    <edge source="4" target="27">
-      <data key="d13">connects</data>
-    </edge>
-    <edge source="4" target="28">
-      <data key="d13">connects</data>
-    </edge>
-    <edge source="6" target="102">
-      <data key="d13">connects</data>
-    </edge>
-    <edge source="7" target="103">
-      <data key="d13">connects</data>
-    </edge>
-    <edge source="29" target="30">
+    <edge source="689" target="691">
       <data key="d13">has</data>
     </edge>
-    <edge source="29" target="31">
+    <edge source="690" target="692">
+      <data key="d13">connects</data>
+    </edge>
+    <edge source="690" target="693">
+      <data key="d13">connects</data>
+    </edge>
+    <edge source="690" target="694">
+      <data key="d13">connects</data>
+    </edge>
+    <edge source="690" target="695">
+      <data key="d13">connects</data>
+    </edge>
+    <edge source="690" target="696">
+      <data key="d13">connects</data>
+    </edge>
+    <edge source="690" target="697">
+      <data key="d13">connects</data>
+    </edge>
+    <edge source="690" target="698">
+      <data key="d13">connects</data>
+    </edge>
+    <edge source="690" target="699">
+      <data key="d13">connects</data>
+    </edge>
+    <edge source="690" target="700">
+      <data key="d13">connects</data>
+    </edge>
+    <edge source="690" target="701">
+      <data key="d13">connects</data>
+    </edge>
+    <edge source="690" target="702">
+      <data key="d13">connects</data>
+    </edge>
+    <edge source="690" target="703">
+      <data key="d13">connects</data>
+    </edge>
+    <edge source="690" target="704">
+      <data key="d13">connects</data>
+    </edge>
+    <edge source="703" target="721">
+      <data key="d13">connects</data>
+    </edge>
+    <edge source="704" target="722">
+      <data key="d13">connects</data>
+    </edge>
+    <edge source="705" target="706">
       <data key="d13">has</data>
     </edge>
-    <edge source="29" target="32">
+    <edge source="705" target="707">
       <data key="d13">has</data>
     </edge>
-    <edge source="32" target="33">
+    <edge source="706" target="708">
       <data key="d13">connects</data>
     </edge>
-    <edge source="32" target="34">
+    <edge source="706" target="709">
       <data key="d13">connects</data>
     </edge>
-    <edge source="32" target="35">
+    <edge source="706" target="710">
       <data key="d13">connects</data>
     </edge>
-    <edge source="32" target="36">
+    <edge source="706" target="711">
       <data key="d13">connects</data>
     </edge>
-    <edge source="32" target="37">
+    <edge source="706" target="712">
       <data key="d13">connects</data>
     </edge>
-    <edge source="32" target="38">
+    <edge source="706" target="713">
       <data key="d13">connects</data>
     </edge>
-    <edge source="32" target="39">
+    <edge source="706" target="714">
       <data key="d13">connects</data>
     </edge>
-    <edge source="32" target="40">
+    <edge source="706" target="715">
       <data key="d13">connects</data>
     </edge>
-    <edge source="32" target="43">
+    <edge source="706" target="716">
       <data key="d13">connects</data>
     </edge>
-    <edge source="32" target="44">
+    <edge source="706" target="717">
       <data key="d13">connects</data>
     </edge>
-    <edge source="32" target="45">
+    <edge source="706" target="718">
       <data key="d13">connects</data>
     </edge>
-    <edge source="32" target="46">
+    <edge source="706" target="719">
       <data key="d13">connects</data>
     </edge>
-    <edge source="32" target="47">
+    <edge source="706" target="720">
       <data key="d13">connects</data>
     </edge>
-    <edge source="32" target="48">
+    <edge source="719" target="723">
       <data key="d13">connects</data>
     </edge>
-    <edge source="32" target="49">
+    <edge source="720" target="722">
       <data key="d13">connects</data>
     </edge>
-    <edge source="32" target="50">
-      <data key="d13">connects</data>
-    </edge>
-    <edge source="32" target="51">
-      <data key="d13">connects</data>
-    </edge>
-    <edge source="32" target="52">
-      <data key="d13">connects</data>
-    </edge>
-    <edge source="32" target="53">
-      <data key="d13">connects</data>
-    </edge>
-    <edge source="32" target="54">
-      <data key="d13">connects</data>
-    </edge>
-    <edge source="32" target="55">
-      <data key="d13">connects</data>
-    </edge>
-    <edge source="32" target="56">
-      <data key="d13">connects</data>
-    </edge>
-    <edge source="40" target="42">
-      <data key="d13">connects</data>
-    </edge>
-    <edge source="41" target="42">
-      <data key="d13">connects</data>
-    </edge>
-    <edge source="57" target="58">
+    <edge source="724" target="725">
       <data key="d13">has</data>
     </edge>
-    <edge source="57" target="59">
+    <edge source="725" target="726">
+      <data key="d13">connects</data>
+    </edge>
+    <edge source="726" target="730">
+      <data key="d13">connects</data>
+    </edge>
+    <edge source="727" target="728">
       <data key="d13">has</data>
     </edge>
-    <edge source="57" target="60">
-      <data key="d13">has</data>
-    </edge>
-    <edge source="60" target="61">
+    <edge source="728" target="729">
       <data key="d13">connects</data>
     </edge>
-    <edge source="60" target="64">
-      <data key="d13">connects</data>
-    </edge>
-    <edge source="60" target="65">
-      <data key="d13">connects</data>
-    </edge>
-    <edge source="60" target="66">
-      <data key="d13">connects</data>
-    </edge>
-    <edge source="60" target="67">
-      <data key="d13">connects</data>
-    </edge>
-    <edge source="60" target="68">
-      <data key="d13">connects</data>
-    </edge>
-    <edge source="60" target="69">
-      <data key="d13">connects</data>
-    </edge>
-    <edge source="60" target="70">
-      <data key="d13">connects</data>
-    </edge>
-    <edge source="60" target="71">
-      <data key="d13">connects</data>
-    </edge>
-    <edge source="60" target="72">
-      <data key="d13">connects</data>
-    </edge>
-    <edge source="60" target="73">
-      <data key="d13">connects</data>
-    </edge>
-    <edge source="60" target="74">
-      <data key="d13">connects</data>
-    </edge>
-    <edge source="60" target="75">
-      <data key="d13">connects</data>
-    </edge>
-    <edge source="60" target="76">
-      <data key="d13">connects</data>
-    </edge>
-    <edge source="61" target="63">
-      <data key="d13">connects</data>
-    </edge>
-    <edge source="62" target="63">
-      <data key="d13">connects</data>
-    </edge>
-    <edge source="75" target="102">
-      <data key="d13">connects</data>
-    </edge>
-    <edge source="76" target="104">
-      <data key="d13">connects</data>
-    </edge>
-    <edge source="77" target="78">
-      <data key="d13">has</data>
-    </edge>
-    <edge source="77" target="79">
-      <data key="d13">has</data>
-    </edge>
-    <edge source="77" target="80">
-      <data key="d13">has</data>
-    </edge>
-    <edge source="80" target="81">
-      <data key="d13">connects</data>
-    </edge>
-    <edge source="80" target="82">
-      <data key="d13">connects</data>
-    </edge>
-    <edge source="80" target="83">
-      <data key="d13">connects</data>
-    </edge>
-    <edge source="80" target="84">
-      <data key="d13">connects</data>
-    </edge>
-    <edge source="80" target="85">
-      <data key="d13">connects</data>
-    </edge>
-    <edge source="80" target="86">
-      <data key="d13">connects</data>
-    </edge>
-    <edge source="80" target="87">
-      <data key="d13">connects</data>
-    </edge>
-    <edge source="80" target="88">
-      <data key="d13">connects</data>
-    </edge>
-    <edge source="80" target="89">
-      <data key="d13">connects</data>
-    </edge>
-    <edge source="80" target="90">
-      <data key="d13">connects</data>
-    </edge>
-    <edge source="80" target="91">
-      <data key="d13">connects</data>
-    </edge>
-    <edge source="80" target="92">
-      <data key="d13">connects</data>
-    </edge>
-    <edge source="80" target="93">
-      <data key="d13">connects</data>
-    </edge>
-    <edge source="80" target="94">
-      <data key="d13">connects</data>
-    </edge>
-    <edge source="80" target="95">
-      <data key="d13">connects</data>
-    </edge>
-    <edge source="80" target="96">
-      <data key="d13">connects</data>
-    </edge>
-    <edge source="80" target="97">
-      <data key="d13">connects</data>
-    </edge>
-    <edge source="80" target="98">
-      <data key="d13">connects</data>
-    </edge>
-    <edge source="80" target="99">
-      <data key="d13">connects</data>
-    </edge>
-    <edge source="80" target="100">
-      <data key="d13">connects</data>
-    </edge>
-    <edge source="80" target="101">
-      <data key="d13">connects</data>
-    </edge>
-    <edge source="82" target="103">
-      <data key="d13">connects</data>
-    </edge>
-    <edge source="83" target="104">
+    <edge source="729" target="731">
       <data key="d13">connects</data>
     </edge>
   </graph>

--- a/neo4j/RENCI-ad.graphml
+++ b/neo4j/RENCI-ad.graphml
@@ -16,184 +16,218 @@
   <key id="d1" for="node" attr.name="Class" attr.type="string" />
   <key id="d0" for="node" attr.name="GraphID" attr.type="string" />
   <graph edgedefault="undirected">
-    <node id="1">
-      <data key="d0">0cb9bb4a-bfb3-47f7-8ddc-b4f1801a9cd6</data>
+    <node id="801">
+      <data key="d0">42479fc2-22a8-4f26-86b8-277beab2e2dd</data>
       <data key="d1">NetworkNode</data>
       <data key="d2">HX6VQ53</data>
-      <data key="d3">renc-w1.fabric-testbed.net</data>
+      <data key="d3">renc-w1</data>
       <data key="d4">Server</data>
       <data key="d5">R7525</data>
-      <data key="d6">{"core": 64, "cpu": 2, "disk": 51000, "ram": 512, "unit": 1}</data>
+      <data key="d6">{"core": 32, "cpu": 2, "disk": 100000, "ram": 512, "unit": 1}</data>
       <data key="d7">false</data>
       <data key="d8">RENC</data>
-      <data key="d9">{"postal": "100 Europa Dr., Chapel Hill, NC 27157"}</data>
-      <data key="d10">{"primary": {"pool_id": "_", "capacities": {"cpu": 2, "core": 64, "ram": 512, "disk": 51000, "unit": 1}}}</data>
+      <data key="d9">{"postal": "100 Europa Dr., Chapel Hill, NC 27517"}</data>
+      <data key="d10">{"primary": {"pool_id": "_", "capacities": {"cpu": 2, "core": 32, "ram": 512, "disk": 100000, "unit": 1}}}</data>
     </node>
-    <node id="2">
-      <data key="d0">0cb9bb4a-bfb3-47f7-8ddc-b4f1801a9cd6</data>
-      <data key="d1">Component</data>
-      <data key="d2">PHLJ016004CC1P0FGN</data>
-      <data key="d3">renc-w1.fabric-testbed.net-nvme-1</data>
-      <data key="d4">NVME</data>
-      <data key="d5">P4510</data>
-      <data key="d6">{"disk": 1000, "unit": 1}</data>
-      <data key="d11">{"bdf": "0000:21:00.0"}</data>
-      <data key="d12">Dell Express Flash NVMe P4510 1TB SFF in PCIe SSD Slot 22 in Bay 2 (0000:21:00.0)</data>
-      <data key="d7">false</data>
-      <data key="d10">{"primary": {"pool_id": "_", "capacities": {"disk": 1000, "unit": 1}}}</data>
-      <data key="d13">{"primary": {"pool_id": "_", "labels": {"bdf": "0000:21:00.0"}}}</data>
-    </node>
-    <node id="3">
-      <data key="d0">0cb9bb4a-bfb3-47f7-8ddc-b4f1801a9cd6</data>
-      <data key="d1">Component</data>
-      <data key="d2">PHLJ0160047K1P0FGN</data>
-      <data key="d3">renc-w1.fabric-testbed.net-nvme-2</data>
-      <data key="d4">NVME</data>
-      <data key="d5">P4510</data>
-      <data key="d6">{"disk": 1000, "unit": 1}</data>
-      <data key="d11">{"bdf": "0000:22:00.0"}</data>
-      <data key="d12">Dell Express Flash NVMe P4510 1TB SFF in PCIe SSD Slot 23 in Bay 2 (0000:22:00.0)</data>
-      <data key="d7">false</data>
-      <data key="d10">{"primary": {"pool_id": "_", "capacities": {"disk": 1000, "unit": 1}}}</data>
-      <data key="d13">{"primary": {"pool_id": "_", "labels": {"bdf": "0000:22:00.0"}}}</data>
-    </node>
-    <node id="4">
-      <data key="d0">0cb9bb4a-bfb3-47f7-8ddc-b4f1801a9cd6</data>
-      <data key="d1">Component</data>
-      <data key="d2">HX6VQ53-gpu-1</data>
-      <data key="d3">renc-w1.fabric-testbed.net-gpu-1</data>
-      <data key="d4">GPU</data>
-      <data key="d5">RTX6000</data>
-      <data key="d6">{"unit": 1}</data>
-      <data key="d11">{"bdf": "0000:25:00.0"}</data>
-      <data key="d12">NVIDIA Corporation TU102GL [Quadro RTX 6000/8000] (rev a1)</data>
-      <data key="d7">false</data>
-      <data key="d10">{"primary": {"pool_id": "_", "capacities": {"unit": 1}}}</data>
-      <data key="d13">{"primary": {"pool_id": "_", "labels": {"bdf": "0000:25:00.0"}}}</data>
-    </node>
-    <node id="5">
-      <data key="d0">0cb9bb4a-bfb3-47f7-8ddc-b4f1801a9cd6</data>
-      <data key="d1">Component</data>
-      <data key="d2">HX6VQ53-gpu-2</data>
-      <data key="d3">renc-w1.fabric-testbed.net-gpu-2</data>
-      <data key="d4">GPU</data>
-      <data key="d5">RTX6000</data>
-      <data key="d6">{"unit": 1}</data>
-      <data key="d11">{"bdf": "0000:81:00.0"}</data>
-      <data key="d12">NVIDIA Corporation TU102GL [Quadro RTX 6000/8000] (rev a1)</data>
-      <data key="d7">false</data>
-      <data key="d10">{"primary": {"pool_id": "_", "capacities": {"unit": 1}}}</data>
-      <data key="d13">{"primary": {"pool_id": "_", "labels": {"bdf": "0000:81:00.0"}}}</data>
-    </node>
-    <node id="6">
-      <data key="d0">0cb9bb4a-bfb3-47f7-8ddc-b4f1801a9cd6</data>
-      <data key="d1">Component</data>
-      <data key="d2">HX6VQ53-slot7</data>
-      <data key="d3">renc-w1.fabric-testbed.net-slot7</data>
-      <data key="d4">SharedNIC</data>
-      <data key="d5">ConnectX-6</data>
-      <data key="d6">{"unit": 127}</data>
-      <data key="d11">{"bdf": ["0000:e2:11.1", "0000:e2:1f.4", "0000:e2:19.0", "0000:e2:10.5", "0000:e2:14.4", "0000:e2:11.5", "0000:e2:1a.2", "0000:e2:11.7", "0000:e2:19.7", "0000:e2:15.3", "0000:e2:15.0", "0000:e2:19.6", "0000:e2:1e.2", "0000:e2:18.1", "0000:e2:1d.2", "0000:e2:1f.0", "0000:e2:1a.3", "0000:e2:14.6", "0000:e2:1f.1", "0000:e2:12.4", "0000:e2:14.0", "0000:e2:1e.5", "0000:e2:1b.1", "0000:e2:1f.5", "0000:e2:17.5", "0000:e2:1c.4", "0000:e2:18.7", "0000:e2:13.7", "0000:e2:12.5", "0000:e2:15.4", "0000:e2:1d.5", "0000:e2:12.1", "0000:e2:14.3", "0000:e2:19.1", "0000:e2:1b.7", "0000:e2:11.4", "0000:e2:1d.4", "0000:e2:15.5", "0000:e2:1c.7", "0000:e2:10.1", "0000:e2:10.7", "0000:e2:17.0", "0000:e2:19.3", "0000:e2:12.0", "0000:e2:1c.2", "0000:e2:1e.0", "0000:e2:1e.7", "0000:e2:1d.7", "0000:e2:15.2", "0000:e2:17.7", "0000:e2:15.1", "0000:e2:17.4", "0000:e2:17.2", "0000:e2:1b.6", "0000:e2:10.2", "0000:e2:1f.3", "0000:e2:1d.3", "0000:e2:1b.0", "0000:e2:14.5", "0000:e2:13.3", "0000:e2:17.3", "0000:e2:13.4", "0000:e2:1d.6", "0000:e2:1c.1", "0000:e2:19.5", "0000:e2:1d.0", "0000:e2:13.0", "0000:e2:14.7", "0000:e2:14.1", "0000:e2:1e.3", "0000:e2:15.6", "0000:e2:1b.2", "0000:e2:18.2", "0000:e2:16.4", "0000:e2:18.4", "0000:e2:15.7", "0000:e2:1c.5", "0000:e2:16.6", "0000:e2:1e.4", "0000:e2:17.1", "0000:e2:1f.7", "0000:e2:13.5", "0000:e2:18.0", "0000:e2:1b.3", "0000:e2:11.6", "0000:e2:1a.6", "0000:e2:1a.7", "0000:e2:1a.1", "0000:e2:18.3", "0000:e2:1b.5", "0000:e2:12.2", "0000:e2:13.2", "0000:e2:12.6", "0000:e2:16.5", "0000:e2:11.3", "0000:e2:18.5", "0000:e2:11.2", "0000:e2:11.0", "0000:e2:16.7", "0000:e2:1c.6", "0000:e2:1a.0", "0000:e2:13.6", "0000:e2:1e.6", "0000:e2:16.2", "0000:e2:16.0", "0000:e2:17.6", "0000:e2:14.2", "0000:e2:1d.1", "0000:e2:12.7", "0000:e2:1b.4", "0000:e2:13.1", "0000:e2:1c.0", "0000:e2:10.3", "0000:e2:1e.1", "0000:e2:19.2", "0000:e2:1f.2", "0000:e2:1f.6", "0000:e2:10.4", "0000:e2:1c.3", "0000:e2:12.3", "0000:e2:18.6", "0000:e2:16.1", "0000:e2:1a.4", "0000:e2:10.6", "0000:e2:19.4", "0000:e2:1a.5", "0000:e2:16.3"]}</data>
-      <data key="d12">Mellanox Technologies MT28908 Family [ConnectX-6] in PCIe Slot 7 (0000:e2:00.1)</data>
-      <data key="d7">false</data>
-      <data key="d10">{"primary": {"pool_id": "_", "capacities": {"unit": 127}}}</data>
-      <data key="d13">{"primary": {"pool_id": "_", "labels": {"bdf": ["0000:e2:11.1", "0000:e2:1f.4", "0000:e2:19.0", "0000:e2:10.5", "0000:e2:14.4", "0000:e2:11.5", "0000:e2:1a.2", "0000:e2:11.7", "0000:e2:19.7", "0000:e2:15.3", "0000:e2:15.0", "0000:e2:19.6", "0000:e2:1e.2", "0000:e2:18.1", "0000:e2:1d.2", "0000:e2:1f.0", "0000:e2:1a.3", "0000:e2:14.6", "0000:e2:1f.1", "0000:e2:12.4", "0000:e2:14.0", "0000:e2:1e.5", "0000:e2:1b.1", "0000:e2:1f.5", "0000:e2:17.5", "0000:e2:1c.4", "0000:e2:18.7", "0000:e2:13.7", "0000:e2:12.5", "0000:e2:15.4", "0000:e2:1d.5", "0000:e2:12.1", "0000:e2:14.3", "0000:e2:19.1", "0000:e2:1b.7", "0000:e2:11.4", "0000:e2:1d.4", "0000:e2:15.5", "0000:e2:1c.7", "0000:e2:10.1", "0000:e2:10.7", "0000:e2:17.0", "0000:e2:19.3", "0000:e2:12.0", "0000:e2:1c.2", "0000:e2:1e.0", "0000:e2:1e.7", "0000:e2:1d.7", "0000:e2:15.2", "0000:e2:17.7", "0000:e2:15.1", "0000:e2:17.4", "0000:e2:17.2", "0000:e2:1b.6", "0000:e2:10.2", "0000:e2:1f.3", "0000:e2:1d.3", "0000:e2:1b.0", "0000:e2:14.5", "0000:e2:13.3", "0000:e2:17.3", "0000:e2:13.4", "0000:e2:1d.6", "0000:e2:1c.1", "0000:e2:19.5", "0000:e2:1d.0", "0000:e2:13.0", "0000:e2:14.7", "0000:e2:14.1", "0000:e2:1e.3", "0000:e2:15.6", "0000:e2:1b.2", "0000:e2:18.2", "0000:e2:16.4", "0000:e2:18.4", "0000:e2:15.7", "0000:e2:1c.5", "0000:e2:16.6", "0000:e2:1e.4", "0000:e2:17.1", "0000:e2:1f.7", "0000:e2:13.5", "0000:e2:18.0", "0000:e2:1b.3", "0000:e2:11.6", "0000:e2:1a.6", "0000:e2:1a.7", "0000:e2:1a.1", "0000:e2:18.3", "0000:e2:1b.5", "0000:e2:12.2", "0000:e2:13.2", "0000:e2:12.6", "0000:e2:16.5", "0000:e2:11.3", "0000:e2:18.5", "0000:e2:11.2", "0000:e2:11.0", "0000:e2:16.7", "0000:e2:1c.6", "0000:e2:1a.0", "0000:e2:13.6", "0000:e2:1e.6", "0000:e2:16.2", "0000:e2:16.0", "0000:e2:17.6", "0000:e2:14.2", "0000:e2:1d.1", "0000:e2:12.7", "0000:e2:1b.4", "0000:e2:13.1", "0000:e2:1c.0", "0000:e2:10.3", "0000:e2:1e.1", "0000:e2:19.2", "0000:e2:1f.2", "0000:e2:1f.6", "0000:e2:10.4", "0000:e2:1c.3", "0000:e2:12.3", "0000:e2:18.6", "0000:e2:16.1", "0000:e2:1a.4", "0000:e2:10.6", "0000:e2:19.4", "0000:e2:1a.5", "0000:e2:16.3"]}}}</data>
-    </node>
-    <node id="7">
-      <data key="d0">0cb9bb4a-bfb3-47f7-8ddc-b4f1801a9cd6</data>
-      <data key="d1">NetworkService</data>
-      <data key="d2">HX6VQ53-slot7-ns</data>
-      <data key="d3">renc-w1.fabric-testbed.net-renc-w1.fabric-testbed.net-slot7-l2ovs</data>
-      <data key="d4">OVS</data>
-      <data key="d7">false</data>
-      <data key="d14">L2</data>
-    </node>
-    <node id="8">
-      <data key="d0">0cb9bb4a-bfb3-47f7-8ddc-b4f1801a9cd6</data>
-      <data key="d1">ConnectionPoint</data>
-      <data key="d2">node_id-04-3F-72-B7-14-ED</data>
-      <data key="d3">renc-w1.fabric-testbed.net-slot7-p1</data>
-      <data key="d4">SharedPort</data>
-      <data key="d6">{"unit": 127}</data>
-      <data key="d11">{"bdf": ["0000:e2:11.1", "0000:e2:1f.4", "0000:e2:19.0", "0000:e2:10.5", "0000:e2:14.4", "0000:e2:11.5", "0000:e2:1a.2", "0000:e2:11.7", "0000:e2:19.7", "0000:e2:15.3", "0000:e2:15.0", "0000:e2:19.6", "0000:e2:1e.2", "0000:e2:18.1", "0000:e2:1d.2", "0000:e2:1f.0", "0000:e2:1a.3", "0000:e2:14.6", "0000:e2:1f.1", "0000:e2:12.4", "0000:e2:14.0", "0000:e2:1e.5", "0000:e2:1b.1", "0000:e2:1f.5", "0000:e2:17.5", "0000:e2:1c.4", "0000:e2:18.7", "0000:e2:13.7", "0000:e2:12.5", "0000:e2:15.4", "0000:e2:1d.5", "0000:e2:12.1", "0000:e2:14.3", "0000:e2:19.1", "0000:e2:1b.7", "0000:e2:11.4", "0000:e2:1d.4", "0000:e2:15.5", "0000:e2:1c.7", "0000:e2:10.1", "0000:e2:10.7", "0000:e2:17.0", "0000:e2:19.3", "0000:e2:12.0", "0000:e2:1c.2", "0000:e2:1e.0", "0000:e2:1e.7", "0000:e2:1d.7", "0000:e2:15.2", "0000:e2:17.7", "0000:e2:15.1", "0000:e2:17.4", "0000:e2:17.2", "0000:e2:1b.6", "0000:e2:10.2", "0000:e2:1f.3", "0000:e2:1d.3", "0000:e2:1b.0", "0000:e2:14.5", "0000:e2:13.3", "0000:e2:17.3", "0000:e2:13.4", "0000:e2:1d.6", "0000:e2:1c.1", "0000:e2:19.5", "0000:e2:1d.0", "0000:e2:13.0", "0000:e2:14.7", "0000:e2:14.1", "0000:e2:1e.3", "0000:e2:15.6", "0000:e2:1b.2", "0000:e2:18.2", "0000:e2:16.4", "0000:e2:18.4", "0000:e2:15.7", "0000:e2:1c.5", "0000:e2:16.6", "0000:e2:1e.4", "0000:e2:17.1", "0000:e2:1f.7", "0000:e2:13.5", "0000:e2:18.0", "0000:e2:1b.3", "0000:e2:11.6", "0000:e2:1a.6", "0000:e2:1a.7", "0000:e2:1a.1", "0000:e2:18.3", "0000:e2:1b.5", "0000:e2:12.2", "0000:e2:13.2", "0000:e2:12.6", "0000:e2:16.5", "0000:e2:11.3", "0000:e2:18.5", "0000:e2:11.2", "0000:e2:11.0", "0000:e2:16.7", "0000:e2:1c.6", "0000:e2:1a.0", "0000:e2:13.6", "0000:e2:1e.6", "0000:e2:16.2", "0000:e2:16.0", "0000:e2:17.6", "0000:e2:14.2", "0000:e2:1d.1", "0000:e2:12.7", "0000:e2:1b.4", "0000:e2:13.1", "0000:e2:1c.0", "0000:e2:10.3", "0000:e2:1e.1", "0000:e2:19.2", "0000:e2:1f.2", "0000:e2:1f.6", "0000:e2:10.4", "0000:e2:1c.3", "0000:e2:12.3", "0000:e2:18.6", "0000:e2:16.1", "0000:e2:1a.4", "0000:e2:10.6", "0000:e2:19.4", "0000:e2:1a.5", "0000:e2:16.3"], "local_name": ["p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1"], "mac": ["02:28:8A:FD:8E:31", "02:A3:D8:3C:ED:76", "02:AC:7C:D7:EA:09", "02:CB:D3:1D:95:C2", "02:D1:10:1B:A3:6E", "06:4F:A5:2C:BD:D8", "06:83:35:C5:E2:68", "06:A0:3A:AE:3F:98", "06:BE:DF:A0:39:F7", "06:E7:AA:80:FE:E6", "0A:88:68:1F:EC:D4", "0E:44:7B:D8:23:C9", "0E:B9:29:CD:21:8E", "12:04:43:72:91:15", "12:1A:33:7D:F5:17", "12:F6:7B:61:01:AA", "16:14:F5:3E:EF:8E", "16:39:7A:AC:1C:3C", "16:61:AE:62:61:46", "16:98:4B:C8:84:B2", "16:E4:84:20:79:2F", "16:EE:ED:A9:E7:B0", "16:FA:17:78:90:5E", "1A:73:E0:7D:82:4E", "1A:CA:ED:62:B8:24", "1E:09:9B:E8:9D:DC", "1E:BD:09:86:AD:D9", "1E:FA:2A:C6:4E:01", "22:67:7E:8E:33:A2", "22:A2:51:AE:73:4B", "26:6B:7C:D5:9E:2B", "2A:9F:7B:92:11:E9", "2E:4C:53:1D:27:24", "2E:B0:D6:89:EC:81", "32:88:8C:15:67:93", "32:DC:E9:9E:C9:48", "3A:89:1B:B2:49:0A", "3E:39:69:81:62:E0", "3E:6D:72:C4:26:F1", "42:BA:C5:32:9B:6E", "46:2A:8F:71:6F:B0", "46:46:FD:B6:86:94", "46:5D:8A:28:B9:B5", "46:83:11:0A:E9:1B", "46:83:D7:BD:5C:17", "4E:C5:06:A9:45:31", "52:FC:F3:9F:AE:17", "56:01:81:57:3E:65", "56:F6:9D:D2:CF:A2", "5A:8E:46:78:08:70", "5E:55:FE:2E:06:B1", "5E:F4:B6:66:DB:28", "62:08:ED:DD:D5:B0", "62:88:72:45:CA:BA", "62:E0:52:A8:32:27", "62:EA:DC:90:A8:EE", "66:0B:86:45:8C:DD", "66:0E:16:1E:41:B3", "66:6A:F8:D4:77:4F", "66:A1:AC:F8:30:01", "66:B7:08:EA:BF:AF", "66:B9:D9:CD:74:D3", "66:E0:53:32:9A:2A", "6A:2A:3C:26:68:A0", "6A:BD:A2:D1:C9:A1", "6E:1B:D1:13:EE:ED", "6E:7C:93:13:10:97", "6E:7D:D2:84:A4:DB", "6E:B8:5C:6C:E4:1D", "6E:CE:61:51:F4:F0", "72:B1:FB:FF:E5:41", "76:03:1D:4A:DC:8A", "76:56:7F:2B:29:B0", "7E:08:74:A9:3B:81", "82:91:4B:41:E7:53", "82:D0:04:18:6A:75", "86:47:83:BB:A8:5A", "86:94:5D:0B:2F:B2", "86:AD:8D:34:BF:42", "8A:13:8B:C4:81:6A", "8A:1E:2D:C2:37:38", "8A:93:C1:FB:0A:E8", "8E:28:31:AA:8B:27", "8E:83:3F:4F:7E:68", "96:5E:9D:51:D6:47", "96:75:0F:1D:87:0F", "96:B1:BE:35:DC:63", "9A:10:CA:39:C5:CF", "9A:89:C2:70:86:D6", "A6:3D:2C:56:AA:7B", "AA:43:E8:3E:72:85", "AA:B9:8C:D4:F3:94", "AA:C6:57:C8:CA:2B", "AA:F2:59:85:AF:09", "AE:5D:65:56:12:3C", "AE:D3:7B:E7:CC:F5", "AE:E6:A6:C8:45:FF", "B2:AA:15:18:7E:4C", "B6:15:DB:1F:8A:CD", "BA:49:F1:67:67:0C", "BA:F0:97:A9:3B:73", "BE:8D:C2:F0:B3:0D", "BE:ED:9E:AC:48:7F", "BE:F0:04:D7:DD:63", "C2:DE:5B:70:D3:1F", "C6:69:E5:81:45:68", "C6:74:FD:66:BD:F7", "C6:BE:9D:58:B3:35", "CA:97:95:37:C5:D4", "CE:34:97:33:37:95", "D2:37:CD:52:A7:26", "D2:75:4E:3C:3D:ED", "D6:19:7B:7E:6B:10", "DA:19:36:13:E8:73", "DA:A3:95:81:BF:85", "DA:B3:DC:23:F9:3F", "DE:58:6C:4B:81:E6", "DE:FF:DC:60:90:6A", "EA:B6:39:B5:B7:6C", "EA:BC:33:FD:16:C3", "EA:E5:E6:CB:F1:3F", "EE:7F:0A:46:04:52", "EE:9B:0E:AE:0B:6A", "EE:DA:4E:B8:1C:67", "F6:D6:C8:57:30:A5", "FA:67:96:CB:D7:CF", "FE:44:FB:F9:35:74"], "vlan": ["2008", "2123", "2071", "2004", "2035", "2012", "2081", "2014", "2078", "2042", "2039", "2077", "2113", "2064", "2105", "2119", "2082", "2037", "2120", "2019", "2031", "2116", "2088", "2124", "2060", "2099", "2070", "2030", "2020", "2043", "2108", "2016", "2034", "2072", "2094", "2011", "2107", "2044", "2102", "2000", "2006", "2055", "2074", "2015", "2097", "2111", "2118", "2110", "2041", "2062", "2040", "2059", "2057", "2093", "2001", "2122", "2106", "2087", "2036", "2026", "2058", "2027", "2109", "2096", "2076", "2103", "2023", "2038", "2032", "2114", "2045", "2089", "2065", "2051", "2067", "2046", "2100", "2053", "2115", "2056", "2126", "2028", "2063", "2090", "2013", "2085", "2086", "2080", "2066", "2092", "2017", "2025", "2021", "2052", "2010", "2068", "2009", "2007", "2054", "2101", "2079", "2029", "2117", "2049", "2047", "2061", "2033", "2104", "2022", "2091", "2024", "2095", "2002", "2112", "2073", "2121", "2125", "2003", "2098", "2018", "2069", "2048", "2083", "2005", "2075", "2084", "2050"]}</data>
-      <data key="d7">false</data>
-      <data key="d10">{"primary": {"pool_id": "_", "capacities": {"unit": 127}}}</data>
-      <data key="d13">{"primary": {"pool_id": "_", "labels": {"bdf": ["0000:e2:11.1", "0000:e2:1f.4", "0000:e2:19.0", "0000:e2:10.5", "0000:e2:14.4", "0000:e2:11.5", "0000:e2:1a.2", "0000:e2:11.7", "0000:e2:19.7", "0000:e2:15.3", "0000:e2:15.0", "0000:e2:19.6", "0000:e2:1e.2", "0000:e2:18.1", "0000:e2:1d.2", "0000:e2:1f.0", "0000:e2:1a.3", "0000:e2:14.6", "0000:e2:1f.1", "0000:e2:12.4", "0000:e2:14.0", "0000:e2:1e.5", "0000:e2:1b.1", "0000:e2:1f.5", "0000:e2:17.5", "0000:e2:1c.4", "0000:e2:18.7", "0000:e2:13.7", "0000:e2:12.5", "0000:e2:15.4", "0000:e2:1d.5", "0000:e2:12.1", "0000:e2:14.3", "0000:e2:19.1", "0000:e2:1b.7", "0000:e2:11.4", "0000:e2:1d.4", "0000:e2:15.5", "0000:e2:1c.7", "0000:e2:10.1", "0000:e2:10.7", "0000:e2:17.0", "0000:e2:19.3", "0000:e2:12.0", "0000:e2:1c.2", "0000:e2:1e.0", "0000:e2:1e.7", "0000:e2:1d.7", "0000:e2:15.2", "0000:e2:17.7", "0000:e2:15.1", "0000:e2:17.4", "0000:e2:17.2", "0000:e2:1b.6", "0000:e2:10.2", "0000:e2:1f.3", "0000:e2:1d.3", "0000:e2:1b.0", "0000:e2:14.5", "0000:e2:13.3", "0000:e2:17.3", "0000:e2:13.4", "0000:e2:1d.6", "0000:e2:1c.1", "0000:e2:19.5", "0000:e2:1d.0", "0000:e2:13.0", "0000:e2:14.7", "0000:e2:14.1", "0000:e2:1e.3", "0000:e2:15.6", "0000:e2:1b.2", "0000:e2:18.2", "0000:e2:16.4", "0000:e2:18.4", "0000:e2:15.7", "0000:e2:1c.5", "0000:e2:16.6", "0000:e2:1e.4", "0000:e2:17.1", "0000:e2:1f.7", "0000:e2:13.5", "0000:e2:18.0", "0000:e2:1b.3", "0000:e2:11.6", "0000:e2:1a.6", "0000:e2:1a.7", "0000:e2:1a.1", "0000:e2:18.3", "0000:e2:1b.5", "0000:e2:12.2", "0000:e2:13.2", "0000:e2:12.6", "0000:e2:16.5", "0000:e2:11.3", "0000:e2:18.5", "0000:e2:11.2", "0000:e2:11.0", "0000:e2:16.7", "0000:e2:1c.6", "0000:e2:1a.0", "0000:e2:13.6", "0000:e2:1e.6", "0000:e2:16.2", "0000:e2:16.0", "0000:e2:17.6", "0000:e2:14.2", "0000:e2:1d.1", "0000:e2:12.7", "0000:e2:1b.4", "0000:e2:13.1", "0000:e2:1c.0", "0000:e2:10.3", "0000:e2:1e.1", "0000:e2:19.2", "0000:e2:1f.2", "0000:e2:1f.6", "0000:e2:10.4", "0000:e2:1c.3", "0000:e2:12.3", "0000:e2:18.6", "0000:e2:16.1", "0000:e2:1a.4", "0000:e2:10.6", "0000:e2:19.4", "0000:e2:1a.5", "0000:e2:16.3"], "mac": ["02:28:8A:FD:8E:31", "02:A3:D8:3C:ED:76", "02:AC:7C:D7:EA:09", "02:CB:D3:1D:95:C2", "02:D1:10:1B:A3:6E", "06:4F:A5:2C:BD:D8", "06:83:35:C5:E2:68", "06:A0:3A:AE:3F:98", "06:BE:DF:A0:39:F7", "06:E7:AA:80:FE:E6", "0A:88:68:1F:EC:D4", "0E:44:7B:D8:23:C9", "0E:B9:29:CD:21:8E", "12:04:43:72:91:15", "12:1A:33:7D:F5:17", "12:F6:7B:61:01:AA", "16:14:F5:3E:EF:8E", "16:39:7A:AC:1C:3C", "16:61:AE:62:61:46", "16:98:4B:C8:84:B2", "16:E4:84:20:79:2F", "16:EE:ED:A9:E7:B0", "16:FA:17:78:90:5E", "1A:73:E0:7D:82:4E", "1A:CA:ED:62:B8:24", "1E:09:9B:E8:9D:DC", "1E:BD:09:86:AD:D9", "1E:FA:2A:C6:4E:01", "22:67:7E:8E:33:A2", "22:A2:51:AE:73:4B", "26:6B:7C:D5:9E:2B", "2A:9F:7B:92:11:E9", "2E:4C:53:1D:27:24", "2E:B0:D6:89:EC:81", "32:88:8C:15:67:93", "32:DC:E9:9E:C9:48", "3A:89:1B:B2:49:0A", "3E:39:69:81:62:E0", "3E:6D:72:C4:26:F1", "42:BA:C5:32:9B:6E", "46:2A:8F:71:6F:B0", "46:46:FD:B6:86:94", "46:5D:8A:28:B9:B5", "46:83:11:0A:E9:1B", "46:83:D7:BD:5C:17", "4E:C5:06:A9:45:31", "52:FC:F3:9F:AE:17", "56:01:81:57:3E:65", "56:F6:9D:D2:CF:A2", "5A:8E:46:78:08:70", "5E:55:FE:2E:06:B1", "5E:F4:B6:66:DB:28", "62:08:ED:DD:D5:B0", "62:88:72:45:CA:BA", "62:E0:52:A8:32:27", "62:EA:DC:90:A8:EE", "66:0B:86:45:8C:DD", "66:0E:16:1E:41:B3", "66:6A:F8:D4:77:4F", "66:A1:AC:F8:30:01", "66:B7:08:EA:BF:AF", "66:B9:D9:CD:74:D3", "66:E0:53:32:9A:2A", "6A:2A:3C:26:68:A0", "6A:BD:A2:D1:C9:A1", "6E:1B:D1:13:EE:ED", "6E:7C:93:13:10:97", "6E:7D:D2:84:A4:DB", "6E:B8:5C:6C:E4:1D", "6E:CE:61:51:F4:F0", "72:B1:FB:FF:E5:41", "76:03:1D:4A:DC:8A", "76:56:7F:2B:29:B0", "7E:08:74:A9:3B:81", "82:91:4B:41:E7:53", "82:D0:04:18:6A:75", "86:47:83:BB:A8:5A", "86:94:5D:0B:2F:B2", "86:AD:8D:34:BF:42", "8A:13:8B:C4:81:6A", "8A:1E:2D:C2:37:38", "8A:93:C1:FB:0A:E8", "8E:28:31:AA:8B:27", "8E:83:3F:4F:7E:68", "96:5E:9D:51:D6:47", "96:75:0F:1D:87:0F", "96:B1:BE:35:DC:63", "9A:10:CA:39:C5:CF", "9A:89:C2:70:86:D6", "A6:3D:2C:56:AA:7B", "AA:43:E8:3E:72:85", "AA:B9:8C:D4:F3:94", "AA:C6:57:C8:CA:2B", "AA:F2:59:85:AF:09", "AE:5D:65:56:12:3C", "AE:D3:7B:E7:CC:F5", "AE:E6:A6:C8:45:FF", "B2:AA:15:18:7E:4C", "B6:15:DB:1F:8A:CD", "BA:49:F1:67:67:0C", "BA:F0:97:A9:3B:73", "BE:8D:C2:F0:B3:0D", "BE:ED:9E:AC:48:7F", "BE:F0:04:D7:DD:63", "C2:DE:5B:70:D3:1F", "C6:69:E5:81:45:68", "C6:74:FD:66:BD:F7", "C6:BE:9D:58:B3:35", "CA:97:95:37:C5:D4", "CE:34:97:33:37:95", "D2:37:CD:52:A7:26", "D2:75:4E:3C:3D:ED", "D6:19:7B:7E:6B:10", "DA:19:36:13:E8:73", "DA:A3:95:81:BF:85", "DA:B3:DC:23:F9:3F", "DE:58:6C:4B:81:E6", "DE:FF:DC:60:90:6A", "EA:B6:39:B5:B7:6C", "EA:BC:33:FD:16:C3", "EA:E5:E6:CB:F1:3F", "EE:7F:0A:46:04:52", "EE:9B:0E:AE:0B:6A", "EE:DA:4E:B8:1C:67", "F6:D6:C8:57:30:A5", "FA:67:96:CB:D7:CF", "FE:44:FB:F9:35:74"], "vlan": ["2008", "2123", "2071", "2004", "2035", "2012", "2081", "2014", "2078", "2042", "2039", "2077", "2113", "2064", "2105", "2119", "2082", "2037", "2120", "2019", "2031", "2116", "2088", "2124", "2060", "2099", "2070", "2030", "2020", "2043", "2108", "2016", "2034", "2072", "2094", "2011", "2107", "2044", "2102", "2000", "2006", "2055", "2074", "2015", "2097", "2111", "2118", "2110", "2041", "2062", "2040", "2059", "2057", "2093", "2001", "2122", "2106", "2087", "2036", "2026", "2058", "2027", "2109", "2096", "2076", "2103", "2023", "2038", "2032", "2114", "2045", "2089", "2065", "2051", "2067", "2046", "2100", "2053", "2115", "2056", "2126", "2028", "2063", "2090", "2013", "2085", "2086", "2080", "2066", "2092", "2017", "2025", "2021", "2052", "2010", "2068", "2009", "2007", "2054", "2101", "2079", "2029", "2117", "2049", "2047", "2061", "2033", "2104", "2022", "2091", "2024", "2095", "2002", "2112", "2073", "2121", "2125", "2003", "2098", "2018", "2069", "2048", "2083", "2005", "2075", "2084", "2050"], "local_name": ["p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1"]}}}</data>
-    </node>
-    <node id="9">
-      <data key="d0">0cb9bb4a-bfb3-47f7-8ddc-b4f1801a9cd6</data>
+    <node id="802">
+      <data key="d0">42479fc2-22a8-4f26-86b8-277beab2e2dd</data>
       <data key="d1">NetworkNode</data>
       <data key="d2">HX7LQ53</data>
-      <data key="d3">renc-w2.fabric-testbed.net</data>
+      <data key="d3">renc-w2</data>
       <data key="d4">Server</data>
       <data key="d5">R7525</data>
-      <data key="d6">{"core": 64, "cpu": 2, "disk": 4800, "ram": 512, "unit": 1}</data>
+      <data key="d6">{"core": 32, "cpu": 2, "disk": 4800, "ram": 512, "unit": 1}</data>
       <data key="d7">false</data>
       <data key="d8">RENC</data>
-      <data key="d9">{"postal": "100 Europa Dr., Chapel Hill, NC 27157"}</data>
-      <data key="d10">{"primary": {"pool_id": "_", "capacities": {"cpu": 2, "core": 64, "ram": 512, "disk": 4800, "unit": 1}}}</data>
+      <data key="d9">{"postal": "100 Europa Dr., Chapel Hill, NC 27517"}</data>
+      <data key="d10">{"primary": {"pool_id": "_", "capacities": {"cpu": 2, "core": 32, "ram": 512, "disk": 4800, "unit": 1}}}</data>
     </node>
-    <node id="10">
-      <data key="d0">0cb9bb4a-bfb3-47f7-8ddc-b4f1801a9cd6</data>
+    <node id="803">
+      <data key="d0">42479fc2-22a8-4f26-86b8-277beab2e2dd</data>
+      <data key="d1">NetworkNode</data>
+      <data key="d2">HX7KQ53</data>
+      <data key="d3">renc-w3</data>
+      <data key="d4">Server</data>
+      <data key="d5">R7525</data>
+      <data key="d6">{"core": 32, "cpu": 2, "disk": 4800, "ram": 512, "unit": 1}</data>
+      <data key="d7">false</data>
+      <data key="d8">RENC</data>
+      <data key="d9">{"postal": "100 Europa Dr., Chapel Hill, NC 27517"}</data>
+      <data key="d10">{"primary": {"pool_id": "_", "capacities": {"cpu": 2, "core": 32, "ram": 512, "disk": 4800, "unit": 1}}}</data>
+    </node>
+    <node id="804">
+      <data key="d0">42479fc2-22a8-4f26-86b8-277beab2e2dd</data>
       <data key="d1">Component</data>
-      <data key="d2">PHLJ015301TU1P0FGN</data>
-      <data key="d3">renc-w2.fabric-testbed.net-nvme-1</data>
+      <data key="d2">PHLJ016004CC1P0FGN</data>
+      <data key="d3">renc-w1-nvme1</data>
       <data key="d4">NVME</data>
       <data key="d5">P4510</data>
       <data key="d6">{"disk": 1000, "unit": 1}</data>
       <data key="d11">{"bdf": "0000:21:00.0"}</data>
-      <data key="d12">Dell Express Flash NVMe P4510 1TB SFF in PCIe SSD Slot 22 in Bay 2 (0000:21:00.0)</data>
+      <data key="d12">Dell Express Flash NVMe P4510 1TB SFF</data>
       <data key="d7">false</data>
       <data key="d10">{"primary": {"pool_id": "_", "capacities": {"disk": 1000, "unit": 1}}}</data>
       <data key="d13">{"primary": {"pool_id": "_", "labels": {"bdf": "0000:21:00.0"}}}</data>
     </node>
-    <node id="11">
-      <data key="d0">0cb9bb4a-bfb3-47f7-8ddc-b4f1801a9cd6</data>
+    <node id="805">
+      <data key="d0">42479fc2-22a8-4f26-86b8-277beab2e2dd</data>
       <data key="d1">Component</data>
-      <data key="d2">PHLJ016004CK1P0FGN</data>
-      <data key="d3">renc-w2.fabric-testbed.net-nvme-2</data>
+      <data key="d2">PHLJ0160047K1P0FGN</data>
+      <data key="d3">renc-w1-nvme2</data>
       <data key="d4">NVME</data>
       <data key="d5">P4510</data>
       <data key="d6">{"disk": 1000, "unit": 1}</data>
       <data key="d11">{"bdf": "0000:22:00.0"}</data>
-      <data key="d12">Dell Express Flash NVMe P4510 1TB SFF in PCIe SSD Slot 23 in Bay 2 (0000:22:00.0)</data>
+      <data key="d12">Dell Express Flash NVMe P4510 1TB SFF</data>
       <data key="d7">false</data>
       <data key="d10">{"primary": {"pool_id": "_", "capacities": {"disk": 1000, "unit": 1}}}</data>
       <data key="d13">{"primary": {"pool_id": "_", "labels": {"bdf": "0000:22:00.0"}}}</data>
     </node>
-    <node id="12">
-      <data key="d0">0cb9bb4a-bfb3-47f7-8ddc-b4f1801a9cd6</data>
+    <node id="806">
+      <data key="d0">42479fc2-22a8-4f26-86b8-277beab2e2dd</data>
+      <data key="d1">Component</data>
+      <data key="d2">PHLJ015301TU1P0FGN</data>
+      <data key="d3">renc-w2-nvme1</data>
+      <data key="d4">NVME</data>
+      <data key="d5">P4510</data>
+      <data key="d6">{"disk": 1000, "unit": 1}</data>
+      <data key="d11">{"bdf": "000:21:00.0"}</data>
+      <data key="d12">Dell Express Flash NVMe P4510 1TB SFF</data>
+      <data key="d7">false</data>
+      <data key="d10">{"primary": {"pool_id": "_", "capacities": {"disk": 1000, "unit": 1}}}</data>
+      <data key="d13">{"primary": {"pool_id": "_", "labels": {"bdf": "000:21:00.0"}}}</data>
+    </node>
+    <node id="807">
+      <data key="d0">42479fc2-22a8-4f26-86b8-277beab2e2dd</data>
+      <data key="d1">Component</data>
+      <data key="d2">PHLJ016004CK1P0FGN</data>
+      <data key="d3">renc-w2-nvme2</data>
+      <data key="d4">NVME</data>
+      <data key="d5">P4510</data>
+      <data key="d6">{"disk": 1000, "unit": 1}</data>
+      <data key="d11">{"bdf": "0000:22:00.0"}</data>
+      <data key="d12">Dell Express Flash NVMe P4510 1TB SFF</data>
+      <data key="d7">false</data>
+      <data key="d10">{"primary": {"pool_id": "_", "capacities": {"disk": 1000, "unit": 1}}}</data>
+      <data key="d13">{"primary": {"pool_id": "_", "labels": {"bdf": "0000:22:00.0"}}}</data>
+    </node>
+    <node id="808">
+      <data key="d0">42479fc2-22a8-4f26-86b8-277beab2e2dd</data>
       <data key="d1">Component</data>
       <data key="d2">PHLJ016002P61P0FGN</data>
-      <data key="d3">renc-w2.fabric-testbed.net-nvme-3</data>
+      <data key="d3">renc-w2-nvme3</data>
       <data key="d4">NVME</data>
       <data key="d5">P4510</data>
       <data key="d6">{"disk": 1000, "unit": 1}</data>
       <data key="d11">{"bdf": "0000:23:00.0"}</data>
-      <data key="d12">Dell Express Flash NVMe P4510 1TB SFF in PCIe SSD Slot 20 in Bay 2 (0000:23:00.0)</data>
+      <data key="d12">Dell Express Flash NVMe P4510 1TB SFF</data>
       <data key="d7">false</data>
       <data key="d10">{"primary": {"pool_id": "_", "capacities": {"disk": 1000, "unit": 1}}}</data>
       <data key="d13">{"primary": {"pool_id": "_", "labels": {"bdf": "0000:23:00.0"}}}</data>
     </node>
-    <node id="13">
-      <data key="d0">0cb9bb4a-bfb3-47f7-8ddc-b4f1801a9cd6</data>
+    <node id="809">
+      <data key="d0">42479fc2-22a8-4f26-86b8-277beab2e2dd</data>
       <data key="d1">Component</data>
       <data key="d2">PHLJ016004CL1P0FGN</data>
-      <data key="d3">renc-w2.fabric-testbed.net-nvme-4</data>
+      <data key="d3">renc-w2-nvme4</data>
       <data key="d4">NVME</data>
       <data key="d5">P4510</data>
       <data key="d6">{"disk": 1000, "unit": 1}</data>
       <data key="d11">{"bdf": "0000:24:00.0"}</data>
-      <data key="d12">Dell Express Flash NVMe P4510 1TB SFF in PCIe SSD Slot 21 in Bay 2 (0000:24:00.0)</data>
+      <data key="d12">Dell Express Flash NVMe P4510 1TB SFF</data>
       <data key="d7">false</data>
       <data key="d10">{"primary": {"pool_id": "_", "capacities": {"disk": 1000, "unit": 1}}}</data>
       <data key="d13">{"primary": {"pool_id": "_", "labels": {"bdf": "0000:24:00.0"}}}</data>
     </node>
-    <node id="14">
-      <data key="d0">0cb9bb4a-bfb3-47f7-8ddc-b4f1801a9cd6</data>
+    <node id="810">
+      <data key="d0">42479fc2-22a8-4f26-86b8-277beab2e2dd</data>
       <data key="d1">Component</data>
-      <data key="d2">HX7LQ53-gpu-1</data>
-      <data key="d3">renc-w2.fabric-testbed.net-gpu-1</data>
+      <data key="d2">PHLJ015301V81P0FGN</data>
+      <data key="d3">renc-w3-nvme1</data>
+      <data key="d4">NVME</data>
+      <data key="d5">P4510</data>
+      <data key="d6">{"disk": 1000, "unit": 1}</data>
+      <data key="d11">{"bdf": "0000:21:00.0"}</data>
+      <data key="d12">Dell Express Flash NVMe P4510 1TB SFF</data>
+      <data key="d7">false</data>
+      <data key="d10">{"primary": {"pool_id": "_", "capacities": {"disk": 1000, "unit": 1}}}</data>
+      <data key="d13">{"primary": {"pool_id": "_", "labels": {"bdf": "0000:21:00.0"}}}</data>
+    </node>
+    <node id="811">
+      <data key="d0">42479fc2-22a8-4f26-86b8-277beab2e2dd</data>
+      <data key="d1">Component</data>
+      <data key="d2">PHLJ0160047L1P0FGN</data>
+      <data key="d3">renc-w3-nvme2</data>
+      <data key="d4">NVME</data>
+      <data key="d5">P4510</data>
+      <data key="d6">{"disk": 1000, "unit": 1}</data>
+      <data key="d11">{"bdf": "0000:22:00.0"}</data>
+      <data key="d12">Dell Express Flash NVMe P4510 1TB SFF</data>
+      <data key="d7">false</data>
+      <data key="d10">{"primary": {"pool_id": "_", "capacities": {"disk": 1000, "unit": 1}}}</data>
+      <data key="d13">{"primary": {"pool_id": "_", "labels": {"bdf": "0000:22:00.0"}}}</data>
+    </node>
+    <node id="812">
+      <data key="d0">42479fc2-22a8-4f26-86b8-277beab2e2dd</data>
+      <data key="d1">Component</data>
+      <data key="d2">PHLJ016004CJ1P0FGN</data>
+      <data key="d3">renc-w3-nvme3</data>
+      <data key="d4">NVME</data>
+      <data key="d5">P4510</data>
+      <data key="d6">{"disk": 1000, "unit": 1}</data>
+      <data key="d11">{"bdf": "0000:23:00.0"}</data>
+      <data key="d12">Dell Express Flash NVMe P4510 1TB SFF</data>
+      <data key="d7">false</data>
+      <data key="d10">{"primary": {"pool_id": "_", "capacities": {"disk": 1000, "unit": 1}}}</data>
+      <data key="d13">{"primary": {"pool_id": "_", "labels": {"bdf": "0000:23:00.0"}}}</data>
+    </node>
+    <node id="813">
+      <data key="d0">42479fc2-22a8-4f26-86b8-277beab2e2dd</data>
+      <data key="d1">Component</data>
+      <data key="d2">PHLJ016004C91P0FGN</data>
+      <data key="d3">renc-w3-nvme4</data>
+      <data key="d4">NVME</data>
+      <data key="d5">P4510</data>
+      <data key="d6">{"disk": 1000, "unit": 1}</data>
+      <data key="d11">{"bdf": "0000:24:00.0"}</data>
+      <data key="d12">Dell Express Flash NVMe P4510 1TB SFF</data>
+      <data key="d7">false</data>
+      <data key="d10">{"primary": {"pool_id": "_", "capacities": {"disk": 1000, "unit": 1}}}</data>
+      <data key="d13">{"primary": {"pool_id": "_", "labels": {"bdf": "0000:24:00.0"}}}</data>
+    </node>
+    <node id="814">
+      <data key="d0">42479fc2-22a8-4f26-86b8-277beab2e2dd</data>
+      <data key="d1">Component</data>
+      <data key="d2">HX6VQ53-gpu1</data>
+      <data key="d3">renc-w1-gpu1</data>
+      <data key="d4">GPU</data>
+      <data key="d5">RTX6000</data>
+      <data key="d6">{"unit": 1}</data>
+      <data key="d11">{"bdf": "0000:25:00.0"}</data>
+      <data key="d12">NVIDIA Corporation TU102GL [Quadro RTX 6000/8000] (rev a1)</data>
+      <data key="d7">false</data>
+      <data key="d10">{"primary": {"pool_id": "_", "capacities": {"unit": 1}}}</data>
+      <data key="d13">{"primary": {"pool_id": "_", "labels": {"bdf": "0000:25:00.0"}}}</data>
+    </node>
+    <node id="815">
+      <data key="d0">42479fc2-22a8-4f26-86b8-277beab2e2dd</data>
+      <data key="d1">Component</data>
+      <data key="d2">HX6VQ53-gpu2</data>
+      <data key="d3">renc-w1-gpu2</data>
+      <data key="d4">GPU</data>
+      <data key="d5">RTX6000</data>
+      <data key="d6">{"unit": 1}</data>
+      <data key="d11">{"bdf": "0000:81:00.0"}</data>
+      <data key="d12">NVIDIA Corporation TU102GL [Quadro RTX 6000/8000] (rev a1)</data>
+      <data key="d7">false</data>
+      <data key="d10">{"primary": {"pool_id": "_", "capacities": {"unit": 1}}}</data>
+      <data key="d13">{"primary": {"pool_id": "_", "labels": {"bdf": "0000:81:00.0"}}}</data>
+    </node>
+    <node id="816">
+      <data key="d0">42479fc2-22a8-4f26-86b8-277beab2e2dd</data>
+      <data key="d1">Component</data>
+      <data key="d2">HX7LQ53-gpu1</data>
+      <data key="d3">renc-w2-gpu1</data>
       <data key="d4">GPU</data>
       <data key="d5">Tesla T4</data>
       <data key="d6">{"unit": 1}</data>
@@ -203,11 +237,11 @@
       <data key="d10">{"primary": {"pool_id": "_", "capacities": {"unit": 1}}}</data>
       <data key="d13">{"primary": {"pool_id": "_", "labels": {"bdf": "0000:25:00.0"}}}</data>
     </node>
-    <node id="15">
-      <data key="d0">0cb9bb4a-bfb3-47f7-8ddc-b4f1801a9cd6</data>
+    <node id="817">
+      <data key="d0">42479fc2-22a8-4f26-86b8-277beab2e2dd</data>
       <data key="d1">Component</data>
-      <data key="d2">HX7LQ53-gpu-2</data>
-      <data key="d3">renc-w2.fabric-testbed.net-gpu-2</data>
+      <data key="d2">HX7LQ53-gpu2</data>
+      <data key="d3">renc-w2-gpu2</data>
       <data key="d4">GPU</data>
       <data key="d5">Tesla T4</data>
       <data key="d6">{"unit": 1}</data>
@@ -217,69 +251,167 @@
       <data key="d10">{"primary": {"pool_id": "_", "capacities": {"unit": 1}}}</data>
       <data key="d13">{"primary": {"pool_id": "_", "labels": {"bdf": "0000:81:00.0"}}}</data>
     </node>
-    <node id="16">
-      <data key="d0">0cb9bb4a-bfb3-47f7-8ddc-b4f1801a9cd6</data>
+    <node id="818">
+      <data key="d0">42479fc2-22a8-4f26-86b8-277beab2e2dd</data>
       <data key="d1">Component</data>
-      <data key="d2">HX7LQ53-slot7</data>
-      <data key="d3">renc-w2.fabric-testbed.net-slot7</data>
+      <data key="d2">HX7KQ53-gpu1</data>
+      <data key="d3">renc-w3-gpu1</data>
+      <data key="d4">GPU</data>
+      <data key="d5">Tesla T4</data>
+      <data key="d6">{"unit": 1}</data>
+      <data key="d11">{"bdf": "0000:25:00.0"}</data>
+      <data key="d12">NVIDIA Corporation TU104GL [Tesla T4] (rev a1)</data>
+      <data key="d7">false</data>
+      <data key="d10">{"primary": {"pool_id": "_", "capacities": {"unit": 1}}}</data>
+      <data key="d13">{"primary": {"pool_id": "_", "labels": {"bdf": "0000:25:00.0"}}}</data>
+    </node>
+    <node id="819">
+      <data key="d0">42479fc2-22a8-4f26-86b8-277beab2e2dd</data>
+      <data key="d1">Component</data>
+      <data key="d2">HX7KQ53-gpu2</data>
+      <data key="d3">renc-w3-gpu2</data>
+      <data key="d4">GPU</data>
+      <data key="d5">Tesla T4</data>
+      <data key="d6">{"unit": 1}</data>
+      <data key="d11">{"bdf": "0000:81:00.0"}</data>
+      <data key="d12">NVIDIA Corporation TU104GL [Tesla T4] (rev a1)</data>
+      <data key="d7">false</data>
+      <data key="d10">{"primary": {"pool_id": "_", "capacities": {"unit": 1}}}</data>
+      <data key="d13">{"primary": {"pool_id": "_", "labels": {"bdf": "0000:81:00.0"}}}</data>
+    </node>
+    <node id="820">
+      <data key="d0">42479fc2-22a8-4f26-86b8-277beab2e2dd</data>
+      <data key="d1">Component</data>
+      <data key="d2">HX6VQ53-shnic</data>
+      <data key="d3">renc-w1-shnic</data>
       <data key="d4">SharedNIC</data>
       <data key="d5">ConnectX-6</data>
-      <data key="d6">{"unit": 127}</data>
-      <data key="d11">{"bdf": ["0000:e2:1c.0", "0000:e2:1b.5", "0000:e2:11.5", "0000:e2:19.6", "0000:e2:1e.5", "0000:e2:16.4", "0000:e2:18.4", "0000:e2:19.4", "0000:e2:1f.3", "0000:e2:17.7", "0000:e2:1a.0", "0000:e2:14.7", "0000:e2:1a.2", "0000:e2:1b.0", "0000:e2:16.3", "0000:e2:15.0", "0000:e2:12.1", "0000:e2:18.3", "0000:e2:12.3", "0000:e2:1a.4", "0000:e2:11.0", "0000:e2:16.6", "0000:e2:11.4", "0000:e2:1b.2", "0000:e2:17.6", "0000:e2:15.1", "0000:e2:10.5", "0000:e2:17.0", "0000:e2:1f.4", "0000:e2:15.2", "0000:e2:13.7", "0000:e2:15.6", "0000:e2:14.4", "0000:e2:1e.2", "0000:e2:1c.3", "0000:e2:18.7", "0000:e2:1f.7", "0000:e2:15.4", "0000:e2:19.7", "0000:e2:14.3", "0000:e2:1d.5", "0000:e2:13.6", "0000:e2:16.5", "0000:e2:14.2", "0000:e2:18.5", "0000:e2:1f.0", "0000:e2:13.0", "0000:e2:17.2", "0000:e2:17.5", "0000:e2:1e.3", "0000:e2:1c.1", "0000:e2:1a.1", "0000:e2:18.2", "0000:e2:1e.7", "0000:e2:1a.3", "0000:e2:10.1", "0000:e2:1b.6", "0000:e2:1f.1", "0000:e2:12.7", "0000:e2:15.3", "0000:e2:1a.7", "0000:e2:18.6", "0000:e2:19.0", "0000:e2:11.3", "0000:e2:13.2", "0000:e2:1d.1", "0000:e2:15.5", "0000:e2:13.4", "0000:e2:19.5", "0000:e2:14.6", "0000:e2:10.7", "0000:e2:1e.4", "0000:e2:18.0", "0000:e2:11.1", "0000:e2:14.1", "0000:e2:13.1", "0000:e2:12.4", "0000:e2:1b.4", "0000:e2:1d.6", "0000:e2:16.0", "0000:e2:1a.5", "0000:e2:1c.2", "0000:e2:12.6", "0000:e2:11.2", "0000:e2:18.1", "0000:e2:15.7", "0000:e2:1e.6", "0000:e2:1c.6", "0000:e2:1e.0", "0000:e2:1c.5", "0000:e2:1f.6", "0000:e2:1d.4", "0000:e2:1f.5", "0000:e2:1b.1", "0000:e2:16.2", "0000:e2:1a.6", "0000:e2:11.6", "0000:e2:16.1", "0000:e2:1d.2", "0000:e2:11.7", "0000:e2:1d.7", "0000:e2:1e.1", "0000:e2:19.3", "0000:e2:14.0", "0000:e2:1d.3", "0000:e2:1c.4", "0000:e2:1f.2", "0000:e2:14.5", "0000:e2:1c.7", "0000:e2:17.4", "0000:e2:17.3", "0000:e2:1b.7", "0000:e2:13.5", "0000:e2:10.2", "0000:e2:19.1", "0000:e2:1b.3", "0000:e2:17.1", "0000:e2:10.4", "0000:e2:12.0", "0000:e2:16.7", "0000:e2:10.3", "0000:e2:12.2", "0000:e2:10.6", "0000:e2:19.2", "0000:e2:12.5", "0000:e2:1d.0", "0000:e2:13.3"]}</data>
-      <data key="d12">Mellanox Technologies MT28908 Family [ConnectX-6] in PCIe Slot 7 (0000:e2:00.1)</data>
+      <data key="d6">{"unit": 4}</data>
+      <data key="d11">{"bdf": ["0000:e2:00.2", "0000:e2:00.3", "0000:e2:00.4", "0000:e2:00.5"]}</data>
+      <data key="d12">Shared NIC: Mellanox Technologies MT28908 Family [ConnectX-6]</data>
       <data key="d7">false</data>
-      <data key="d10">{"primary": {"pool_id": "_", "capacities": {"unit": 127}}}</data>
-      <data key="d13">{"primary": {"pool_id": "_", "labels": {"bdf": ["0000:e2:1c.0", "0000:e2:1b.5", "0000:e2:11.5", "0000:e2:19.6", "0000:e2:1e.5", "0000:e2:16.4", "0000:e2:18.4", "0000:e2:19.4", "0000:e2:1f.3", "0000:e2:17.7", "0000:e2:1a.0", "0000:e2:14.7", "0000:e2:1a.2", "0000:e2:1b.0", "0000:e2:16.3", "0000:e2:15.0", "0000:e2:12.1", "0000:e2:18.3", "0000:e2:12.3", "0000:e2:1a.4", "0000:e2:11.0", "0000:e2:16.6", "0000:e2:11.4", "0000:e2:1b.2", "0000:e2:17.6", "0000:e2:15.1", "0000:e2:10.5", "0000:e2:17.0", "0000:e2:1f.4", "0000:e2:15.2", "0000:e2:13.7", "0000:e2:15.6", "0000:e2:14.4", "0000:e2:1e.2", "0000:e2:1c.3", "0000:e2:18.7", "0000:e2:1f.7", "0000:e2:15.4", "0000:e2:19.7", "0000:e2:14.3", "0000:e2:1d.5", "0000:e2:13.6", "0000:e2:16.5", "0000:e2:14.2", "0000:e2:18.5", "0000:e2:1f.0", "0000:e2:13.0", "0000:e2:17.2", "0000:e2:17.5", "0000:e2:1e.3", "0000:e2:1c.1", "0000:e2:1a.1", "0000:e2:18.2", "0000:e2:1e.7", "0000:e2:1a.3", "0000:e2:10.1", "0000:e2:1b.6", "0000:e2:1f.1", "0000:e2:12.7", "0000:e2:15.3", "0000:e2:1a.7", "0000:e2:18.6", "0000:e2:19.0", "0000:e2:11.3", "0000:e2:13.2", "0000:e2:1d.1", "0000:e2:15.5", "0000:e2:13.4", "0000:e2:19.5", "0000:e2:14.6", "0000:e2:10.7", "0000:e2:1e.4", "0000:e2:18.0", "0000:e2:11.1", "0000:e2:14.1", "0000:e2:13.1", "0000:e2:12.4", "0000:e2:1b.4", "0000:e2:1d.6", "0000:e2:16.0", "0000:e2:1a.5", "0000:e2:1c.2", "0000:e2:12.6", "0000:e2:11.2", "0000:e2:18.1", "0000:e2:15.7", "0000:e2:1e.6", "0000:e2:1c.6", "0000:e2:1e.0", "0000:e2:1c.5", "0000:e2:1f.6", "0000:e2:1d.4", "0000:e2:1f.5", "0000:e2:1b.1", "0000:e2:16.2", "0000:e2:1a.6", "0000:e2:11.6", "0000:e2:16.1", "0000:e2:1d.2", "0000:e2:11.7", "0000:e2:1d.7", "0000:e2:1e.1", "0000:e2:19.3", "0000:e2:14.0", "0000:e2:1d.3", "0000:e2:1c.4", "0000:e2:1f.2", "0000:e2:14.5", "0000:e2:1c.7", "0000:e2:17.4", "0000:e2:17.3", "0000:e2:1b.7", "0000:e2:13.5", "0000:e2:10.2", "0000:e2:19.1", "0000:e2:1b.3", "0000:e2:17.1", "0000:e2:10.4", "0000:e2:12.0", "0000:e2:16.7", "0000:e2:10.3", "0000:e2:12.2", "0000:e2:10.6", "0000:e2:19.2", "0000:e2:12.5", "0000:e2:1d.0", "0000:e2:13.3"]}}}</data>
+      <data key="d10">{"primary": {"pool_id": "_", "capacities": {"unit": 4}}}</data>
+      <data key="d13">{"primary": {"pool_id": "_", "labels": {"bdf": ["0000:e2:00.2", "0000:e2:00.3", "0000:e2:00.4", "0000:e2:00.5"]}}}</data>
     </node>
-    <node id="17">
-      <data key="d0">0cb9bb4a-bfb3-47f7-8ddc-b4f1801a9cd6</data>
+    <node id="821">
+      <data key="d0">42479fc2-22a8-4f26-86b8-277beab2e2dd</data>
       <data key="d1">NetworkService</data>
-      <data key="d2">HX7LQ53-slot7-ns</data>
-      <data key="d3">renc-w2.fabric-testbed.net-renc-w2.fabric-testbed.net-slot7-l2ovs</data>
+      <data key="d2">HX6VQ53-shnic-sf</data>
+      <data key="d3">renc-w1-renc-w1-shnic-l2ovs</data>
       <data key="d4">OVS</data>
       <data key="d7">false</data>
       <data key="d14">L2</data>
     </node>
-    <node id="18">
-      <data key="d0">0cb9bb4a-bfb3-47f7-8ddc-b4f1801a9cd6</data>
+    <node id="822">
+      <data key="d0">42479fc2-22a8-4f26-86b8-277beab2e2dd</data>
       <data key="d1">ConnectionPoint</data>
-      <data key="d2">node_id-04-3F-72-B7-18-B5</data>
-      <data key="d3">renc-w2.fabric-testbed.net-slot7-p1</data>
+      <data key="d2">node_id-04-3F-72-B7-14-EC</data>
+      <data key="d3">renc-w1-shnic-p1</data>
       <data key="d4">SharedPort</data>
-      <data key="d6">{"unit": 127}</data>
-      <data key="d11">{"bdf": ["0000:e2:1c.0", "0000:e2:1b.5", "0000:e2:11.5", "0000:e2:19.6", "0000:e2:1e.5", "0000:e2:16.4", "0000:e2:18.4", "0000:e2:19.4", "0000:e2:1f.3", "0000:e2:17.7", "0000:e2:1a.0", "0000:e2:14.7", "0000:e2:1a.2", "0000:e2:1b.0", "0000:e2:16.3", "0000:e2:15.0", "0000:e2:12.1", "0000:e2:18.3", "0000:e2:12.3", "0000:e2:1a.4", "0000:e2:11.0", "0000:e2:16.6", "0000:e2:11.4", "0000:e2:1b.2", "0000:e2:17.6", "0000:e2:15.1", "0000:e2:10.5", "0000:e2:17.0", "0000:e2:1f.4", "0000:e2:15.2", "0000:e2:13.7", "0000:e2:15.6", "0000:e2:14.4", "0000:e2:1e.2", "0000:e2:1c.3", "0000:e2:18.7", "0000:e2:1f.7", "0000:e2:15.4", "0000:e2:19.7", "0000:e2:14.3", "0000:e2:1d.5", "0000:e2:13.6", "0000:e2:16.5", "0000:e2:14.2", "0000:e2:18.5", "0000:e2:1f.0", "0000:e2:13.0", "0000:e2:17.2", "0000:e2:17.5", "0000:e2:1e.3", "0000:e2:1c.1", "0000:e2:1a.1", "0000:e2:18.2", "0000:e2:1e.7", "0000:e2:1a.3", "0000:e2:10.1", "0000:e2:1b.6", "0000:e2:1f.1", "0000:e2:12.7", "0000:e2:15.3", "0000:e2:1a.7", "0000:e2:18.6", "0000:e2:19.0", "0000:e2:11.3", "0000:e2:13.2", "0000:e2:1d.1", "0000:e2:15.5", "0000:e2:13.4", "0000:e2:19.5", "0000:e2:14.6", "0000:e2:10.7", "0000:e2:1e.4", "0000:e2:18.0", "0000:e2:11.1", "0000:e2:14.1", "0000:e2:13.1", "0000:e2:12.4", "0000:e2:1b.4", "0000:e2:1d.6", "0000:e2:16.0", "0000:e2:1a.5", "0000:e2:1c.2", "0000:e2:12.6", "0000:e2:11.2", "0000:e2:18.1", "0000:e2:15.7", "0000:e2:1e.6", "0000:e2:1c.6", "0000:e2:1e.0", "0000:e2:1c.5", "0000:e2:1f.6", "0000:e2:1d.4", "0000:e2:1f.5", "0000:e2:1b.1", "0000:e2:16.2", "0000:e2:1a.6", "0000:e2:11.6", "0000:e2:16.1", "0000:e2:1d.2", "0000:e2:11.7", "0000:e2:1d.7", "0000:e2:1e.1", "0000:e2:19.3", "0000:e2:14.0", "0000:e2:1d.3", "0000:e2:1c.4", "0000:e2:1f.2", "0000:e2:14.5", "0000:e2:1c.7", "0000:e2:17.4", "0000:e2:17.3", "0000:e2:1b.7", "0000:e2:13.5", "0000:e2:10.2", "0000:e2:19.1", "0000:e2:1b.3", "0000:e2:17.1", "0000:e2:10.4", "0000:e2:12.0", "0000:e2:16.7", "0000:e2:10.3", "0000:e2:12.2", "0000:e2:10.6", "0000:e2:19.2", "0000:e2:12.5", "0000:e2:1d.0", "0000:e2:13.3"], "local_name": ["p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1"], "mac": ["02:68:AE:4C:F1:AC", "02:C0:A3:0F:B0:C7", "06:4B:BC:C8:47:E5", "06:AC:C2:13:1E:04", "0A:4A:F0:71:78:C7", "0A:E9:99:03:CC:EF", "0A:FC:8D:A7:28:9F", "0E:3D:A6:F8:FF:62", "0E:44:14:2D:CE:DB", "0E:5A:36:36:A7:59", "0E:AB:63:FB:6B:43", "0E:C0:A1:B6:76:9F", "0E:D3:47:CE:BE:F1", "12:6B:8A:1B:74:B0", "12:D0:92:74:CF:D2", "16:2E:C9:0D:39:6E", "16:8A:30:EB:B7:3B", "16:94:2B:2A:AC:4E", "1A:38:0C:E4:76:5C", "1A:61:DE:D9:56:DE", "1E:EE:D9:3A:96:16", "22:73:29:71:6D:47", "26:62:7E:F8:D4:F6", "2E:97:A2:27:89:C9", "2E:A4:E3:F8:09:FF", "32:3B:B9:04:88:27", "32:A9:59:F3:10:08", "36:9D:0B:81:35:86", "36:EB:D5:76:78:CF", "3A:A8:73:C8:F3:37", "3E:25:83:83:A5:F6", "3E:66:E7:C4:C3:08", "3E:D9:5F:43:3A:00", "42:12:AD:87:57:29", "42:D6:EF:85:24:12", "4A:2A:50:10:6B:57", "4E:85:83:9C:40:A1", "52:30:B1:BB:91:35", "52:52:9E:15:F2:1E", "52:96:98:01:41:3F", "52:E8:E7:B0:76:CD", "52:FF:0D:28:61:C2", "56:7D:8C:EF:07:FA", "56:9B:49:70:69:24", "56:A7:E1:2F:6D:58", "56:FE:3A:37:2B:2C", "5A:0F:73:54:EA:48", "5A:2D:88:43:AE:6F", "5A:B9:B6:D0:94:9A", "5E:53:9C:D8:22:3B", "62:18:FF:6F:CA:71", "62:E5:E4:EA:5E:D9", "66:8F:C2:4D:BB:B9", "66:A8:B9:88:F1:87", "66:BF:79:6C:13:C7", "6A:41:83:3A:9C:4D", "6A:F6:8E:47:52:2F", "6E:3D:7C:DF:1A:B4", "6E:BF:AF:78:A2:32", "6E:DE:A2:75:31:71", "72:26:EB:D0:19:BB", "72:31:79:EF:29:9B", "76:03:28:C0:9F:90", "76:06:D5:97:68:67", "76:9E:86:9E:D8:0E", "76:FE:A4:6D:6F:94", "7E:05:B9:85:B6:70", "7E:99:56:0F:E3:AE", "7E:BB:F0:7D:A0:C0", "82:55:6A:30:5A:A2", "86:10:F0:07:2C:2D", "86:9D:E8:AE:D5:D0", "86:A3:2D:20:57:F1", "8A:16:E3:50:D3:C1", "8A:2A:63:7E:B0:97", "8A:75:29:01:85:BD", "8A:88:27:7E:D6:B7", "8A:97:AA:BB:F3:2A", "8A:9A:48:37:E2:C9", "8E:07:E5:CF:0D:DC", "8E:7B:F8:37:BB:71", "92:39:FB:9E:43:14", "92:5C:8D:CB:BB:98", "92:76:11:EF:95:D3", "9A:8A:64:22:78:04", "9A:8F:5A:E8:D2:FD", "9A:AE:D0:A8:CE:48", "9A:D9:6C:58:F3:04", "9E:8C:E7:3E:F4:55", "A2:3C:03:BC:3A:A6", "A2:67:D4:EA:0E:D1", "A2:78:EB:D7:9A:44", "A2:7A:E1:37:EF:3F", "A2:8C:92:DE:79:A7", "A6:A7:96:FF:B4:06", "A6:B8:61:38:D4:7D", "AA:18:40:A4:C2:CF", "AA:DA:1E:FE:B9:1A", "AE:3B:3E:E0:86:6B", "BA:AD:B2:AA:39:EE", "BE:79:90:AF:08:DF", "BE:93:E6:71:88:B3", "BE:B3:40:5C:00:7E", "C2:71:E3:68:57:36", "CA:2C:36:10:4D:7D", "CE:1D:00:8F:3A:58", "D2:19:66:94:6F:90", "DE:36:BF:58:A7:50", "DE:57:3C:C3:7F:C1", "DE:AC:78:09:DE:39", "DE:F8:3E:C6:D1:57", "E6:B0:69:F5:78:68", "E6:CB:CC:1C:5A:2F", "E6:D5:88:D4:A8:C0", "E6:F6:8F:0A:93:44", "EA:00:5D:BB:75:CC", "EA:AF:9D:4D:A9:23", "F6:07:38:F5:A7:33", "F6:4A:15:6E:AB:AB", "F6:57:1C:40:9D:88", "F6:71:60:AB:39:F3", "FA:8C:2F:F0:85:20", "FE:4C:F3:FD:CB:A2", "FE:87:24:F0:A3:0D", "FE:E2:27:1D:FA:2C", "FE:E4:42:A3:72:A9", "FE:F6:BF:39:80:51"], "vlan": ["2095", "2092", "2012", "2077", "2116", "2051", "2067", "2075", "2122", "2062", "2079", "2038", "2081", "2087", "2050", "2039", "2016", "2066", "2018", "2083", "2007", "2053", "2011", "2089", "2061", "2040", "2004", "2055", "2123", "2041", "2030", "2045", "2035", "2113", "2098", "2070", "2126", "2043", "2078", "2034", "2108", "2029", "2052", "2033", "2068", "2119", "2023", "2057", "2060", "2114", "2096", "2080", "2065", "2118", "2082", "2000", "2093", "2120", "2022", "2042", "2086", "2069", "2071", "2010", "2025", "2104", "2044", "2027", "2076", "2037", "2006", "2115", "2063", "2008", "2032", "2024", "2019", "2091", "2109", "2047", "2084", "2097", "2021", "2009", "2064", "2046", "2117", "2101", "2111", "2100", "2125", "2107", "2124", "2088", "2049", "2085", "2013", "2048", "2105", "2014", "2110", "2112", "2074", "2031", "2106", "2099", "2121", "2036", "2102", "2059", "2058", "2094", "2028", "2001", "2072", "2090", "2056", "2003", "2015", "2054", "2002", "2017", "2005", "2073", "2020", "2103", "2026"]}</data>
+      <data key="d6">{"unit": 4}</data>
+      <data key="d11">{"bdf": ["0000:e2:00.2", "0000:e2:00.3", "0000:e2:00.4", "0000:e2:00.5"], "local_name": ["p1", "p1", "p1", "p1"], "mac": ["04:3F:72:B7:14:ED", "04:3F:72:B7:14:EE", "04:3F:72:B7:14:EF", "04:3F:72:B7:14:F0"], "vlan": ["1001", "1002", "1003", "1004"]}</data>
       <data key="d7">false</data>
-      <data key="d10">{"primary": {"pool_id": "_", "capacities": {"unit": 127}}}</data>
-      <data key="d13">{"primary": {"pool_id": "_", "labels": {"bdf": ["0000:e2:1c.0", "0000:e2:1b.5", "0000:e2:11.5", "0000:e2:19.6", "0000:e2:1e.5", "0000:e2:16.4", "0000:e2:18.4", "0000:e2:19.4", "0000:e2:1f.3", "0000:e2:17.7", "0000:e2:1a.0", "0000:e2:14.7", "0000:e2:1a.2", "0000:e2:1b.0", "0000:e2:16.3", "0000:e2:15.0", "0000:e2:12.1", "0000:e2:18.3", "0000:e2:12.3", "0000:e2:1a.4", "0000:e2:11.0", "0000:e2:16.6", "0000:e2:11.4", "0000:e2:1b.2", "0000:e2:17.6", "0000:e2:15.1", "0000:e2:10.5", "0000:e2:17.0", "0000:e2:1f.4", "0000:e2:15.2", "0000:e2:13.7", "0000:e2:15.6", "0000:e2:14.4", "0000:e2:1e.2", "0000:e2:1c.3", "0000:e2:18.7", "0000:e2:1f.7", "0000:e2:15.4", "0000:e2:19.7", "0000:e2:14.3", "0000:e2:1d.5", "0000:e2:13.6", "0000:e2:16.5", "0000:e2:14.2", "0000:e2:18.5", "0000:e2:1f.0", "0000:e2:13.0", "0000:e2:17.2", "0000:e2:17.5", "0000:e2:1e.3", "0000:e2:1c.1", "0000:e2:1a.1", "0000:e2:18.2", "0000:e2:1e.7", "0000:e2:1a.3", "0000:e2:10.1", "0000:e2:1b.6", "0000:e2:1f.1", "0000:e2:12.7", "0000:e2:15.3", "0000:e2:1a.7", "0000:e2:18.6", "0000:e2:19.0", "0000:e2:11.3", "0000:e2:13.2", "0000:e2:1d.1", "0000:e2:15.5", "0000:e2:13.4", "0000:e2:19.5", "0000:e2:14.6", "0000:e2:10.7", "0000:e2:1e.4", "0000:e2:18.0", "0000:e2:11.1", "0000:e2:14.1", "0000:e2:13.1", "0000:e2:12.4", "0000:e2:1b.4", "0000:e2:1d.6", "0000:e2:16.0", "0000:e2:1a.5", "0000:e2:1c.2", "0000:e2:12.6", "0000:e2:11.2", "0000:e2:18.1", "0000:e2:15.7", "0000:e2:1e.6", "0000:e2:1c.6", "0000:e2:1e.0", "0000:e2:1c.5", "0000:e2:1f.6", "0000:e2:1d.4", "0000:e2:1f.5", "0000:e2:1b.1", "0000:e2:16.2", "0000:e2:1a.6", "0000:e2:11.6", "0000:e2:16.1", "0000:e2:1d.2", "0000:e2:11.7", "0000:e2:1d.7", "0000:e2:1e.1", "0000:e2:19.3", "0000:e2:14.0", "0000:e2:1d.3", "0000:e2:1c.4", "0000:e2:1f.2", "0000:e2:14.5", "0000:e2:1c.7", "0000:e2:17.4", "0000:e2:17.3", "0000:e2:1b.7", "0000:e2:13.5", "0000:e2:10.2", "0000:e2:19.1", "0000:e2:1b.3", "0000:e2:17.1", "0000:e2:10.4", "0000:e2:12.0", "0000:e2:16.7", "0000:e2:10.3", "0000:e2:12.2", "0000:e2:10.6", "0000:e2:19.2", "0000:e2:12.5", "0000:e2:1d.0", "0000:e2:13.3"], "mac": ["02:68:AE:4C:F1:AC", "02:C0:A3:0F:B0:C7", "06:4B:BC:C8:47:E5", "06:AC:C2:13:1E:04", "0A:4A:F0:71:78:C7", "0A:E9:99:03:CC:EF", "0A:FC:8D:A7:28:9F", "0E:3D:A6:F8:FF:62", "0E:44:14:2D:CE:DB", "0E:5A:36:36:A7:59", "0E:AB:63:FB:6B:43", "0E:C0:A1:B6:76:9F", "0E:D3:47:CE:BE:F1", "12:6B:8A:1B:74:B0", "12:D0:92:74:CF:D2", "16:2E:C9:0D:39:6E", "16:8A:30:EB:B7:3B", "16:94:2B:2A:AC:4E", "1A:38:0C:E4:76:5C", "1A:61:DE:D9:56:DE", "1E:EE:D9:3A:96:16", "22:73:29:71:6D:47", "26:62:7E:F8:D4:F6", "2E:97:A2:27:89:C9", "2E:A4:E3:F8:09:FF", "32:3B:B9:04:88:27", "32:A9:59:F3:10:08", "36:9D:0B:81:35:86", "36:EB:D5:76:78:CF", "3A:A8:73:C8:F3:37", "3E:25:83:83:A5:F6", "3E:66:E7:C4:C3:08", "3E:D9:5F:43:3A:00", "42:12:AD:87:57:29", "42:D6:EF:85:24:12", "4A:2A:50:10:6B:57", "4E:85:83:9C:40:A1", "52:30:B1:BB:91:35", "52:52:9E:15:F2:1E", "52:96:98:01:41:3F", "52:E8:E7:B0:76:CD", "52:FF:0D:28:61:C2", "56:7D:8C:EF:07:FA", "56:9B:49:70:69:24", "56:A7:E1:2F:6D:58", "56:FE:3A:37:2B:2C", "5A:0F:73:54:EA:48", "5A:2D:88:43:AE:6F", "5A:B9:B6:D0:94:9A", "5E:53:9C:D8:22:3B", "62:18:FF:6F:CA:71", "62:E5:E4:EA:5E:D9", "66:8F:C2:4D:BB:B9", "66:A8:B9:88:F1:87", "66:BF:79:6C:13:C7", "6A:41:83:3A:9C:4D", "6A:F6:8E:47:52:2F", "6E:3D:7C:DF:1A:B4", "6E:BF:AF:78:A2:32", "6E:DE:A2:75:31:71", "72:26:EB:D0:19:BB", "72:31:79:EF:29:9B", "76:03:28:C0:9F:90", "76:06:D5:97:68:67", "76:9E:86:9E:D8:0E", "76:FE:A4:6D:6F:94", "7E:05:B9:85:B6:70", "7E:99:56:0F:E3:AE", "7E:BB:F0:7D:A0:C0", "82:55:6A:30:5A:A2", "86:10:F0:07:2C:2D", "86:9D:E8:AE:D5:D0", "86:A3:2D:20:57:F1", "8A:16:E3:50:D3:C1", "8A:2A:63:7E:B0:97", "8A:75:29:01:85:BD", "8A:88:27:7E:D6:B7", "8A:97:AA:BB:F3:2A", "8A:9A:48:37:E2:C9", "8E:07:E5:CF:0D:DC", "8E:7B:F8:37:BB:71", "92:39:FB:9E:43:14", "92:5C:8D:CB:BB:98", "92:76:11:EF:95:D3", "9A:8A:64:22:78:04", "9A:8F:5A:E8:D2:FD", "9A:AE:D0:A8:CE:48", "9A:D9:6C:58:F3:04", "9E:8C:E7:3E:F4:55", "A2:3C:03:BC:3A:A6", "A2:67:D4:EA:0E:D1", "A2:78:EB:D7:9A:44", "A2:7A:E1:37:EF:3F", "A2:8C:92:DE:79:A7", "A6:A7:96:FF:B4:06", "A6:B8:61:38:D4:7D", "AA:18:40:A4:C2:CF", "AA:DA:1E:FE:B9:1A", "AE:3B:3E:E0:86:6B", "BA:AD:B2:AA:39:EE", "BE:79:90:AF:08:DF", "BE:93:E6:71:88:B3", "BE:B3:40:5C:00:7E", "C2:71:E3:68:57:36", "CA:2C:36:10:4D:7D", "CE:1D:00:8F:3A:58", "D2:19:66:94:6F:90", "DE:36:BF:58:A7:50", "DE:57:3C:C3:7F:C1", "DE:AC:78:09:DE:39", "DE:F8:3E:C6:D1:57", "E6:B0:69:F5:78:68", "E6:CB:CC:1C:5A:2F", "E6:D5:88:D4:A8:C0", "E6:F6:8F:0A:93:44", "EA:00:5D:BB:75:CC", "EA:AF:9D:4D:A9:23", "F6:07:38:F5:A7:33", "F6:4A:15:6E:AB:AB", "F6:57:1C:40:9D:88", "F6:71:60:AB:39:F3", "FA:8C:2F:F0:85:20", "FE:4C:F3:FD:CB:A2", "FE:87:24:F0:A3:0D", "FE:E2:27:1D:FA:2C", "FE:E4:42:A3:72:A9", "FE:F6:BF:39:80:51"], "vlan": ["2095", "2092", "2012", "2077", "2116", "2051", "2067", "2075", "2122", "2062", "2079", "2038", "2081", "2087", "2050", "2039", "2016", "2066", "2018", "2083", "2007", "2053", "2011", "2089", "2061", "2040", "2004", "2055", "2123", "2041", "2030", "2045", "2035", "2113", "2098", "2070", "2126", "2043", "2078", "2034", "2108", "2029", "2052", "2033", "2068", "2119", "2023", "2057", "2060", "2114", "2096", "2080", "2065", "2118", "2082", "2000", "2093", "2120", "2022", "2042", "2086", "2069", "2071", "2010", "2025", "2104", "2044", "2027", "2076", "2037", "2006", "2115", "2063", "2008", "2032", "2024", "2019", "2091", "2109", "2047", "2084", "2097", "2021", "2009", "2064", "2046", "2117", "2101", "2111", "2100", "2125", "2107", "2124", "2088", "2049", "2085", "2013", "2048", "2105", "2014", "2110", "2112", "2074", "2031", "2106", "2099", "2121", "2036", "2102", "2059", "2058", "2094", "2028", "2001", "2072", "2090", "2056", "2003", "2015", "2054", "2002", "2017", "2005", "2073", "2020", "2103", "2026"], "local_name": ["p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1"]}}}</data>
+      <data key="d10">{"primary": {"pool_id": "_", "capacities": {"unit": 4}}}</data>
+      <data key="d13">{"primary": {"pool_id": "_", "labels": {"bdf": ["0000:e2:00.2", "0000:e2:00.3", "0000:e2:00.4", "0000:e2:00.5"], "mac": ["04:3F:72:B7:14:ED", "04:3F:72:B7:14:EE", "04:3F:72:B7:14:EF", "04:3F:72:B7:14:F0"], "vlan": ["1001", "1002", "1003", "1004"], "local_name": ["p1", "p1", "p1", "p1"]}}}</data>
     </node>
-    <node id="19">
-      <data key="d0">0cb9bb4a-bfb3-47f7-8ddc-b4f1801a9cd6</data>
+    <node id="823">
+      <data key="d0">42479fc2-22a8-4f26-86b8-277beab2e2dd</data>
       <data key="d1">Component</data>
-      <data key="d2">HX7LQ53-slot3</data>
-      <data key="d3">renc-w2.fabric-testbed.net-slot3</data>
+      <data key="d2">HX7LQ53-shnic</data>
+      <data key="d3">renc-w2-shnic</data>
+      <data key="d4">SharedNIC</data>
+      <data key="d5">ConnectX-6</data>
+      <data key="d6">{"unit": 4}</data>
+      <data key="d11">{"bdf": ["0000:e2:00.2", "0000:e2:00.3", "0000:e2:00.4", "0000:e2:00.5"]}</data>
+      <data key="d12">Shared NIC: Mellanox Technologies MT28908 Family [ConnectX-6]</data>
+      <data key="d7">false</data>
+      <data key="d10">{"primary": {"pool_id": "_", "capacities": {"unit": 4}}}</data>
+      <data key="d13">{"primary": {"pool_id": "_", "labels": {"bdf": ["0000:e2:00.2", "0000:e2:00.3", "0000:e2:00.4", "0000:e2:00.5"]}}}</data>
+    </node>
+    <node id="824">
+      <data key="d0">42479fc2-22a8-4f26-86b8-277beab2e2dd</data>
+      <data key="d1">NetworkService</data>
+      <data key="d2">HX7LQ53-shnic-sf</data>
+      <data key="d3">renc-w2-renc-w2-shnic-l2ovs</data>
+      <data key="d4">OVS</data>
+      <data key="d7">false</data>
+      <data key="d14">L2</data>
+    </node>
+    <node id="825">
+      <data key="d0">42479fc2-22a8-4f26-86b8-277beab2e2dd</data>
+      <data key="d1">ConnectionPoint</data>
+      <data key="d2">node_id-04-3F-72-B7-18-B4</data>
+      <data key="d3">renc-w2-shnic-p1</data>
+      <data key="d4">SharedPort</data>
+      <data key="d6">{"unit": 4}</data>
+      <data key="d11">{"bdf": ["0000:e2:00.2", "0000:e2:00.3", "0000:e2:00.4", "0000:e2:00.5"], "local_name": ["p1", "p1", "p1", "p1"], "mac": ["04:3F:72:B7:18:B5", "04:3F:72:B7:18:B6", "04:3F:72:B7:18:B7", "04:3F:72:B7:18:B8"], "vlan": ["1001", "1002", "1003", "1004"]}</data>
+      <data key="d7">false</data>
+      <data key="d10">{"primary": {"pool_id": "_", "capacities": {"unit": 4}}}</data>
+      <data key="d13">{"primary": {"pool_id": "_", "labels": {"bdf": ["0000:e2:00.2", "0000:e2:00.3", "0000:e2:00.4", "0000:e2:00.5"], "mac": ["04:3F:72:B7:18:B5", "04:3F:72:B7:18:B6", "04:3F:72:B7:18:B7", "04:3F:72:B7:18:B8"], "vlan": ["1001", "1002", "1003", "1004"], "local_name": ["p1", "p1", "p1", "p1"]}}}</data>
+    </node>
+    <node id="826">
+      <data key="d0">42479fc2-22a8-4f26-86b8-277beab2e2dd</data>
+      <data key="d1">Component</data>
+      <data key="d2">HX7KQ53-shnic</data>
+      <data key="d3">renc-w3-shnic</data>
+      <data key="d4">SharedNIC</data>
+      <data key="d5">ConnectX-6</data>
+      <data key="d6">{"unit": 4}</data>
+      <data key="d11">{"bdf": ["0000:e2:00.2", "0000:e2:00.3", "0000:e2:00.4", "0000:e2:00.5"]}</data>
+      <data key="d12">Shared NIC: Mellanox Technologies MT28908 Family [ConnectX-6]</data>
+      <data key="d7">false</data>
+      <data key="d10">{"primary": {"pool_id": "_", "capacities": {"unit": 4}}}</data>
+      <data key="d13">{"primary": {"pool_id": "_", "labels": {"bdf": ["0000:e2:00.2", "0000:e2:00.3", "0000:e2:00.4", "0000:e2:00.5"]}}}</data>
+    </node>
+    <node id="827">
+      <data key="d0">42479fc2-22a8-4f26-86b8-277beab2e2dd</data>
+      <data key="d1">NetworkService</data>
+      <data key="d2">HX7KQ53-shnic-sf</data>
+      <data key="d3">renc-w3-renc-w3-shnic-l2ovs</data>
+      <data key="d4">OVS</data>
+      <data key="d7">false</data>
+      <data key="d14">L2</data>
+    </node>
+    <node id="828">
+      <data key="d0">42479fc2-22a8-4f26-86b8-277beab2e2dd</data>
+      <data key="d1">ConnectionPoint</data>
+      <data key="d2">node_id-04-3F-72-B7-16-14</data>
+      <data key="d3">renc-w3-shnic-p1</data>
+      <data key="d4">SharedPort</data>
+      <data key="d6">{"unit": 4}</data>
+      <data key="d11">{"bdf": ["0000:e2:00.2", "0000:e2:00.3", "0000:e2:00.4", "0000:e2:00.5"], "local_name": ["p1", "p1", "p1", "p1"], "mac": ["04:3F:72:B7:16:15", "04:3F:72:B7:16:16", "04:3F:72:B7:16:17", "04:3F:72:B7:16:18"], "vlan": ["1001", "1002", "1003", "1004"]}</data>
+      <data key="d7">false</data>
+      <data key="d10">{"primary": {"pool_id": "_", "capacities": {"unit": 4}}}</data>
+      <data key="d13">{"primary": {"pool_id": "_", "labels": {"bdf": ["0000:e2:00.2", "0000:e2:00.3", "0000:e2:00.4", "0000:e2:00.5"], "mac": ["04:3F:72:B7:16:15", "04:3F:72:B7:16:16", "04:3F:72:B7:16:17", "04:3F:72:B7:16:18"], "vlan": ["1001", "1002", "1003", "1004"], "local_name": ["p1", "p1", "p1", "p1"]}}}</data>
+    </node>
+    <node id="829">
+      <data key="d0">42479fc2-22a8-4f26-86b8-277beab2e2dd</data>
+      <data key="d1">Component</data>
+      <data key="d2">HX7LQ53-nic1</data>
+      <data key="d3">renc-w2-nic1</data>
       <data key="d4">SmartNIC</data>
       <data key="d5">ConnectX-6</data>
       <data key="d6">{"unit": 1}</data>
       <data key="d11">{"bdf": ["0000:41:00.0", "0000:41:00.1"]}</data>
-      <data key="d12">Mellanox Technologies MT28908 Family [ConnectX-6] in PCIe Slot 3 (0000:41:00.0)</data>
+      <data key="d12">Mellanox Technologies MT28908 Family [ConnectX-6]</data>
       <data key="d7">false</data>
       <data key="d10">{"primary": {"pool_id": "_", "capacities": {"unit": 1}}}</data>
       <data key="d13">{"primary": {"pool_id": "_", "labels": {"bdf": ["0000:41:00.0", "0000:41:00.1"]}}}</data>
     </node>
-    <node id="20">
-      <data key="d0">0cb9bb4a-bfb3-47f7-8ddc-b4f1801a9cd6</data>
+    <node id="830">
+      <data key="d0">42479fc2-22a8-4f26-86b8-277beab2e2dd</data>
       <data key="d1">NetworkService</data>
-      <data key="d2">HX7LQ53-slot3-ns</data>
-      <data key="d3">renc-w2.fabric-testbed.net-renc-w2.fabric-testbed.net-slot3-l2ovs</data>
+      <data key="d2">HX7LQ53-nic1-sf</data>
+      <data key="d3">renc-w2-renc-w2-nic1-l2ovs</data>
       <data key="d4">OVS</data>
       <data key="d7">false</data>
       <data key="d14">L2</data>
     </node>
-    <node id="21">
-      <data key="d0">0cb9bb4a-bfb3-47f7-8ddc-b4f1801a9cd6</data>
+    <node id="831">
+      <data key="d0">42479fc2-22a8-4f26-86b8-277beab2e2dd</data>
       <data key="d1">ConnectionPoint</data>
       <data key="d2">node_id-04-3F-72-B7-15-74</data>
-      <data key="d3">renc-w2.fabric-testbed.net-slot3-p1</data>
+      <data key="d3">renc-w2-nic1-p1</data>
       <data key="d4">DedicatedPort</data>
       <data key="d6">{"bw": 100, "unit": 1}</data>
       <data key="d11">{"local_name": "p1", "mac": "04:3F:72:B7:15:74", "vlan_range": "1-4096"}</data>
@@ -287,11 +419,11 @@
       <data key="d10">{"primary": {"pool_id": "_", "capacities": {"bw": 100, "unit": 1}}}</data>
       <data key="d13">{"primary": {"pool_id": "_", "labels": {"mac": "04:3F:72:B7:15:74", "vlan_range": "1-4096", "local_name": "p1"}}}</data>
     </node>
-    <node id="22">
-      <data key="d0">0cb9bb4a-bfb3-47f7-8ddc-b4f1801a9cd6</data>
+    <node id="832">
+      <data key="d0">42479fc2-22a8-4f26-86b8-277beab2e2dd</data>
       <data key="d1">ConnectionPoint</data>
       <data key="d2">node_id-04-3F-72-B7-15-75</data>
-      <data key="d3">renc-w2.fabric-testbed.net-slot3-p2</data>
+      <data key="d3">renc-w2-nic1-p2</data>
       <data key="d4">DedicatedPort</data>
       <data key="d6">{"bw": 100, "unit": 1}</data>
       <data key="d11">{"local_name": "p2", "mac": "04:3F:72:B7:15:75", "vlan_range": "1-4096"}</data>
@@ -299,34 +431,34 @@
       <data key="d10">{"primary": {"pool_id": "_", "capacities": {"bw": 100, "unit": 1}}}</data>
       <data key="d13">{"primary": {"pool_id": "_", "labels": {"mac": "04:3F:72:B7:15:75", "vlan_range": "1-4096", "local_name": "p2"}}}</data>
     </node>
-    <node id="23">
-      <data key="d0">0cb9bb4a-bfb3-47f7-8ddc-b4f1801a9cd6</data>
+    <node id="833">
+      <data key="d0">42479fc2-22a8-4f26-86b8-277beab2e2dd</data>
       <data key="d1">Component</data>
-      <data key="d2">HX7LQ53-slot6</data>
-      <data key="d3">renc-w2.fabric-testbed.net-slot6</data>
+      <data key="d2">HX7LQ53-nic2</data>
+      <data key="d3">renc-w2-nic2</data>
       <data key="d4">SmartNIC</data>
       <data key="d5">ConnectX-6</data>
       <data key="d6">{"unit": 1}</data>
       <data key="d11">{"bdf": ["0000:a1:00.0", "0000:a1:00.1"]}</data>
-      <data key="d12">Mellanox Technologies MT28908 Family [ConnectX-6] in PCIe Slot 6 (0000:a1:00.0)</data>
+      <data key="d12">Mellanox Technologies MT28908 Family [ConnectX-6]</data>
       <data key="d7">false</data>
       <data key="d10">{"primary": {"pool_id": "_", "capacities": {"unit": 1}}}</data>
       <data key="d13">{"primary": {"pool_id": "_", "labels": {"bdf": ["0000:a1:00.0", "0000:a1:00.1"]}}}</data>
     </node>
-    <node id="24">
-      <data key="d0">0cb9bb4a-bfb3-47f7-8ddc-b4f1801a9cd6</data>
+    <node id="834">
+      <data key="d0">42479fc2-22a8-4f26-86b8-277beab2e2dd</data>
       <data key="d1">NetworkService</data>
-      <data key="d2">HX7LQ53-slot6-ns</data>
-      <data key="d3">renc-w2.fabric-testbed.net-renc-w2.fabric-testbed.net-slot6-l2ovs</data>
+      <data key="d2">HX7LQ53-nic2-sf</data>
+      <data key="d3">renc-w2-renc-w2-nic2-l2ovs</data>
       <data key="d4">OVS</data>
       <data key="d7">false</data>
       <data key="d14">L2</data>
     </node>
-    <node id="25">
-      <data key="d0">0cb9bb4a-bfb3-47f7-8ddc-b4f1801a9cd6</data>
+    <node id="835">
+      <data key="d0">42479fc2-22a8-4f26-86b8-277beab2e2dd</data>
       <data key="d1">ConnectionPoint</data>
       <data key="d2">node_id-04-3F-72-B7-19-5C</data>
-      <data key="d3">renc-w2.fabric-testbed.net-slot6-p1</data>
+      <data key="d3">renc-w2-nic2-p1</data>
       <data key="d4">DedicatedPort</data>
       <data key="d6">{"bw": 100, "unit": 1}</data>
       <data key="d11">{"local_name": "p1", "mac": "04:3F:72:B7:19:5C", "vlan_range": "1-4096"}</data>
@@ -334,11 +466,11 @@
       <data key="d10">{"primary": {"pool_id": "_", "capacities": {"bw": 100, "unit": 1}}}</data>
       <data key="d13">{"primary": {"pool_id": "_", "labels": {"mac": "04:3F:72:B7:19:5C", "vlan_range": "1-4096", "local_name": "p1"}}}</data>
     </node>
-    <node id="26">
-      <data key="d0">0cb9bb4a-bfb3-47f7-8ddc-b4f1801a9cd6</data>
+    <node id="836">
+      <data key="d0">42479fc2-22a8-4f26-86b8-277beab2e2dd</data>
       <data key="d1">ConnectionPoint</data>
       <data key="d2">node_id-04-3F-72-B7-19-5D</data>
-      <data key="d3">renc-w2.fabric-testbed.net-slot6-p2</data>
+      <data key="d3">renc-w2-nic2-p2</data>
       <data key="d4">DedicatedPort</data>
       <data key="d6">{"bw": 100, "unit": 1}</data>
       <data key="d11">{"local_name": "p2", "mac": "04:3F:72:B7:19:5D", "vlan_range": "1-4096"}</data>
@@ -346,166 +478,34 @@
       <data key="d10">{"primary": {"pool_id": "_", "capacities": {"bw": 100, "unit": 1}}}</data>
       <data key="d13">{"primary": {"pool_id": "_", "labels": {"mac": "04:3F:72:B7:19:5D", "vlan_range": "1-4096", "local_name": "p2"}}}</data>
     </node>
-    <node id="27">
-      <data key="d0">0cb9bb4a-bfb3-47f7-8ddc-b4f1801a9cd6</data>
-      <data key="d1">NetworkNode</data>
-      <data key="d2">HX7KQ53</data>
-      <data key="d3">renc-w3.fabric-testbed.net</data>
-      <data key="d4">Server</data>
-      <data key="d5">R7525</data>
-      <data key="d6">{"core": 64, "cpu": 2, "disk": 4800, "ram": 512, "unit": 1}</data>
-      <data key="d7">false</data>
-      <data key="d8">RENC</data>
-      <data key="d9">{"postal": "100 Europa Dr., Chapel Hill, NC 27157"}</data>
-      <data key="d10">{"primary": {"pool_id": "_", "capacities": {"cpu": 2, "core": 64, "ram": 512, "disk": 4800, "unit": 1}}}</data>
-    </node>
-    <node id="28">
-      <data key="d0">0cb9bb4a-bfb3-47f7-8ddc-b4f1801a9cd6</data>
+    <node id="837">
+      <data key="d0">42479fc2-22a8-4f26-86b8-277beab2e2dd</data>
       <data key="d1">Component</data>
-      <data key="d2">PHLJ015301V81P0FGN</data>
-      <data key="d3">renc-w3.fabric-testbed.net-nvme-1</data>
-      <data key="d4">NVME</data>
-      <data key="d5">P4510</data>
-      <data key="d6">{"disk": 1000, "unit": 1}</data>
-      <data key="d11">{"bdf": "0000:21:00.0"}</data>
-      <data key="d12">Dell Express Flash NVMe P4510 1TB SFF in PCIe SSD Slot 22 in Bay 2 (0000:21:00.0)</data>
-      <data key="d7">false</data>
-      <data key="d10">{"primary": {"pool_id": "_", "capacities": {"disk": 1000, "unit": 1}}}</data>
-      <data key="d13">{"primary": {"pool_id": "_", "labels": {"bdf": "0000:21:00.0"}}}</data>
-    </node>
-    <node id="29">
-      <data key="d0">0cb9bb4a-bfb3-47f7-8ddc-b4f1801a9cd6</data>
-      <data key="d1">Component</data>
-      <data key="d2">PHLJ0160047L1P0FGN</data>
-      <data key="d3">renc-w3.fabric-testbed.net-nvme-2</data>
-      <data key="d4">NVME</data>
-      <data key="d5">P4510</data>
-      <data key="d6">{"disk": 1000, "unit": 1}</data>
-      <data key="d11">{"bdf": "0000:22:00.0"}</data>
-      <data key="d12">Dell Express Flash NVMe P4510 1TB SFF in PCIe SSD Slot 23 in Bay 2 (0000:22:00.0)</data>
-      <data key="d7">false</data>
-      <data key="d10">{"primary": {"pool_id": "_", "capacities": {"disk": 1000, "unit": 1}}}</data>
-      <data key="d13">{"primary": {"pool_id": "_", "labels": {"bdf": "0000:22:00.0"}}}</data>
-    </node>
-    <node id="30">
-      <data key="d0">0cb9bb4a-bfb3-47f7-8ddc-b4f1801a9cd6</data>
-      <data key="d1">Component</data>
-      <data key="d2">PHLJ016004CJ1P0FGN</data>
-      <data key="d3">renc-w3.fabric-testbed.net-nvme-3</data>
-      <data key="d4">NVME</data>
-      <data key="d5">P4510</data>
-      <data key="d6">{"disk": 1000, "unit": 1}</data>
-      <data key="d11">{"bdf": "0000:23:00.0"}</data>
-      <data key="d12">Dell Express Flash NVMe P4510 1TB SFF in PCIe SSD Slot 20 in Bay 2 (0000:23:00.0)</data>
-      <data key="d7">false</data>
-      <data key="d10">{"primary": {"pool_id": "_", "capacities": {"disk": 1000, "unit": 1}}}</data>
-      <data key="d13">{"primary": {"pool_id": "_", "labels": {"bdf": "0000:23:00.0"}}}</data>
-    </node>
-    <node id="31">
-      <data key="d0">0cb9bb4a-bfb3-47f7-8ddc-b4f1801a9cd6</data>
-      <data key="d1">Component</data>
-      <data key="d2">PHLJ016004C91P0FGN</data>
-      <data key="d3">renc-w3.fabric-testbed.net-nvme-4</data>
-      <data key="d4">NVME</data>
-      <data key="d5">P4510</data>
-      <data key="d6">{"disk": 1000, "unit": 1}</data>
-      <data key="d11">{"bdf": "0000:24:00.0"}</data>
-      <data key="d12">Dell Express Flash NVMe P4510 1TB SFF in PCIe SSD Slot 21 in Bay 2 (0000:24:00.0)</data>
-      <data key="d7">false</data>
-      <data key="d10">{"primary": {"pool_id": "_", "capacities": {"disk": 1000, "unit": 1}}}</data>
-      <data key="d13">{"primary": {"pool_id": "_", "labels": {"bdf": "0000:24:00.0"}}}</data>
-    </node>
-    <node id="32">
-      <data key="d0">0cb9bb4a-bfb3-47f7-8ddc-b4f1801a9cd6</data>
-      <data key="d1">Component</data>
-      <data key="d2">HX7KQ53-gpu-1</data>
-      <data key="d3">renc-w3.fabric-testbed.net-gpu-1</data>
-      <data key="d4">GPU</data>
-      <data key="d5">Tesla T4</data>
-      <data key="d6">{"unit": 1}</data>
-      <data key="d11">{"bdf": "0000:25:00.0"}</data>
-      <data key="d12">NVIDIA Corporation TU104GL [Tesla T4] (rev a1)</data>
-      <data key="d7">false</data>
-      <data key="d10">{"primary": {"pool_id": "_", "capacities": {"unit": 1}}}</data>
-      <data key="d13">{"primary": {"pool_id": "_", "labels": {"bdf": "0000:25:00.0"}}}</data>
-    </node>
-    <node id="33">
-      <data key="d0">0cb9bb4a-bfb3-47f7-8ddc-b4f1801a9cd6</data>
-      <data key="d1">Component</data>
-      <data key="d2">HX7KQ53-gpu-2</data>
-      <data key="d3">renc-w3.fabric-testbed.net-gpu-2</data>
-      <data key="d4">GPU</data>
-      <data key="d5">Tesla T4</data>
-      <data key="d6">{"unit": 1}</data>
-      <data key="d11">{"bdf": "0000:81:00.0"}</data>
-      <data key="d12">NVIDIA Corporation TU104GL [Tesla T4] (rev a1)</data>
-      <data key="d7">false</data>
-      <data key="d10">{"primary": {"pool_id": "_", "capacities": {"unit": 1}}}</data>
-      <data key="d13">{"primary": {"pool_id": "_", "labels": {"bdf": "0000:81:00.0"}}}</data>
-    </node>
-    <node id="34">
-      <data key="d0">0cb9bb4a-bfb3-47f7-8ddc-b4f1801a9cd6</data>
-      <data key="d1">Component</data>
-      <data key="d2">HX7KQ53-slot7</data>
-      <data key="d3">renc-w3.fabric-testbed.net-slot7</data>
-      <data key="d4">SharedNIC</data>
-      <data key="d5">ConnectX-6</data>
-      <data key="d6">{"unit": 127}</data>
-      <data key="d11">{"bdf": ["0000:e2:1a.6", "0000:e2:1a.5", "0000:e2:18.2", "0000:e2:12.6", "0000:e2:15.4", "0000:e2:11.0", "0000:e2:14.0", "0000:e2:14.1", "0000:e2:12.0", "0000:e2:1f.2", "0000:e2:14.6", "0000:e2:17.4", "0000:e2:13.3", "0000:e2:12.3", "0000:e2:18.7", "0000:e2:1b.7", "0000:e2:1c.5", "0000:e2:11.1", "0000:e2:1a.0", "0000:e2:1d.2", "0000:e2:18.0", "0000:e2:1f.0", "0000:e2:13.1", "0000:e2:10.1", "0000:e2:1f.1", "0000:e2:1d.0", "0000:e2:1c.2", "0000:e2:1e.5", "0000:e2:1a.2", "0000:e2:10.7", "0000:e2:13.0", "0000:e2:1f.4", "0000:e2:19.6", "0000:e2:1f.5", "0000:e2:15.0", "0000:e2:1f.3", "0000:e2:14.7", "0000:e2:18.5", "0000:e2:1c.7", "0000:e2:1b.1", "0000:e2:17.3", "0000:e2:10.4", "0000:e2:1d.6", "0000:e2:1d.3", "0000:e2:18.6", "0000:e2:1f.7", "0000:e2:1b.0", "0000:e2:10.6", "0000:e2:1d.5", "0000:e2:19.5", "0000:e2:1e.2", "0000:e2:1c.4", "0000:e2:15.2", "0000:e2:17.6", "0000:e2:19.2", "0000:e2:1d.7", "0000:e2:1f.6", "0000:e2:17.7", "0000:e2:13.7", "0000:e2:1a.3", "0000:e2:1b.3", "0000:e2:19.1", "0000:e2:1b.2", "0000:e2:19.0", "0000:e2:16.5", "0000:e2:1c.0", "0000:e2:1e.7", "0000:e2:16.2", "0000:e2:1b.6", "0000:e2:16.1", "0000:e2:13.6", "0000:e2:19.3", "0000:e2:13.2", "0000:e2:10.2", "0000:e2:1e.4", "0000:e2:12.4", "0000:e2:17.1", "0000:e2:18.4", "0000:e2:18.1", "0000:e2:17.2", "0000:e2:18.3", "0000:e2:11.7", "0000:e2:12.5", "0000:e2:15.5", "0000:e2:17.5", "0000:e2:1c.6", "0000:e2:11.5", "0000:e2:14.5", "0000:e2:1e.6", "0000:e2:14.2", "0000:e2:12.7", "0000:e2:14.3", "0000:e2:10.3", "0000:e2:1e.3", "0000:e2:13.5", "0000:e2:12.1", "0000:e2:1a.4", "0000:e2:17.0", "0000:e2:1d.1", "0000:e2:16.6", "0000:e2:15.1", "0000:e2:1e.1", "0000:e2:15.7", "0000:e2:13.4", "0000:e2:1a.7", "0000:e2:16.4", "0000:e2:1a.1", "0000:e2:15.3", "0000:e2:15.6", "0000:e2:19.4", "0000:e2:1c.1", "0000:e2:16.3", "0000:e2:11.2", "0000:e2:11.4", "0000:e2:16.7", "0000:e2:1d.4", "0000:e2:1b.5", "0000:e2:1c.3", "0000:e2:19.7", "0000:e2:10.5", "0000:e2:16.0", "0000:e2:1e.0", "0000:e2:1b.4", "0000:e2:14.4", "0000:e2:11.3", "0000:e2:11.6", "0000:e2:12.2"]}</data>
-      <data key="d12">Mellanox Technologies MT28908 Family [ConnectX-6] in PCIe Slot 7 (0000:e2:00.1)</data>
-      <data key="d7">false</data>
-      <data key="d10">{"primary": {"pool_id": "_", "capacities": {"unit": 127}}}</data>
-      <data key="d13">{"primary": {"pool_id": "_", "labels": {"bdf": ["0000:e2:1a.6", "0000:e2:1a.5", "0000:e2:18.2", "0000:e2:12.6", "0000:e2:15.4", "0000:e2:11.0", "0000:e2:14.0", "0000:e2:14.1", "0000:e2:12.0", "0000:e2:1f.2", "0000:e2:14.6", "0000:e2:17.4", "0000:e2:13.3", "0000:e2:12.3", "0000:e2:18.7", "0000:e2:1b.7", "0000:e2:1c.5", "0000:e2:11.1", "0000:e2:1a.0", "0000:e2:1d.2", "0000:e2:18.0", "0000:e2:1f.0", "0000:e2:13.1", "0000:e2:10.1", "0000:e2:1f.1", "0000:e2:1d.0", "0000:e2:1c.2", "0000:e2:1e.5", "0000:e2:1a.2", "0000:e2:10.7", "0000:e2:13.0", "0000:e2:1f.4", "0000:e2:19.6", "0000:e2:1f.5", "0000:e2:15.0", "0000:e2:1f.3", "0000:e2:14.7", "0000:e2:18.5", "0000:e2:1c.7", "0000:e2:1b.1", "0000:e2:17.3", "0000:e2:10.4", "0000:e2:1d.6", "0000:e2:1d.3", "0000:e2:18.6", "0000:e2:1f.7", "0000:e2:1b.0", "0000:e2:10.6", "0000:e2:1d.5", "0000:e2:19.5", "0000:e2:1e.2", "0000:e2:1c.4", "0000:e2:15.2", "0000:e2:17.6", "0000:e2:19.2", "0000:e2:1d.7", "0000:e2:1f.6", "0000:e2:17.7", "0000:e2:13.7", "0000:e2:1a.3", "0000:e2:1b.3", "0000:e2:19.1", "0000:e2:1b.2", "0000:e2:19.0", "0000:e2:16.5", "0000:e2:1c.0", "0000:e2:1e.7", "0000:e2:16.2", "0000:e2:1b.6", "0000:e2:16.1", "0000:e2:13.6", "0000:e2:19.3", "0000:e2:13.2", "0000:e2:10.2", "0000:e2:1e.4", "0000:e2:12.4", "0000:e2:17.1", "0000:e2:18.4", "0000:e2:18.1", "0000:e2:17.2", "0000:e2:18.3", "0000:e2:11.7", "0000:e2:12.5", "0000:e2:15.5", "0000:e2:17.5", "0000:e2:1c.6", "0000:e2:11.5", "0000:e2:14.5", "0000:e2:1e.6", "0000:e2:14.2", "0000:e2:12.7", "0000:e2:14.3", "0000:e2:10.3", "0000:e2:1e.3", "0000:e2:13.5", "0000:e2:12.1", "0000:e2:1a.4", "0000:e2:17.0", "0000:e2:1d.1", "0000:e2:16.6", "0000:e2:15.1", "0000:e2:1e.1", "0000:e2:15.7", "0000:e2:13.4", "0000:e2:1a.7", "0000:e2:16.4", "0000:e2:1a.1", "0000:e2:15.3", "0000:e2:15.6", "0000:e2:19.4", "0000:e2:1c.1", "0000:e2:16.3", "0000:e2:11.2", "0000:e2:11.4", "0000:e2:16.7", "0000:e2:1d.4", "0000:e2:1b.5", "0000:e2:1c.3", "0000:e2:19.7", "0000:e2:10.5", "0000:e2:16.0", "0000:e2:1e.0", "0000:e2:1b.4", "0000:e2:14.4", "0000:e2:11.3", "0000:e2:11.6", "0000:e2:12.2"]}}}</data>
-    </node>
-    <node id="35">
-      <data key="d0">0cb9bb4a-bfb3-47f7-8ddc-b4f1801a9cd6</data>
-      <data key="d1">NetworkService</data>
-      <data key="d2">HX7KQ53-slot7-ns</data>
-      <data key="d3">renc-w3.fabric-testbed.net-renc-w3.fabric-testbed.net-slot7-l2ovs</data>
-      <data key="d4">OVS</data>
-      <data key="d7">false</data>
-      <data key="d14">L2</data>
-    </node>
-    <node id="36">
-      <data key="d0">0cb9bb4a-bfb3-47f7-8ddc-b4f1801a9cd6</data>
-      <data key="d1">ConnectionPoint</data>
-      <data key="d2">node_id-04-3F-72-B7-16-15</data>
-      <data key="d3">renc-w3.fabric-testbed.net-slot7-p1</data>
-      <data key="d4">SharedPort</data>
-      <data key="d6">{"unit": 127}</data>
-      <data key="d11">{"bdf": ["0000:e2:1a.6", "0000:e2:1a.5", "0000:e2:18.2", "0000:e2:12.6", "0000:e2:15.4", "0000:e2:11.0", "0000:e2:14.0", "0000:e2:14.1", "0000:e2:12.0", "0000:e2:1f.2", "0000:e2:14.6", "0000:e2:17.4", "0000:e2:13.3", "0000:e2:12.3", "0000:e2:18.7", "0000:e2:1b.7", "0000:e2:1c.5", "0000:e2:11.1", "0000:e2:1a.0", "0000:e2:1d.2", "0000:e2:18.0", "0000:e2:1f.0", "0000:e2:13.1", "0000:e2:10.1", "0000:e2:1f.1", "0000:e2:1d.0", "0000:e2:1c.2", "0000:e2:1e.5", "0000:e2:1a.2", "0000:e2:10.7", "0000:e2:13.0", "0000:e2:1f.4", "0000:e2:19.6", "0000:e2:1f.5", "0000:e2:15.0", "0000:e2:1f.3", "0000:e2:14.7", "0000:e2:18.5", "0000:e2:1c.7", "0000:e2:1b.1", "0000:e2:17.3", "0000:e2:10.4", "0000:e2:1d.6", "0000:e2:1d.3", "0000:e2:18.6", "0000:e2:1f.7", "0000:e2:1b.0", "0000:e2:10.6", "0000:e2:1d.5", "0000:e2:19.5", "0000:e2:1e.2", "0000:e2:1c.4", "0000:e2:15.2", "0000:e2:17.6", "0000:e2:19.2", "0000:e2:1d.7", "0000:e2:1f.6", "0000:e2:17.7", "0000:e2:13.7", "0000:e2:1a.3", "0000:e2:1b.3", "0000:e2:19.1", "0000:e2:1b.2", "0000:e2:19.0", "0000:e2:16.5", "0000:e2:1c.0", "0000:e2:1e.7", "0000:e2:16.2", "0000:e2:1b.6", "0000:e2:16.1", "0000:e2:13.6", "0000:e2:19.3", "0000:e2:13.2", "0000:e2:10.2", "0000:e2:1e.4", "0000:e2:12.4", "0000:e2:17.1", "0000:e2:18.4", "0000:e2:18.1", "0000:e2:17.2", "0000:e2:18.3", "0000:e2:11.7", "0000:e2:12.5", "0000:e2:15.5", "0000:e2:17.5", "0000:e2:1c.6", "0000:e2:11.5", "0000:e2:14.5", "0000:e2:1e.6", "0000:e2:14.2", "0000:e2:12.7", "0000:e2:14.3", "0000:e2:10.3", "0000:e2:1e.3", "0000:e2:13.5", "0000:e2:12.1", "0000:e2:1a.4", "0000:e2:17.0", "0000:e2:1d.1", "0000:e2:16.6", "0000:e2:15.1", "0000:e2:1e.1", "0000:e2:15.7", "0000:e2:13.4", "0000:e2:1a.7", "0000:e2:16.4", "0000:e2:1a.1", "0000:e2:15.3", "0000:e2:15.6", "0000:e2:19.4", "0000:e2:1c.1", "0000:e2:16.3", "0000:e2:11.2", "0000:e2:11.4", "0000:e2:16.7", "0000:e2:1d.4", "0000:e2:1b.5", "0000:e2:1c.3", "0000:e2:19.7", "0000:e2:10.5", "0000:e2:16.0", "0000:e2:1e.0", "0000:e2:1b.4", "0000:e2:14.4", "0000:e2:11.3", "0000:e2:11.6", "0000:e2:12.2"], "local_name": ["p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1"], "mac": ["06:AE:E2:A2:DF:36", "06:EA:CE:BE:04:26", "0A:51:23:72:A2:06", "0A:6A:67:1A:A4:BA", "0A:F6:65:AC:A1:4D", "0E:FF:20:53:5C:8D", "12:1B:8F:38:A5:3F", "16:C8:74:C5:01:71", "1E:7C:90:09:C5:07", "1E:85:06:2C:40:C5", "1E:C7:DC:D3:61:35", "22:1D:75:2B:9F:35", "26:5B:1E:13:82:B3", "2A:2C:F8:3D:13:36", "2A:62:CA:B6:17:16", "2E:0E:8C:6F:D9:39", "2E:2C:A9:7A:5C:7C", "36:5A:5A:45:DA:DA", "36:85:4A:D3:FC:EF", "36:8F:AF:85:35:2C", "36:D0:F2:72:52:7D", "36:ED:92:E0:55:2C", "3A:2D:1E:FA:44:6A", "3A:93:3D:1A:AC:E9", "3E:03:55:B6:59:E5", "3E:3B:F4:4C:6E:7A", "42:02:07:43:88:71", "42:40:86:DA:1A:E8", "4A:DC:33:A9:47:6A", "4E:4B:29:95:49:A1", "4E:8F:2E:A6:65:F8", "52:12:B3:19:91:55", "52:78:1D:7B:41:6C", "52:93:A9:F8:D0:44", "56:46:AD:3A:30:71", "56:A6:E5:C9:20:B0", "56:D4:B8:05:10:B7", "5A:56:BC:A9:90:12", "5A:71:03:F3:4E:5C", "5A:73:89:77:32:F7", "5A:7F:69:74:55:22", "5A:BC:3B:45:7C:22", "5E:0C:AD:01:2E:8F", "5E:2F:4C:BD:BA:FF", "5E:75:06:1A:1C:C7", "5E:C4:55:5A:7B:C2", "62:20:C6:FF:FF:A8", "62:C1:FC:E5:A7:B6", "62:E7:C3:80:FA:0F", "66:06:69:3A:23:6E", "6A:2B:43:5B:64:6D", "6A:3E:34:B2:8E:B2", "6A:D3:B5:01:79:72", "6A:EB:FA:F4:BD:19", "6E:95:EE:5D:62:D8", "6E:9C:22:92:01:DE", "6E:E6:3C:4B:8F:B4", "6E:F8:48:CF:8D:13", "72:BA:A7:70:28:53", "76:12:C4:D6:A6:58", "76:21:6C:7E:DB:4E", "76:9F:BB:BD:AB:89", "7E:2A:DB:C7:B1:46", "86:D3:06:E5:0C:52", "86:E5:83:AB:63:C9", "8A:EA:E7:96:EA:37", "92:51:3D:25:D3:99", "92:96:8B:6E:E2:57", "96:6E:AC:F5:0C:A0", "9A:40:C6:50:8B:08", "9E:BC:A9:34:0F:E8", "9E:EB:74:CB:1E:1B", "A2:0A:19:D3:0B:5E", "A2:E6:52:43:54:58", "A6:14:2A:DA:3E:89", "A6:43:A5:72:2D:AA", "A6:F9:1E:84:67:B1", "AA:07:2B:B2:BD:3D", "AA:C6:72:8F:08:78", "AE:40:11:5B:54:00", "AE:42:64:3F:4F:73", "AE:97:DD:70:55:EC", "B2:82:24:CE:9A:3D", "B2:B7:B7:C6:66:02", "B2:EE:D4:00:91:ED", "B6:1C:CB:51:1B:51", "B6:A8:69:D5:3E:9A", "B6:B4:AE:4D:24:7B", "BA:45:3E:4F:BF:F4", "BA:69:93:80:44:F5", "BA:6F:66:44:5B:D4", "C2:D4:E4:12:E5:3D", "C6:2E:C8:56:2C:C0", "C6:42:43:59:DB:DC", "C6:46:9E:F9:71:BD", "C6:E5:20:89:6B:C5", "CE:2A:93:AF:B1:05", "CE:AC:17:70:9D:17", "D2:03:5B:E1:C7:FB", "D2:58:BE:F4:A9:68", "D6:72:70:BB:CE:22", "D6:72:E4:39:4E:2F", "D6:D4:21:FE:62:9F", "DA:60:48:D3:EF:E6", "DA:B6:BE:E5:86:9D", "DA:BB:FE:0D:62:93", "DE:C2:A0:61:E3:10", "E2:07:08:E5:BE:F1", "E6:10:55:2F:E0:1D", "E6:38:25:DC:70:3F", "E6:D2:8E:F6:EE:31", "E6:D6:04:58:00:B3", "EE:34:A2:8C:E3:10", "EE:C8:50:3E:1D:96", "EE:FF:A6:0D:B9:F9", "F2:00:B7:19:8D:04", "F2:47:69:FE:35:60", "F2:BB:D1:5F:F8:D6", "F2:FF:D0:FD:91:AF", "F6:81:F5:9B:2F:09", "FE:38:76:FD:A4:84", "FE:82:A6:BD:3C:FF", "FE:A3:41:56:53:C8", "FE:C0:46:D5:F7:F6", "FE:E8:57:7A:64:F4", "FE:EC:7F:EA:F3:6B", "FE:F8:4F:51:E1:9A"], "vlan": ["2085", "2084", "2065", "2021", "2043", "2007", "2031", "2032", "2015", "2121", "2037", "2059", "2026", "2018", "2070", "2094", "2100", "2008", "2079", "2105", "2063", "2119", "2024", "2000", "2120", "2103", "2097", "2116", "2081", "2006", "2023", "2123", "2077", "2124", "2039", "2122", "2038", "2068", "2102", "2088", "2058", "2003", "2109", "2106", "2069", "2126", "2087", "2005", "2108", "2076", "2113", "2099", "2041", "2061", "2073", "2110", "2125", "2062", "2030", "2082", "2090", "2072", "2089", "2071", "2052", "2095", "2118", "2049", "2093", "2048", "2029", "2074", "2025", "2001", "2115", "2019", "2056", "2067", "2064", "2057", "2066", "2014", "2020", "2044", "2060", "2101", "2012", "2036", "2117", "2033", "2022", "2034", "2002", "2114", "2028", "2016", "2083", "2055", "2104", "2053", "2040", "2112", "2046", "2027", "2086", "2051", "2080", "2042", "2045", "2075", "2096", "2050", "2009", "2011", "2054", "2107", "2092", "2098", "2078", "2004", "2047", "2111", "2091", "2035", "2010", "2013", "2017"]}</data>
-      <data key="d7">false</data>
-      <data key="d10">{"primary": {"pool_id": "_", "capacities": {"unit": 127}}}</data>
-      <data key="d13">{"primary": {"pool_id": "_", "labels": {"bdf": ["0000:e2:1a.6", "0000:e2:1a.5", "0000:e2:18.2", "0000:e2:12.6", "0000:e2:15.4", "0000:e2:11.0", "0000:e2:14.0", "0000:e2:14.1", "0000:e2:12.0", "0000:e2:1f.2", "0000:e2:14.6", "0000:e2:17.4", "0000:e2:13.3", "0000:e2:12.3", "0000:e2:18.7", "0000:e2:1b.7", "0000:e2:1c.5", "0000:e2:11.1", "0000:e2:1a.0", "0000:e2:1d.2", "0000:e2:18.0", "0000:e2:1f.0", "0000:e2:13.1", "0000:e2:10.1", "0000:e2:1f.1", "0000:e2:1d.0", "0000:e2:1c.2", "0000:e2:1e.5", "0000:e2:1a.2", "0000:e2:10.7", "0000:e2:13.0", "0000:e2:1f.4", "0000:e2:19.6", "0000:e2:1f.5", "0000:e2:15.0", "0000:e2:1f.3", "0000:e2:14.7", "0000:e2:18.5", "0000:e2:1c.7", "0000:e2:1b.1", "0000:e2:17.3", "0000:e2:10.4", "0000:e2:1d.6", "0000:e2:1d.3", "0000:e2:18.6", "0000:e2:1f.7", "0000:e2:1b.0", "0000:e2:10.6", "0000:e2:1d.5", "0000:e2:19.5", "0000:e2:1e.2", "0000:e2:1c.4", "0000:e2:15.2", "0000:e2:17.6", "0000:e2:19.2", "0000:e2:1d.7", "0000:e2:1f.6", "0000:e2:17.7", "0000:e2:13.7", "0000:e2:1a.3", "0000:e2:1b.3", "0000:e2:19.1", "0000:e2:1b.2", "0000:e2:19.0", "0000:e2:16.5", "0000:e2:1c.0", "0000:e2:1e.7", "0000:e2:16.2", "0000:e2:1b.6", "0000:e2:16.1", "0000:e2:13.6", "0000:e2:19.3", "0000:e2:13.2", "0000:e2:10.2", "0000:e2:1e.4", "0000:e2:12.4", "0000:e2:17.1", "0000:e2:18.4", "0000:e2:18.1", "0000:e2:17.2", "0000:e2:18.3", "0000:e2:11.7", "0000:e2:12.5", "0000:e2:15.5", "0000:e2:17.5", "0000:e2:1c.6", "0000:e2:11.5", "0000:e2:14.5", "0000:e2:1e.6", "0000:e2:14.2", "0000:e2:12.7", "0000:e2:14.3", "0000:e2:10.3", "0000:e2:1e.3", "0000:e2:13.5", "0000:e2:12.1", "0000:e2:1a.4", "0000:e2:17.0", "0000:e2:1d.1", "0000:e2:16.6", "0000:e2:15.1", "0000:e2:1e.1", "0000:e2:15.7", "0000:e2:13.4", "0000:e2:1a.7", "0000:e2:16.4", "0000:e2:1a.1", "0000:e2:15.3", "0000:e2:15.6", "0000:e2:19.4", "0000:e2:1c.1", "0000:e2:16.3", "0000:e2:11.2", "0000:e2:11.4", "0000:e2:16.7", "0000:e2:1d.4", "0000:e2:1b.5", "0000:e2:1c.3", "0000:e2:19.7", "0000:e2:10.5", "0000:e2:16.0", "0000:e2:1e.0", "0000:e2:1b.4", "0000:e2:14.4", "0000:e2:11.3", "0000:e2:11.6", "0000:e2:12.2"], "mac": ["06:AE:E2:A2:DF:36", "06:EA:CE:BE:04:26", "0A:51:23:72:A2:06", "0A:6A:67:1A:A4:BA", "0A:F6:65:AC:A1:4D", "0E:FF:20:53:5C:8D", "12:1B:8F:38:A5:3F", "16:C8:74:C5:01:71", "1E:7C:90:09:C5:07", "1E:85:06:2C:40:C5", "1E:C7:DC:D3:61:35", "22:1D:75:2B:9F:35", "26:5B:1E:13:82:B3", "2A:2C:F8:3D:13:36", "2A:62:CA:B6:17:16", "2E:0E:8C:6F:D9:39", "2E:2C:A9:7A:5C:7C", "36:5A:5A:45:DA:DA", "36:85:4A:D3:FC:EF", "36:8F:AF:85:35:2C", "36:D0:F2:72:52:7D", "36:ED:92:E0:55:2C", "3A:2D:1E:FA:44:6A", "3A:93:3D:1A:AC:E9", "3E:03:55:B6:59:E5", "3E:3B:F4:4C:6E:7A", "42:02:07:43:88:71", "42:40:86:DA:1A:E8", "4A:DC:33:A9:47:6A", "4E:4B:29:95:49:A1", "4E:8F:2E:A6:65:F8", "52:12:B3:19:91:55", "52:78:1D:7B:41:6C", "52:93:A9:F8:D0:44", "56:46:AD:3A:30:71", "56:A6:E5:C9:20:B0", "56:D4:B8:05:10:B7", "5A:56:BC:A9:90:12", "5A:71:03:F3:4E:5C", "5A:73:89:77:32:F7", "5A:7F:69:74:55:22", "5A:BC:3B:45:7C:22", "5E:0C:AD:01:2E:8F", "5E:2F:4C:BD:BA:FF", "5E:75:06:1A:1C:C7", "5E:C4:55:5A:7B:C2", "62:20:C6:FF:FF:A8", "62:C1:FC:E5:A7:B6", "62:E7:C3:80:FA:0F", "66:06:69:3A:23:6E", "6A:2B:43:5B:64:6D", "6A:3E:34:B2:8E:B2", "6A:D3:B5:01:79:72", "6A:EB:FA:F4:BD:19", "6E:95:EE:5D:62:D8", "6E:9C:22:92:01:DE", "6E:E6:3C:4B:8F:B4", "6E:F8:48:CF:8D:13", "72:BA:A7:70:28:53", "76:12:C4:D6:A6:58", "76:21:6C:7E:DB:4E", "76:9F:BB:BD:AB:89", "7E:2A:DB:C7:B1:46", "86:D3:06:E5:0C:52", "86:E5:83:AB:63:C9", "8A:EA:E7:96:EA:37", "92:51:3D:25:D3:99", "92:96:8B:6E:E2:57", "96:6E:AC:F5:0C:A0", "9A:40:C6:50:8B:08", "9E:BC:A9:34:0F:E8", "9E:EB:74:CB:1E:1B", "A2:0A:19:D3:0B:5E", "A2:E6:52:43:54:58", "A6:14:2A:DA:3E:89", "A6:43:A5:72:2D:AA", "A6:F9:1E:84:67:B1", "AA:07:2B:B2:BD:3D", "AA:C6:72:8F:08:78", "AE:40:11:5B:54:00", "AE:42:64:3F:4F:73", "AE:97:DD:70:55:EC", "B2:82:24:CE:9A:3D", "B2:B7:B7:C6:66:02", "B2:EE:D4:00:91:ED", "B6:1C:CB:51:1B:51", "B6:A8:69:D5:3E:9A", "B6:B4:AE:4D:24:7B", "BA:45:3E:4F:BF:F4", "BA:69:93:80:44:F5", "BA:6F:66:44:5B:D4", "C2:D4:E4:12:E5:3D", "C6:2E:C8:56:2C:C0", "C6:42:43:59:DB:DC", "C6:46:9E:F9:71:BD", "C6:E5:20:89:6B:C5", "CE:2A:93:AF:B1:05", "CE:AC:17:70:9D:17", "D2:03:5B:E1:C7:FB", "D2:58:BE:F4:A9:68", "D6:72:70:BB:CE:22", "D6:72:E4:39:4E:2F", "D6:D4:21:FE:62:9F", "DA:60:48:D3:EF:E6", "DA:B6:BE:E5:86:9D", "DA:BB:FE:0D:62:93", "DE:C2:A0:61:E3:10", "E2:07:08:E5:BE:F1", "E6:10:55:2F:E0:1D", "E6:38:25:DC:70:3F", "E6:D2:8E:F6:EE:31", "E6:D6:04:58:00:B3", "EE:34:A2:8C:E3:10", "EE:C8:50:3E:1D:96", "EE:FF:A6:0D:B9:F9", "F2:00:B7:19:8D:04", "F2:47:69:FE:35:60", "F2:BB:D1:5F:F8:D6", "F2:FF:D0:FD:91:AF", "F6:81:F5:9B:2F:09", "FE:38:76:FD:A4:84", "FE:82:A6:BD:3C:FF", "FE:A3:41:56:53:C8", "FE:C0:46:D5:F7:F6", "FE:E8:57:7A:64:F4", "FE:EC:7F:EA:F3:6B", "FE:F8:4F:51:E1:9A"], "vlan": ["2085", "2084", "2065", "2021", "2043", "2007", "2031", "2032", "2015", "2121", "2037", "2059", "2026", "2018", "2070", "2094", "2100", "2008", "2079", "2105", "2063", "2119", "2024", "2000", "2120", "2103", "2097", "2116", "2081", "2006", "2023", "2123", "2077", "2124", "2039", "2122", "2038", "2068", "2102", "2088", "2058", "2003", "2109", "2106", "2069", "2126", "2087", "2005", "2108", "2076", "2113", "2099", "2041", "2061", "2073", "2110", "2125", "2062", "2030", "2082", "2090", "2072", "2089", "2071", "2052", "2095", "2118", "2049", "2093", "2048", "2029", "2074", "2025", "2001", "2115", "2019", "2056", "2067", "2064", "2057", "2066", "2014", "2020", "2044", "2060", "2101", "2012", "2036", "2117", "2033", "2022", "2034", "2002", "2114", "2028", "2016", "2083", "2055", "2104", "2053", "2040", "2112", "2046", "2027", "2086", "2051", "2080", "2042", "2045", "2075", "2096", "2050", "2009", "2011", "2054", "2107", "2092", "2098", "2078", "2004", "2047", "2111", "2091", "2035", "2010", "2013", "2017"], "local_name": ["p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1"]}}}</data>
-    </node>
-    <node id="37">
-      <data key="d0">0cb9bb4a-bfb3-47f7-8ddc-b4f1801a9cd6</data>
-      <data key="d1">Component</data>
-      <data key="d2">HX7KQ53-slot3</data>
-      <data key="d3">renc-w3.fabric-testbed.net-slot3</data>
+      <data key="d2">HX7KQ53-nic1</data>
+      <data key="d3">renc-w3-nic1</data>
       <data key="d4">SmartNIC</data>
       <data key="d5">ConnectX-5</data>
       <data key="d6">{"unit": 1}</data>
       <data key="d11">{"bdf": ["0000:41:00.0", "0000:41:00.1"]}</data>
-      <data key="d12">Mellanox Technologies MT27800 Family [ConnectX-5] in PCIe Slot 3 (0000:41:00.0)</data>
+      <data key="d12">Mellanox Technologies MT27800 Family [ConnectX-5]</data>
       <data key="d7">false</data>
       <data key="d10">{"primary": {"pool_id": "_", "capacities": {"unit": 1}}}</data>
       <data key="d13">{"primary": {"pool_id": "_", "labels": {"bdf": ["0000:41:00.0", "0000:41:00.1"]}}}</data>
     </node>
-    <node id="38">
-      <data key="d0">0cb9bb4a-bfb3-47f7-8ddc-b4f1801a9cd6</data>
+    <node id="838">
+      <data key="d0">42479fc2-22a8-4f26-86b8-277beab2e2dd</data>
       <data key="d1">NetworkService</data>
-      <data key="d2">HX7KQ53-slot3-ns</data>
-      <data key="d3">renc-w3.fabric-testbed.net-renc-w3.fabric-testbed.net-slot3-l2ovs</data>
+      <data key="d2">HX7KQ53-nic1-sf</data>
+      <data key="d3">renc-w3-renc-w3-nic1-l2ovs</data>
       <data key="d4">OVS</data>
       <data key="d7">false</data>
       <data key="d14">L2</data>
     </node>
-    <node id="39">
-      <data key="d0">0cb9bb4a-bfb3-47f7-8ddc-b4f1801a9cd6</data>
+    <node id="839">
+      <data key="d0">42479fc2-22a8-4f26-86b8-277beab2e2dd</data>
       <data key="d1">ConnectionPoint</data>
       <data key="d2">node_id-0C-42-A1-BE-8F-D4</data>
-      <data key="d3">renc-w3.fabric-testbed.net-slot3-p1</data>
+      <data key="d3">renc-w3-nic1-p1</data>
       <data key="d4">DedicatedPort</data>
       <data key="d6">{"bw": 25, "unit": 1}</data>
       <data key="d11">{"local_name": "p1", "mac": "0C:42:A1:BE:8F:D4", "vlan_range": "1-4096"}</data>
@@ -513,11 +513,11 @@
       <data key="d10">{"primary": {"pool_id": "_", "capacities": {"bw": 25, "unit": 1}}}</data>
       <data key="d13">{"primary": {"pool_id": "_", "labels": {"mac": "0C:42:A1:BE:8F:D4", "vlan_range": "1-4096", "local_name": "p1"}}}</data>
     </node>
-    <node id="40">
-      <data key="d0">0cb9bb4a-bfb3-47f7-8ddc-b4f1801a9cd6</data>
+    <node id="840">
+      <data key="d0">42479fc2-22a8-4f26-86b8-277beab2e2dd</data>
       <data key="d1">ConnectionPoint</data>
       <data key="d2">node_id-0C-42-A1-BE-8F-D5</data>
-      <data key="d3">renc-w3.fabric-testbed.net-slot3-p2</data>
+      <data key="d3">renc-w3-nic1-p2</data>
       <data key="d4">DedicatedPort</data>
       <data key="d6">{"bw": 25, "unit": 1}</data>
       <data key="d11">{"local_name": "p2", "mac": "0C:42:A1:BE:8F:D5", "vlan_range": "1-4096"}</data>
@@ -525,34 +525,34 @@
       <data key="d10">{"primary": {"pool_id": "_", "capacities": {"bw": 25, "unit": 1}}}</data>
       <data key="d13">{"primary": {"pool_id": "_", "labels": {"mac": "0C:42:A1:BE:8F:D5", "vlan_range": "1-4096", "local_name": "p2"}}}</data>
     </node>
-    <node id="41">
-      <data key="d0">0cb9bb4a-bfb3-47f7-8ddc-b4f1801a9cd6</data>
+    <node id="841">
+      <data key="d0">42479fc2-22a8-4f26-86b8-277beab2e2dd</data>
       <data key="d1">Component</data>
-      <data key="d2">HX7KQ53-slot6</data>
-      <data key="d3">renc-w3.fabric-testbed.net-slot6</data>
+      <data key="d2">HX7KQ53-nic2</data>
+      <data key="d3">renc-w3-nic2</data>
       <data key="d4">SmartNIC</data>
       <data key="d5">ConnectX-5</data>
       <data key="d6">{"unit": 1}</data>
       <data key="d11">{"bdf": ["0000:a1:00.0", "0000:a1:00.1"]}</data>
-      <data key="d12">Mellanox Technologies MT27800 Family [ConnectX-5] in PCIe Slot 6 (0000:a1:00.0)</data>
+      <data key="d12">Mellanox Technologies MT27800 Family [ConnectX-5]</data>
       <data key="d7">false</data>
       <data key="d10">{"primary": {"pool_id": "_", "capacities": {"unit": 1}}}</data>
       <data key="d13">{"primary": {"pool_id": "_", "labels": {"bdf": ["0000:a1:00.0", "0000:a1:00.1"]}}}</data>
     </node>
-    <node id="42">
-      <data key="d0">0cb9bb4a-bfb3-47f7-8ddc-b4f1801a9cd6</data>
+    <node id="842">
+      <data key="d0">42479fc2-22a8-4f26-86b8-277beab2e2dd</data>
       <data key="d1">NetworkService</data>
-      <data key="d2">HX7KQ53-slot6-ns</data>
-      <data key="d3">renc-w3.fabric-testbed.net-renc-w3.fabric-testbed.net-slot6-l2ovs</data>
+      <data key="d2">HX7KQ53-nic2-sf</data>
+      <data key="d3">renc-w3-renc-w3-nic2-l2ovs</data>
       <data key="d4">OVS</data>
       <data key="d7">false</data>
       <data key="d14">L2</data>
     </node>
-    <node id="43">
-      <data key="d0">0cb9bb4a-bfb3-47f7-8ddc-b4f1801a9cd6</data>
+    <node id="843">
+      <data key="d0">42479fc2-22a8-4f26-86b8-277beab2e2dd</data>
       <data key="d1">ConnectionPoint</data>
       <data key="d2">node_id-0C-42-A1-BE-8F-E8</data>
-      <data key="d3">renc-w3.fabric-testbed.net-slot6-p1</data>
+      <data key="d3">renc-w3-nic2-p1</data>
       <data key="d4">DedicatedPort</data>
       <data key="d6">{"bw": 25, "unit": 1}</data>
       <data key="d11">{"local_name": "p1", "mac": "0C:42:A1:BE:8F:E8", "vlan_range": "1-4096"}</data>
@@ -560,11 +560,11 @@
       <data key="d10">{"primary": {"pool_id": "_", "capacities": {"bw": 25, "unit": 1}}}</data>
       <data key="d13">{"primary": {"pool_id": "_", "labels": {"mac": "0C:42:A1:BE:8F:E8", "vlan_range": "1-4096", "local_name": "p1"}}}</data>
     </node>
-    <node id="44">
-      <data key="d0">0cb9bb4a-bfb3-47f7-8ddc-b4f1801a9cd6</data>
+    <node id="844">
+      <data key="d0">42479fc2-22a8-4f26-86b8-277beab2e2dd</data>
       <data key="d1">ConnectionPoint</data>
       <data key="d2">node_id-0C-42-A1-BE-8F-E9</data>
-      <data key="d3">renc-w3.fabric-testbed.net-slot6-p2</data>
+      <data key="d3">renc-w3-nic2-p2</data>
       <data key="d4">DedicatedPort</data>
       <data key="d6">{"bw": 25, "unit": 1}</data>
       <data key="d11">{"local_name": "p2", "mac": "0C:42:A1:BE:8F:E9", "vlan_range": "1-4096"}</data>
@@ -572,20 +572,20 @@
       <data key="d10">{"primary": {"pool_id": "_", "capacities": {"bw": 25, "unit": 1}}}</data>
       <data key="d13">{"primary": {"pool_id": "_", "labels": {"mac": "0C:42:A1:BE:8F:E9", "vlan_range": "1-4096", "local_name": "p2"}}}</data>
     </node>
-    <node id="45">
-      <data key="d0">0cb9bb4a-bfb3-47f7-8ddc-b4f1801a9cd6</data>
+    <node id="845">
+      <data key="d0">42479fc2-22a8-4f26-86b8-277beab2e2dd</data>
       <data key="d1">NetworkNode</data>
       <data key="d2">BDXTQ53</data>
-      <data key="d3">renc-storage.fabric-testbed.net</data>
+      <data key="d3">renc-nas</data>
       <data key="d4">NAS</data>
       <data key="d5">ME4084</data>
-      <data key="d6">{"disk": 336000, "unit": 1}</data>
+      <data key="d6">{"disk": 100000, "unit": 1}</data>
       <data key="d7">false</data>
       <data key="d8">RENC</data>
-      <data key="d10">{"primary": {"pool_id": "_", "capacities": {"disk": 336000, "unit": 1}}}</data>
+      <data key="d10">{"primary": {"pool_id": "_", "capacities": {"disk": 100000, "unit": 1}}}</data>
     </node>
-    <node id="46">
-      <data key="d0">0cb9bb4a-bfb3-47f7-8ddc-b4f1801a9cd6</data>
+    <node id="846">
+      <data key="d0">42479fc2-22a8-4f26-86b8-277beab2e2dd</data>
       <data key="d1">NetworkNode</data>
       <data key="d2">node+renc-data-sw:ip+192.168.11.3</data>
       <data key="d3">renc-data-sw</data>
@@ -593,8 +593,8 @@
       <data key="d7">true</data>
       <data key="d8">RENC</data>
     </node>
-    <node id="47">
-      <data key="d0">0cb9bb4a-bfb3-47f7-8ddc-b4f1801a9cd6</data>
+    <node id="847">
+      <data key="d0">42479fc2-22a8-4f26-86b8-277beab2e2dd</data>
       <data key="d1">NetworkService</data>
       <data key="d2">node+renc-data-sw:ip+192.168.11.3-ns</data>
       <data key="d3">renc-data-sw-ns</data>
@@ -602,16 +602,16 @@
       <data key="d7">true</data>
       <data key="d14">L2</data>
     </node>
-    <node id="48">
-      <data key="d0">0cb9bb4a-bfb3-47f7-8ddc-b4f1801a9cd6</data>
+    <node id="848">
+      <data key="d0">42479fc2-22a8-4f26-86b8-277beab2e2dd</data>
       <data key="d1">ConnectionPoint</data>
       <data key="d2">port+renc-data-sw:HundredGigE0/0/0/5</data>
       <data key="d3">HundredGigE0/0/0/5</data>
       <data key="d4">TrunkPort</data>
       <data key="d7">true</data>
     </node>
-    <node id="49">
-      <data key="d0">0cb9bb4a-bfb3-47f7-8ddc-b4f1801a9cd6</data>
+    <node id="849">
+      <data key="d0">42479fc2-22a8-4f26-86b8-277beab2e2dd</data>
       <data key="d1">Link</data>
       <data key="d2">port+renc-data-sw:HundredGigE0/0/0/5-DAC</data>
       <data key="d3">l1</data>
@@ -619,67 +619,67 @@
       <data key="d7">false</data>
       <data key="d14">L2</data>
     </node>
-    <node id="50">
-      <data key="d0">0cb9bb4a-bfb3-47f7-8ddc-b4f1801a9cd6</data>
-      <data key="d1">ConnectionPoint</data>
-      <data key="d2">port+renc-data-sw:HundredGigE0/0/0/9</data>
-      <data key="d3">HundredGigE0/0/0/9</data>
-      <data key="d4">TrunkPort</data>
-      <data key="d7">true</data>
-    </node>
-    <node id="51">
-      <data key="d0">0cb9bb4a-bfb3-47f7-8ddc-b4f1801a9cd6</data>
-      <data key="d1">Link</data>
-      <data key="d2">port+renc-data-sw:HundredGigE0/0/0/9-DAC</data>
-      <data key="d3">l2</data>
-      <data key="d4">Patch</data>
-      <data key="d7">false</data>
-      <data key="d14">L2</data>
-    </node>
-    <node id="52">
-      <data key="d0">0cb9bb4a-bfb3-47f7-8ddc-b4f1801a9cd6</data>
+    <node id="850">
+      <data key="d0">42479fc2-22a8-4f26-86b8-277beab2e2dd</data>
       <data key="d1">ConnectionPoint</data>
       <data key="d2">port+renc-data-sw:HundredGigE0/0/0/13</data>
       <data key="d3">HundredGigE0/0/0/13</data>
       <data key="d4">TrunkPort</data>
       <data key="d7">true</data>
     </node>
-    <node id="53">
-      <data key="d0">0cb9bb4a-bfb3-47f7-8ddc-b4f1801a9cd6</data>
+    <node id="851">
+      <data key="d0">42479fc2-22a8-4f26-86b8-277beab2e2dd</data>
       <data key="d1">Link</data>
       <data key="d2">port+renc-data-sw:HundredGigE0/0/0/13-DAC</data>
-      <data key="d3">l3</data>
+      <data key="d3">l2</data>
       <data key="d4">Patch</data>
       <data key="d7">false</data>
       <data key="d14">L2</data>
     </node>
-    <node id="54">
-      <data key="d0">0cb9bb4a-bfb3-47f7-8ddc-b4f1801a9cd6</data>
+    <node id="852">
+      <data key="d0">42479fc2-22a8-4f26-86b8-277beab2e2dd</data>
       <data key="d1">ConnectionPoint</data>
       <data key="d2">port+renc-data-sw:HundredGigE0/0/0/15</data>
       <data key="d3">HundredGigE0/0/0/15</data>
       <data key="d4">TrunkPort</data>
       <data key="d7">true</data>
     </node>
-    <node id="55">
-      <data key="d0">0cb9bb4a-bfb3-47f7-8ddc-b4f1801a9cd6</data>
+    <node id="853">
+      <data key="d0">42479fc2-22a8-4f26-86b8-277beab2e2dd</data>
       <data key="d1">Link</data>
       <data key="d2">port+renc-data-sw:HundredGigE0/0/0/15-DAC</data>
+      <data key="d3">l3</data>
+      <data key="d4">Patch</data>
+      <data key="d7">false</data>
+      <data key="d14">L2</data>
+    </node>
+    <node id="854">
+      <data key="d0">42479fc2-22a8-4f26-86b8-277beab2e2dd</data>
+      <data key="d1">ConnectionPoint</data>
+      <data key="d2">port+renc-data-sw:HundredGigE0/0/0/9</data>
+      <data key="d3">HundredGigE0/0/0/9</data>
+      <data key="d4">TrunkPort</data>
+      <data key="d7">true</data>
+    </node>
+    <node id="855">
+      <data key="d0">42479fc2-22a8-4f26-86b8-277beab2e2dd</data>
+      <data key="d1">Link</data>
+      <data key="d2">port+renc-data-sw:HundredGigE0/0/0/9-DAC</data>
       <data key="d3">l4</data>
       <data key="d4">Patch</data>
       <data key="d7">false</data>
       <data key="d14">L2</data>
     </node>
-    <node id="56">
-      <data key="d0">0cb9bb4a-bfb3-47f7-8ddc-b4f1801a9cd6</data>
+    <node id="856">
+      <data key="d0">42479fc2-22a8-4f26-86b8-277beab2e2dd</data>
       <data key="d1">ConnectionPoint</data>
       <data key="d2">port+renc-data-sw:HundredGigE0/0/0/17</data>
       <data key="d3">HundredGigE0/0/0/17</data>
       <data key="d4">TrunkPort</data>
       <data key="d7">true</data>
     </node>
-    <node id="57">
-      <data key="d0">0cb9bb4a-bfb3-47f7-8ddc-b4f1801a9cd6</data>
+    <node id="857">
+      <data key="d0">42479fc2-22a8-4f26-86b8-277beab2e2dd</data>
       <data key="d1">Link</data>
       <data key="d2">port+renc-data-sw:HundredGigE0/0/0/17-DAC</data>
       <data key="d3">l5</data>
@@ -687,16 +687,16 @@
       <data key="d7">false</data>
       <data key="d14">L2</data>
     </node>
-    <node id="58">
-      <data key="d0">0cb9bb4a-bfb3-47f7-8ddc-b4f1801a9cd6</data>
+    <node id="858">
+      <data key="d0">42479fc2-22a8-4f26-86b8-277beab2e2dd</data>
       <data key="d1">ConnectionPoint</data>
       <data key="d2">port+renc-data-sw:HundredGigE0/0/0/19</data>
       <data key="d3">HundredGigE0/0/0/19</data>
       <data key="d4">TrunkPort</data>
       <data key="d7">true</data>
     </node>
-    <node id="59">
-      <data key="d0">0cb9bb4a-bfb3-47f7-8ddc-b4f1801a9cd6</data>
+    <node id="859">
+      <data key="d0">42479fc2-22a8-4f26-86b8-277beab2e2dd</data>
       <data key="d1">Link</data>
       <data key="d2">port+renc-data-sw:HundredGigE0/0/0/19-DAC</data>
       <data key="d3">l6</data>
@@ -704,16 +704,16 @@
       <data key="d7">false</data>
       <data key="d14">L2</data>
     </node>
-    <node id="60">
-      <data key="d0">0cb9bb4a-bfb3-47f7-8ddc-b4f1801a9cd6</data>
+    <node id="860">
+      <data key="d0">42479fc2-22a8-4f26-86b8-277beab2e2dd</data>
       <data key="d1">ConnectionPoint</data>
       <data key="d2">port+renc-data-sw:HundredGigE0/0/0/21</data>
       <data key="d3">HundredGigE0/0/0/21</data>
       <data key="d4">TrunkPort</data>
       <data key="d7">true</data>
     </node>
-    <node id="61">
-      <data key="d0">0cb9bb4a-bfb3-47f7-8ddc-b4f1801a9cd6</data>
+    <node id="861">
+      <data key="d0">42479fc2-22a8-4f26-86b8-277beab2e2dd</data>
       <data key="d1">Link</data>
       <data key="d2">port+renc-data-sw:HundredGigE0/0/0/21-DAC</data>
       <data key="d3">l7</data>
@@ -721,297 +721,297 @@
       <data key="d7">false</data>
       <data key="d14">L2</data>
     </node>
-    <node id="62">
-      <data key="d0">0cb9bb4a-bfb3-47f7-8ddc-b4f1801a9cd6</data>
+    <node id="862">
+      <data key="d0">42479fc2-22a8-4f26-86b8-277beab2e2dd</data>
       <data key="d1">ConnectionPoint</data>
-      <data key="d2">port+renc-data-sw:TwentyFiveGigE0/0/0/23/1</data>
-      <data key="d3">TwentyFiveGigE0/0/0/23/1</data>
+      <data key="d2">port+renc-data-sw:HundredGigE0/0/0/25.1</data>
+      <data key="d3">HundredGigE0/0/0/25.1</data>
       <data key="d4">TrunkPort</data>
       <data key="d7">true</data>
     </node>
-    <node id="63">
-      <data key="d0">0cb9bb4a-bfb3-47f7-8ddc-b4f1801a9cd6</data>
+    <node id="863">
+      <data key="d0">42479fc2-22a8-4f26-86b8-277beab2e2dd</data>
       <data key="d1">Link</data>
-      <data key="d2">port+renc-data-sw:TwentyFiveGigE0/0/0/23/1-DAC</data>
+      <data key="d2">port+renc-data-sw:HundredGigE0/0/0/25.1-DAC</data>
       <data key="d3">l8</data>
       <data key="d4">Patch</data>
       <data key="d7">false</data>
       <data key="d14">L2</data>
     </node>
-    <node id="64">
-      <data key="d0">0cb9bb4a-bfb3-47f7-8ddc-b4f1801a9cd6</data>
+    <node id="864">
+      <data key="d0">42479fc2-22a8-4f26-86b8-277beab2e2dd</data>
       <data key="d1">ConnectionPoint</data>
-      <data key="d2">port+renc-data-sw:TwentyFiveGigE0/0/0/23/0</data>
-      <data key="d3">TwentyFiveGigE0/0/0/23/0</data>
+      <data key="d2">port+renc-data-sw:HundredGigE0/0/0/25.2</data>
+      <data key="d3">HundredGigE0/0/0/25.2</data>
       <data key="d4">TrunkPort</data>
       <data key="d7">true</data>
     </node>
-    <node id="65">
-      <data key="d0">0cb9bb4a-bfb3-47f7-8ddc-b4f1801a9cd6</data>
+    <node id="865">
+      <data key="d0">42479fc2-22a8-4f26-86b8-277beab2e2dd</data>
       <data key="d1">Link</data>
-      <data key="d2">port+renc-data-sw:TwentyFiveGigE0/0/0/23/0-DAC</data>
+      <data key="d2">port+renc-data-sw:HundredGigE0/0/0/25.2-DAC</data>
       <data key="d3">l9</data>
       <data key="d4">Patch</data>
       <data key="d7">false</data>
       <data key="d14">L2</data>
     </node>
-    <node id="66">
-      <data key="d0">0cb9bb4a-bfb3-47f7-8ddc-b4f1801a9cd6</data>
+    <node id="866">
+      <data key="d0">42479fc2-22a8-4f26-86b8-277beab2e2dd</data>
       <data key="d1">ConnectionPoint</data>
-      <data key="d2">port+renc-data-sw:TwentyFiveGigE0/0/0/23/3</data>
-      <data key="d3">TwentyFiveGigE0/0/0/23/3</data>
+      <data key="d2">port+renc-data-sw:HundredGigE0/0/0/25.3</data>
+      <data key="d3">HundredGigE0/0/0/25.3</data>
       <data key="d4">TrunkPort</data>
       <data key="d7">true</data>
     </node>
-    <node id="67">
-      <data key="d0">0cb9bb4a-bfb3-47f7-8ddc-b4f1801a9cd6</data>
+    <node id="867">
+      <data key="d0">42479fc2-22a8-4f26-86b8-277beab2e2dd</data>
       <data key="d1">Link</data>
-      <data key="d2">port+renc-data-sw:TwentyFiveGigE0/0/0/23/3-DAC</data>
+      <data key="d2">port+renc-data-sw:HundredGigE0/0/0/25.3-DAC</data>
       <data key="d3">l10</data>
       <data key="d4">Patch</data>
       <data key="d7">false</data>
       <data key="d14">L2</data>
     </node>
-    <node id="68">
-      <data key="d0">0cb9bb4a-bfb3-47f7-8ddc-b4f1801a9cd6</data>
+    <node id="868">
+      <data key="d0">42479fc2-22a8-4f26-86b8-277beab2e2dd</data>
       <data key="d1">ConnectionPoint</data>
-      <data key="d2">port+renc-data-sw:TwentyFiveGigE0/0/0/23/2</data>
-      <data key="d3">TwentyFiveGigE0/0/0/23/2</data>
+      <data key="d2">port+renc-data-sw:HundredGigE0/0/0/25.4</data>
+      <data key="d3">HundredGigE0/0/0/25.4</data>
       <data key="d4">TrunkPort</data>
       <data key="d7">true</data>
     </node>
-    <node id="69">
-      <data key="d0">0cb9bb4a-bfb3-47f7-8ddc-b4f1801a9cd6</data>
+    <node id="869">
+      <data key="d0">42479fc2-22a8-4f26-86b8-277beab2e2dd</data>
       <data key="d1">Link</data>
-      <data key="d2">port+renc-data-sw:TwentyFiveGigE0/0/0/23/2-DAC</data>
+      <data key="d2">port+renc-data-sw:HundredGigE0/0/0/25.4-DAC</data>
       <data key="d3">l11</data>
       <data key="d4">Patch</data>
       <data key="d7">false</data>
       <data key="d14">L2</data>
     </node>
-    <edge source="1" target="2">
+    <edge source="801" target="804">
       <data key="d15">has</data>
     </edge>
-    <edge source="1" target="3">
+    <edge source="801" target="805">
       <data key="d15">has</data>
     </edge>
-    <edge source="1" target="4">
+    <edge source="801" target="814">
       <data key="d15">has</data>
     </edge>
-    <edge source="1" target="5">
+    <edge source="801" target="815">
       <data key="d15">has</data>
     </edge>
-    <edge source="1" target="6">
+    <edge source="801" target="820">
       <data key="d15">has</data>
     </edge>
-    <edge source="6" target="7">
+    <edge source="802" target="806">
       <data key="d15">has</data>
     </edge>
-    <edge source="7" target="8">
-      <data key="d15">connects</data>
-    </edge>
-    <edge source="8" target="49">
-      <data key="d15">connects</data>
-    </edge>
-    <edge source="9" target="10">
+    <edge source="802" target="807">
       <data key="d15">has</data>
     </edge>
-    <edge source="9" target="11">
+    <edge source="802" target="808">
       <data key="d15">has</data>
     </edge>
-    <edge source="9" target="12">
+    <edge source="802" target="809">
       <data key="d15">has</data>
     </edge>
-    <edge source="9" target="13">
+    <edge source="802" target="816">
       <data key="d15">has</data>
     </edge>
-    <edge source="9" target="14">
+    <edge source="802" target="817">
       <data key="d15">has</data>
     </edge>
-    <edge source="9" target="15">
+    <edge source="802" target="823">
       <data key="d15">has</data>
     </edge>
-    <edge source="9" target="16">
+    <edge source="802" target="829">
       <data key="d15">has</data>
     </edge>
-    <edge source="9" target="19">
+    <edge source="802" target="833">
       <data key="d15">has</data>
     </edge>
-    <edge source="9" target="23">
+    <edge source="803" target="810">
       <data key="d15">has</data>
     </edge>
-    <edge source="16" target="17">
+    <edge source="803" target="811">
       <data key="d15">has</data>
     </edge>
-    <edge source="17" target="18">
-      <data key="d15">connects</data>
-    </edge>
-    <edge source="18" target="51">
-      <data key="d15">connects</data>
-    </edge>
-    <edge source="19" target="20">
+    <edge source="803" target="812">
       <data key="d15">has</data>
     </edge>
-    <edge source="20" target="21">
-      <data key="d15">connects</data>
-    </edge>
-    <edge source="20" target="22">
-      <data key="d15">connects</data>
-    </edge>
-    <edge source="21" target="53">
-      <data key="d15">connects</data>
-    </edge>
-    <edge source="22" target="55">
-      <data key="d15">connects</data>
-    </edge>
-    <edge source="23" target="24">
+    <edge source="803" target="813">
       <data key="d15">has</data>
     </edge>
-    <edge source="24" target="25">
-      <data key="d15">connects</data>
-    </edge>
-    <edge source="24" target="26">
-      <data key="d15">connects</data>
-    </edge>
-    <edge source="25" target="57">
-      <data key="d15">connects</data>
-    </edge>
-    <edge source="26" target="59">
-      <data key="d15">connects</data>
-    </edge>
-    <edge source="27" target="28">
+    <edge source="803" target="818">
       <data key="d15">has</data>
     </edge>
-    <edge source="27" target="29">
+    <edge source="803" target="819">
       <data key="d15">has</data>
     </edge>
-    <edge source="27" target="30">
+    <edge source="803" target="826">
       <data key="d15">has</data>
     </edge>
-    <edge source="27" target="31">
+    <edge source="803" target="837">
       <data key="d15">has</data>
     </edge>
-    <edge source="27" target="32">
+    <edge source="803" target="841">
       <data key="d15">has</data>
     </edge>
-    <edge source="27" target="33">
+    <edge source="820" target="821">
       <data key="d15">has</data>
     </edge>
-    <edge source="27" target="34">
+    <edge source="821" target="822">
+      <data key="d15">connects</data>
+    </edge>
+    <edge source="822" target="849">
+      <data key="d15">connects</data>
+    </edge>
+    <edge source="823" target="824">
       <data key="d15">has</data>
     </edge>
-    <edge source="27" target="37">
+    <edge source="824" target="825">
+      <data key="d15">connects</data>
+    </edge>
+    <edge source="825" target="851">
+      <data key="d15">connects</data>
+    </edge>
+    <edge source="826" target="827">
       <data key="d15">has</data>
     </edge>
-    <edge source="27" target="41">
+    <edge source="827" target="828">
+      <data key="d15">connects</data>
+    </edge>
+    <edge source="828" target="861">
+      <data key="d15">connects</data>
+    </edge>
+    <edge source="829" target="830">
       <data key="d15">has</data>
     </edge>
-    <edge source="34" target="35">
+    <edge source="830" target="831">
+      <data key="d15">connects</data>
+    </edge>
+    <edge source="830" target="832">
+      <data key="d15">connects</data>
+    </edge>
+    <edge source="831" target="853">
+      <data key="d15">connects</data>
+    </edge>
+    <edge source="832" target="855">
+      <data key="d15">connects</data>
+    </edge>
+    <edge source="833" target="834">
       <data key="d15">has</data>
     </edge>
-    <edge source="35" target="36">
+    <edge source="834" target="835">
       <data key="d15">connects</data>
     </edge>
-    <edge source="36" target="61">
+    <edge source="834" target="836">
       <data key="d15">connects</data>
     </edge>
-    <edge source="37" target="38">
+    <edge source="835" target="857">
+      <data key="d15">connects</data>
+    </edge>
+    <edge source="836" target="859">
+      <data key="d15">connects</data>
+    </edge>
+    <edge source="837" target="838">
       <data key="d15">has</data>
     </edge>
-    <edge source="38" target="39">
+    <edge source="838" target="839">
       <data key="d15">connects</data>
     </edge>
-    <edge source="38" target="40">
+    <edge source="838" target="840">
       <data key="d15">connects</data>
     </edge>
-    <edge source="39" target="65">
+    <edge source="839" target="863">
       <data key="d15">connects</data>
     </edge>
-    <edge source="40" target="63">
+    <edge source="840" target="865">
       <data key="d15">connects</data>
     </edge>
-    <edge source="41" target="42">
+    <edge source="841" target="842">
       <data key="d15">has</data>
     </edge>
-    <edge source="42" target="43">
+    <edge source="842" target="843">
       <data key="d15">connects</data>
     </edge>
-    <edge source="42" target="44">
+    <edge source="842" target="844">
       <data key="d15">connects</data>
     </edge>
-    <edge source="43" target="67">
+    <edge source="843" target="867">
       <data key="d15">connects</data>
     </edge>
-    <edge source="44" target="69">
+    <edge source="844" target="869">
       <data key="d15">connects</data>
     </edge>
-    <edge source="46" target="47">
+    <edge source="846" target="847">
       <data key="d15">has</data>
     </edge>
-    <edge source="47" target="48">
+    <edge source="847" target="848">
       <data key="d15">connects</data>
     </edge>
-    <edge source="47" target="50">
+    <edge source="847" target="850">
       <data key="d15">connects</data>
     </edge>
-    <edge source="47" target="52">
+    <edge source="847" target="852">
       <data key="d15">connects</data>
     </edge>
-    <edge source="47" target="54">
+    <edge source="847" target="854">
       <data key="d15">connects</data>
     </edge>
-    <edge source="47" target="56">
+    <edge source="847" target="856">
       <data key="d15">connects</data>
     </edge>
-    <edge source="47" target="58">
+    <edge source="847" target="858">
       <data key="d15">connects</data>
     </edge>
-    <edge source="47" target="60">
+    <edge source="847" target="860">
       <data key="d15">connects</data>
     </edge>
-    <edge source="47" target="62">
+    <edge source="847" target="862">
       <data key="d15">connects</data>
     </edge>
-    <edge source="47" target="64">
+    <edge source="847" target="864">
       <data key="d15">connects</data>
     </edge>
-    <edge source="47" target="66">
+    <edge source="847" target="866">
       <data key="d15">connects</data>
     </edge>
-    <edge source="47" target="68">
+    <edge source="847" target="868">
       <data key="d15">connects</data>
     </edge>
-    <edge source="48" target="49">
+    <edge source="848" target="849">
       <data key="d15">connects</data>
     </edge>
-    <edge source="50" target="51">
+    <edge source="850" target="851">
       <data key="d15">connects</data>
     </edge>
-    <edge source="52" target="53">
+    <edge source="852" target="853">
       <data key="d15">connects</data>
     </edge>
-    <edge source="54" target="55">
+    <edge source="854" target="855">
       <data key="d15">connects</data>
     </edge>
-    <edge source="56" target="57">
+    <edge source="856" target="857">
       <data key="d15">connects</data>
     </edge>
-    <edge source="58" target="59">
+    <edge source="858" target="859">
       <data key="d15">connects</data>
     </edge>
-    <edge source="60" target="61">
+    <edge source="860" target="861">
       <data key="d15">connects</data>
     </edge>
-    <edge source="62" target="63">
+    <edge source="862" target="863">
       <data key="d15">connects</data>
     </edge>
-    <edge source="64" target="65">
+    <edge source="864" target="865">
       <data key="d15">connects</data>
     </edge>
-    <edge source="66" target="67">
+    <edge source="866" target="867">
       <data key="d15">connects</data>
     </edge>
-    <edge source="68" target="69">
+    <edge source="868" target="869">
       <data key="d15">connects</data>
     </edge>
   </graph>

--- a/neo4j/UKY-ad.graphml
+++ b/neo4j/UKY-ad.graphml
@@ -16,184 +16,218 @@
   <key id="d1" for="node" attr.name="Class" attr.type="string" />
   <key id="d0" for="node" attr.name="GraphID" attr.type="string" />
   <graph edgedefault="undirected">
-    <node id="1">
-      <data key="d0">2b44168c-2bc0-4fcc-bb95-1ae2a471e539</data>
+    <node id="870">
+      <data key="d0">98fe2449-ab4a-47bd-ac5c-9a11cf72c8a1</data>
       <data key="d1">NetworkNode</data>
       <data key="d2">3JB2R53</data>
-      <data key="d3">uky-w1.fabric-testbed.net</data>
+      <data key="d3">uky-w1</data>
       <data key="d4">Server</data>
       <data key="d5">R7525</data>
-      <data key="d6">{"core": 64, "cpu": 2, "disk": 51000, "ram": 512, "unit": 1}</data>
+      <data key="d6">{"core": 32, "cpu": 2, "disk": 100000, "ram": 512, "unit": 1}</data>
       <data key="d7">false</data>
       <data key="d8">UKY</data>
-      <data key="d9">{"postal": "301 Hilltop Ave,Lexington, KY 40506"}</data>
-      <data key="d10">{"primary": {"pool_id": "_", "capacities": {"cpu": 2, "core": 64, "ram": 512, "disk": 51000, "unit": 1}}}</data>
+      <data key="d9">{"postal": "301 Hilltop Ave Lexington, KY 40506"}</data>
+      <data key="d10">{"primary": {"pool_id": "_", "capacities": {"cpu": 2, "core": 32, "ram": 512, "disk": 100000, "unit": 1}}}</data>
     </node>
-    <node id="2">
-      <data key="d0">2b44168c-2bc0-4fcc-bb95-1ae2a471e539</data>
-      <data key="d1">Component</data>
-      <data key="d2">PHLJ0160046A1P0FGN</data>
-      <data key="d3">uky-w1.fabric-testbed.net-nvme-1</data>
-      <data key="d4">NVME</data>
-      <data key="d5">P4510</data>
-      <data key="d6">{"disk": 1000, "unit": 1}</data>
-      <data key="d11">{"bdf": "0000:21:00.0"}</data>
-      <data key="d12">Dell Express Flash NVMe P4510 1TB SFF in PCIe SSD Slot 22 in Bay 2 (0000:21:00.0)</data>
-      <data key="d7">false</data>
-      <data key="d10">{"primary": {"pool_id": "_", "capacities": {"disk": 1000, "unit": 1}}}</data>
-      <data key="d13">{"primary": {"pool_id": "_", "labels": {"bdf": "0000:21:00.0"}}}</data>
-    </node>
-    <node id="3">
-      <data key="d0">2b44168c-2bc0-4fcc-bb95-1ae2a471e539</data>
-      <data key="d1">Component</data>
-      <data key="d2">PHLJ016003SU1P0FGN</data>
-      <data key="d3">uky-w1.fabric-testbed.net-nvme-2</data>
-      <data key="d4">NVME</data>
-      <data key="d5">P4510</data>
-      <data key="d6">{"disk": 1000, "unit": 1}</data>
-      <data key="d11">{"bdf": "0000:22:00.0"}</data>
-      <data key="d12">Dell Express Flash NVMe P4510 1TB SFF in PCIe SSD Slot 23 in Bay 2 (0000:22:00.0)</data>
-      <data key="d7">false</data>
-      <data key="d10">{"primary": {"pool_id": "_", "capacities": {"disk": 1000, "unit": 1}}}</data>
-      <data key="d13">{"primary": {"pool_id": "_", "labels": {"bdf": "0000:22:00.0"}}}</data>
-    </node>
-    <node id="4">
-      <data key="d0">2b44168c-2bc0-4fcc-bb95-1ae2a471e539</data>
-      <data key="d1">Component</data>
-      <data key="d2">3JB2R53-gpu-1</data>
-      <data key="d3">uky-w1.fabric-testbed.net-gpu-1</data>
-      <data key="d4">GPU</data>
-      <data key="d5">RTX6000</data>
-      <data key="d6">{"unit": 1}</data>
-      <data key="d11">{"bdf": "0000:25:00.0"}</data>
-      <data key="d12">NVIDIA Corporation TU102GL [Quadro RTX 6000/8000] (rev a1)</data>
-      <data key="d7">false</data>
-      <data key="d10">{"primary": {"pool_id": "_", "capacities": {"unit": 1}}}</data>
-      <data key="d13">{"primary": {"pool_id": "_", "labels": {"bdf": "0000:25:00.0"}}}</data>
-    </node>
-    <node id="5">
-      <data key="d0">2b44168c-2bc0-4fcc-bb95-1ae2a471e539</data>
-      <data key="d1">Component</data>
-      <data key="d2">3JB2R53-gpu-2</data>
-      <data key="d3">uky-w1.fabric-testbed.net-gpu-2</data>
-      <data key="d4">GPU</data>
-      <data key="d5">RTX6000</data>
-      <data key="d6">{"unit": 1}</data>
-      <data key="d11">{"bdf": "0000:81:00.0"}</data>
-      <data key="d12">NVIDIA Corporation TU102GL [Quadro RTX 6000/8000] (rev a1)</data>
-      <data key="d7">false</data>
-      <data key="d10">{"primary": {"pool_id": "_", "capacities": {"unit": 1}}}</data>
-      <data key="d13">{"primary": {"pool_id": "_", "labels": {"bdf": "0000:81:00.0"}}}</data>
-    </node>
-    <node id="6">
-      <data key="d0">2b44168c-2bc0-4fcc-bb95-1ae2a471e539</data>
-      <data key="d1">Component</data>
-      <data key="d2">3JB2R53-slot6</data>
-      <data key="d3">uky-w1.fabric-testbed.net-slot6</data>
-      <data key="d4">SharedNIC</data>
-      <data key="d5">ConnectX-6</data>
-      <data key="d6">{"unit": 127}</data>
-      <data key="d11">{"bdf": ["0000:a1:16.4", "0000:a1:15.2", "0000:a1:1b.5", "0000:a1:10.1", "0000:a1:18.2", "0000:a1:14.2", "0000:a1:16.7", "0000:a1:1e.7", "0000:a1:1a.6", "0000:a1:12.4", "0000:a1:12.5", "0000:a1:14.0", "0000:a1:1e.2", "0000:a1:1e.5", "0000:a1:1a.0", "0000:a1:1b.7", "0000:a1:17.4", "0000:a1:1b.0", "0000:a1:1c.4", "0000:a1:13.5", "0000:a1:13.7", "0000:a1:13.1", "0000:a1:1b.3", "0000:a1:12.6", "0000:a1:1b.4", "0000:a1:12.2", "0000:a1:1d.1", "0000:a1:1e.4", "0000:a1:14.3", "0000:a1:16.6", "0000:a1:16.1", "0000:a1:15.6", "0000:a1:15.1", "0000:a1:1d.7", "0000:a1:1a.7", "0000:a1:19.4", "0000:a1:11.6", "0000:a1:1d.5", "0000:a1:18.0", "0000:a1:19.5", "0000:a1:14.1", "0000:a1:11.1", "0000:a1:11.5", "0000:a1:11.4", "0000:a1:13.0", "0000:a1:1f.0", "0000:a1:15.4", "0000:a1:1c.7", "0000:a1:16.3", "0000:a1:1d.4", "0000:a1:1f.6", "0000:a1:16.0", "0000:a1:1c.6", "0000:a1:14.6", "0000:a1:1f.7", "0000:a1:1f.1", "0000:a1:15.3", "0000:a1:13.2", "0000:a1:1e.3", "0000:a1:14.5", "0000:a1:1a.2", "0000:a1:10.4", "0000:a1:1d.2", "0000:a1:15.0", "0000:a1:1d.3", "0000:a1:17.2", "0000:a1:17.0", "0000:a1:10.6", "0000:a1:17.5", "0000:a1:18.4", "0000:a1:12.1", "0000:a1:11.7", "0000:a1:19.7", "0000:a1:10.7", "0000:a1:12.3", "0000:a1:1b.2", "0000:a1:15.5", "0000:a1:18.7", "0000:a1:1a.5", "0000:a1:1f.3", "0000:a1:18.3", "0000:a1:17.1", "0000:a1:14.4", "0000:a1:13.4", "0000:a1:1d.6", "0000:a1:11.0", "0000:a1:10.3", "0000:a1:1d.0", "0000:a1:1a.3", "0000:a1:1a.4", "0000:a1:1b.1", "0000:a1:1c.2", "0000:a1:19.2", "0000:a1:1c.5", "0000:a1:19.0", "0000:a1:11.2", "0000:a1:16.5", "0000:a1:10.2", "0000:a1:17.6", "0000:a1:12.0", "0000:a1:1c.1", "0000:a1:17.3", "0000:a1:1f.4", "0000:a1:13.3", "0000:a1:10.5", "0000:a1:14.7", "0000:a1:18.1", "0000:a1:17.7", "0000:a1:1f.2", "0000:a1:1c.0", "0000:a1:1e.6", "0000:a1:19.6", "0000:a1:1c.3", "0000:a1:19.1", "0000:a1:1a.1", "0000:a1:1e.1", "0000:a1:11.3", "0000:a1:19.3", "0000:a1:18.5", "0000:a1:1e.0", "0000:a1:12.7", "0000:a1:16.2", "0000:a1:1f.5", "0000:a1:18.6", "0000:a1:13.6", "0000:a1:1b.6", "0000:a1:15.7"]}</data>
-      <data key="d12">Mellanox Technologies MT28908 Family [ConnectX-6] in PCIe Slot 6 (0000:a1:00.1)</data>
-      <data key="d7">false</data>
-      <data key="d10">{"primary": {"pool_id": "_", "capacities": {"unit": 127}}}</data>
-      <data key="d13">{"primary": {"pool_id": "_", "labels": {"bdf": ["0000:a1:16.4", "0000:a1:15.2", "0000:a1:1b.5", "0000:a1:10.1", "0000:a1:18.2", "0000:a1:14.2", "0000:a1:16.7", "0000:a1:1e.7", "0000:a1:1a.6", "0000:a1:12.4", "0000:a1:12.5", "0000:a1:14.0", "0000:a1:1e.2", "0000:a1:1e.5", "0000:a1:1a.0", "0000:a1:1b.7", "0000:a1:17.4", "0000:a1:1b.0", "0000:a1:1c.4", "0000:a1:13.5", "0000:a1:13.7", "0000:a1:13.1", "0000:a1:1b.3", "0000:a1:12.6", "0000:a1:1b.4", "0000:a1:12.2", "0000:a1:1d.1", "0000:a1:1e.4", "0000:a1:14.3", "0000:a1:16.6", "0000:a1:16.1", "0000:a1:15.6", "0000:a1:15.1", "0000:a1:1d.7", "0000:a1:1a.7", "0000:a1:19.4", "0000:a1:11.6", "0000:a1:1d.5", "0000:a1:18.0", "0000:a1:19.5", "0000:a1:14.1", "0000:a1:11.1", "0000:a1:11.5", "0000:a1:11.4", "0000:a1:13.0", "0000:a1:1f.0", "0000:a1:15.4", "0000:a1:1c.7", "0000:a1:16.3", "0000:a1:1d.4", "0000:a1:1f.6", "0000:a1:16.0", "0000:a1:1c.6", "0000:a1:14.6", "0000:a1:1f.7", "0000:a1:1f.1", "0000:a1:15.3", "0000:a1:13.2", "0000:a1:1e.3", "0000:a1:14.5", "0000:a1:1a.2", "0000:a1:10.4", "0000:a1:1d.2", "0000:a1:15.0", "0000:a1:1d.3", "0000:a1:17.2", "0000:a1:17.0", "0000:a1:10.6", "0000:a1:17.5", "0000:a1:18.4", "0000:a1:12.1", "0000:a1:11.7", "0000:a1:19.7", "0000:a1:10.7", "0000:a1:12.3", "0000:a1:1b.2", "0000:a1:15.5", "0000:a1:18.7", "0000:a1:1a.5", "0000:a1:1f.3", "0000:a1:18.3", "0000:a1:17.1", "0000:a1:14.4", "0000:a1:13.4", "0000:a1:1d.6", "0000:a1:11.0", "0000:a1:10.3", "0000:a1:1d.0", "0000:a1:1a.3", "0000:a1:1a.4", "0000:a1:1b.1", "0000:a1:1c.2", "0000:a1:19.2", "0000:a1:1c.5", "0000:a1:19.0", "0000:a1:11.2", "0000:a1:16.5", "0000:a1:10.2", "0000:a1:17.6", "0000:a1:12.0", "0000:a1:1c.1", "0000:a1:17.3", "0000:a1:1f.4", "0000:a1:13.3", "0000:a1:10.5", "0000:a1:14.7", "0000:a1:18.1", "0000:a1:17.7", "0000:a1:1f.2", "0000:a1:1c.0", "0000:a1:1e.6", "0000:a1:19.6", "0000:a1:1c.3", "0000:a1:19.1", "0000:a1:1a.1", "0000:a1:1e.1", "0000:a1:11.3", "0000:a1:19.3", "0000:a1:18.5", "0000:a1:1e.0", "0000:a1:12.7", "0000:a1:16.2", "0000:a1:1f.5", "0000:a1:18.6", "0000:a1:13.6", "0000:a1:1b.6", "0000:a1:15.7"]}}}</data>
-    </node>
-    <node id="7">
-      <data key="d0">2b44168c-2bc0-4fcc-bb95-1ae2a471e539</data>
-      <data key="d1">NetworkService</data>
-      <data key="d2">3JB2R53-slot6-ns</data>
-      <data key="d3">uky-w1.fabric-testbed.net-uky-w1.fabric-testbed.net-slot6-l2ovs</data>
-      <data key="d4">OVS</data>
-      <data key="d7">false</data>
-      <data key="d14">L2</data>
-    </node>
-    <node id="8">
-      <data key="d0">2b44168c-2bc0-4fcc-bb95-1ae2a471e539</data>
-      <data key="d1">ConnectionPoint</data>
-      <data key="d2">node_id-0C-42-A1-EA-C7-61</data>
-      <data key="d3">uky-w1.fabric-testbed.net-slot6-p1</data>
-      <data key="d4">SharedPort</data>
-      <data key="d6">{"unit": 127}</data>
-      <data key="d11">{"bdf": ["0000:a1:16.4", "0000:a1:15.2", "0000:a1:1b.5", "0000:a1:10.1", "0000:a1:18.2", "0000:a1:14.2", "0000:a1:16.7", "0000:a1:1e.7", "0000:a1:1a.6", "0000:a1:12.4", "0000:a1:12.5", "0000:a1:14.0", "0000:a1:1e.2", "0000:a1:1e.5", "0000:a1:1a.0", "0000:a1:1b.7", "0000:a1:17.4", "0000:a1:1b.0", "0000:a1:1c.4", "0000:a1:13.5", "0000:a1:13.7", "0000:a1:13.1", "0000:a1:1b.3", "0000:a1:12.6", "0000:a1:1b.4", "0000:a1:12.2", "0000:a1:1d.1", "0000:a1:1e.4", "0000:a1:14.3", "0000:a1:16.6", "0000:a1:16.1", "0000:a1:15.6", "0000:a1:15.1", "0000:a1:1d.7", "0000:a1:1a.7", "0000:a1:19.4", "0000:a1:11.6", "0000:a1:1d.5", "0000:a1:18.0", "0000:a1:19.5", "0000:a1:14.1", "0000:a1:11.1", "0000:a1:11.5", "0000:a1:11.4", "0000:a1:13.0", "0000:a1:1f.0", "0000:a1:15.4", "0000:a1:1c.7", "0000:a1:16.3", "0000:a1:1d.4", "0000:a1:1f.6", "0000:a1:16.0", "0000:a1:1c.6", "0000:a1:14.6", "0000:a1:1f.7", "0000:a1:1f.1", "0000:a1:15.3", "0000:a1:13.2", "0000:a1:1e.3", "0000:a1:14.5", "0000:a1:1a.2", "0000:a1:10.4", "0000:a1:1d.2", "0000:a1:15.0", "0000:a1:1d.3", "0000:a1:17.2", "0000:a1:17.0", "0000:a1:10.6", "0000:a1:17.5", "0000:a1:18.4", "0000:a1:12.1", "0000:a1:11.7", "0000:a1:19.7", "0000:a1:10.7", "0000:a1:12.3", "0000:a1:1b.2", "0000:a1:15.5", "0000:a1:18.7", "0000:a1:1a.5", "0000:a1:1f.3", "0000:a1:18.3", "0000:a1:17.1", "0000:a1:14.4", "0000:a1:13.4", "0000:a1:1d.6", "0000:a1:11.0", "0000:a1:10.3", "0000:a1:1d.0", "0000:a1:1a.3", "0000:a1:1a.4", "0000:a1:1b.1", "0000:a1:1c.2", "0000:a1:19.2", "0000:a1:1c.5", "0000:a1:19.0", "0000:a1:11.2", "0000:a1:16.5", "0000:a1:10.2", "0000:a1:17.6", "0000:a1:12.0", "0000:a1:1c.1", "0000:a1:17.3", "0000:a1:1f.4", "0000:a1:13.3", "0000:a1:10.5", "0000:a1:14.7", "0000:a1:18.1", "0000:a1:17.7", "0000:a1:1f.2", "0000:a1:1c.0", "0000:a1:1e.6", "0000:a1:19.6", "0000:a1:1c.3", "0000:a1:19.1", "0000:a1:1a.1", "0000:a1:1e.1", "0000:a1:11.3", "0000:a1:19.3", "0000:a1:18.5", "0000:a1:1e.0", "0000:a1:12.7", "0000:a1:16.2", "0000:a1:1f.5", "0000:a1:18.6", "0000:a1:13.6", "0000:a1:1b.6", "0000:a1:15.7"], "local_name": ["p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1"], "mac": ["02:A8:53:AD:CA:D8", "06:12:FC:F2:54:75", "06:40:8C:D6:22:47", "06:64:A9:8D:B7:24", "06:8D:F5:E6:F2:C8", "06:A5:50:3D:63:11", "06:D4:20:05:7D:59", "0A:06:D8:7C:7D:F0", "0A:8D:86:0C:38:71", "0A:8E:8F:8F:DE:3A", "0A:DF:1D:50:29:85", "0A:E8:FB:5C:D1:0E", "0E:5E:84:0D:29:AA", "0E:D0:BF:CA:70:C6", "12:09:C2:10:09:44", "12:63:72:FB:43:ED", "12:A8:79:F7:5E:BB", "12:C4:27:98:C2:64", "16:32:37:FE:30:A5", "16:63:76:8C:B5:41", "16:E2:74:ED:E9:62", "16:E5:74:FA:21:6D", "1E:B8:50:98:70:32", "22:F0:F6:DF:B9:02", "26:FA:29:32:26:BC", "2A:84:A9:EE:F8:19", "2A:B0:22:1C:6A:C4", "2E:03:01:65:EC:1A", "2E:0C:FF:0E:4D:7D", "2E:3F:C6:AE:B5:85", "36:EB:BB:7A:8E:19", "36:FB:90:8F:E4:56", "3A:04:A1:BB:7E:48", "3A:D7:3A:14:A0:F4", "42:06:E0:A4:F8:61", "42:51:B9:4B:79:69", "42:F6:EA:72:A5:DA", "46:0B:8C:47:73:F8", "46:35:29:FA:A6:3A", "4A:07:91:08:DA:DC", "4A:20:A6:EB:57:71", "4A:62:78:4F:CF:8F", "4A:E4:7B:53:B7:DE", "4E:97:D6:79:26:E9", "52:0D:86:17:94:69", "52:55:C3:10:82:60", "56:17:52:5E:43:BF", "56:93:43:D9:7E:9B", "56:B2:46:C5:80:BE", "5A:2E:5D:2C:8F:99", "5E:04:28:3D:65:02", "5E:96:96:0D:02:C6", "5E:CD:9C:F9:1E:3D", "62:BE:09:1F:59:7C", "66:B2:E3:5F:01:77", "6E:F3:9E:1D:2B:01", "72:4B:FF:26:FA:64", "72:AB:5A:00:74:D8", "72:CE:1F:1E:3A:B9", "72:E8:D8:45:D5:FA", "72:ED:AD:71:5C:C2", "76:7A:52:24:09:CD", "7A:7C:FE:4E:CF:93", "7A:A5:9D:1F:5F:86", "7A:E3:49:05:30:A9", "7E:3E:DE:13:64:24", "7E:B4:8B:EA:CE:A2", "82:1B:6C:9E:66:98", "82:B1:A8:5A:71:D9", "8A:01:EB:B4:D9:1F", "8A:EC:B7:A1:4E:CA", "92:CA:9E:50:95:37", "96:0B:54:8E:DB:84", "96:3C:98:B7:5B:45", "96:FD:50:7C:F2:C9", "9A:58:8F:8F:C5:25", "9A:87:BD:04:E2:4A", "9A:A7:33:6D:FE:65", "9E:73:06:C8:D2:1C", "A2:7F:CD:1F:0E:E7", "A2:AC:50:56:8A:CD", "A6:2F:BC:5B:66:CB", "A6:A8:B7:22:EA:83", "AA:61:3C:E6:66:2A", "AA:8F:8B:33:0F:54", "AA:9C:CD:9C:D4:08", "AA:BA:2C:9C:01:48", "AE:82:AE:82:0A:F9", "B2:84:BB:97:10:9A", "B2:91:01:A7:84:00", "B2:D3:AA:A7:65:4E", "B6:13:E9:85:FC:F5", "B6:23:E9:DD:94:50", "B6:2E:57:F8:52:4A", "BA:0F:31:02:71:7F", "BE:2A:76:D6:28:90", "BE:40:43:8B:C8:58", "C2:28:D7:68:A6:4D", "C2:61:EC:46:CA:30", "C2:F4:39:C4:44:27", "C6:D8:9C:76:BD:80", "D2:0B:87:6B:3F:56", "D2:0B:E9:41:26:57", "D2:E6:EB:B0:03:CD", "D6:50:99:08:1F:5A", "D6:81:7B:81:76:43", "D6:86:24:04:6A:01", "D6:8E:78:C5:F9:E0", "DE:59:4F:9D:AB:E0", "DE:8D:29:2F:59:A5", "E2:49:2C:E4:83:B0", "E2:75:6E:53:BA:FD", "E2:AD:03:79:E5:C7", "E2:AD:DC:87:74:B5", "E2:E2:39:2B:A8:BA", "E6:26:46:4E:02:55", "E6:2F:E5:C5:87:DC", "EA:40:31:FA:44:75", "EA:FC:BC:83:F6:58", "EE:E2:02:BC:FF:70", "F6:91:74:97:65:A3", "FE:08:A8:EB:65:D6", "FE:1A:52:F7:B1:58", "FE:3F:02:AF:36:F8", "FE:6A:2D:04:10:48", "FE:88:BF:2D:2F:38", "FE:A3:6A:CB:14:79"], "vlan": ["2051", "2041", "2092", "2000", "2065", "2033", "2054", "2118", "2085", "2019", "2020", "2031", "2113", "2116", "2079", "2094", "2059", "2087", "2099", "2028", "2030", "2024", "2090", "2021", "2091", "2017", "2104", "2115", "2034", "2053", "2048", "2045", "2040", "2110", "2086", "2075", "2013", "2108", "2063", "2076", "2032", "2008", "2012", "2011", "2023", "2119", "2043", "2102", "2050", "2107", "2125", "2047", "2101", "2037", "2126", "2120", "2042", "2025", "2114", "2036", "2081", "2003", "2105", "2039", "2106", "2057", "2055", "2005", "2060", "2067", "2016", "2014", "2078", "2006", "2018", "2089", "2044", "2070", "2084", "2122", "2066", "2056", "2035", "2027", "2109", "2007", "2002", "2103", "2082", "2083", "2088", "2097", "2073", "2100", "2071", "2009", "2052", "2001", "2061", "2015", "2096", "2058", "2123", "2026", "2004", "2038", "2064", "2062", "2121", "2095", "2117", "2077", "2098", "2072", "2080", "2112", "2010", "2074", "2068", "2111", "2022", "2049", "2124", "2069", "2029", "2093", "2046"]}</data>
-      <data key="d7">false</data>
-      <data key="d10">{"primary": {"pool_id": "_", "capacities": {"unit": 127}}}</data>
-      <data key="d13">{"primary": {"pool_id": "_", "labels": {"bdf": ["0000:a1:16.4", "0000:a1:15.2", "0000:a1:1b.5", "0000:a1:10.1", "0000:a1:18.2", "0000:a1:14.2", "0000:a1:16.7", "0000:a1:1e.7", "0000:a1:1a.6", "0000:a1:12.4", "0000:a1:12.5", "0000:a1:14.0", "0000:a1:1e.2", "0000:a1:1e.5", "0000:a1:1a.0", "0000:a1:1b.7", "0000:a1:17.4", "0000:a1:1b.0", "0000:a1:1c.4", "0000:a1:13.5", "0000:a1:13.7", "0000:a1:13.1", "0000:a1:1b.3", "0000:a1:12.6", "0000:a1:1b.4", "0000:a1:12.2", "0000:a1:1d.1", "0000:a1:1e.4", "0000:a1:14.3", "0000:a1:16.6", "0000:a1:16.1", "0000:a1:15.6", "0000:a1:15.1", "0000:a1:1d.7", "0000:a1:1a.7", "0000:a1:19.4", "0000:a1:11.6", "0000:a1:1d.5", "0000:a1:18.0", "0000:a1:19.5", "0000:a1:14.1", "0000:a1:11.1", "0000:a1:11.5", "0000:a1:11.4", "0000:a1:13.0", "0000:a1:1f.0", "0000:a1:15.4", "0000:a1:1c.7", "0000:a1:16.3", "0000:a1:1d.4", "0000:a1:1f.6", "0000:a1:16.0", "0000:a1:1c.6", "0000:a1:14.6", "0000:a1:1f.7", "0000:a1:1f.1", "0000:a1:15.3", "0000:a1:13.2", "0000:a1:1e.3", "0000:a1:14.5", "0000:a1:1a.2", "0000:a1:10.4", "0000:a1:1d.2", "0000:a1:15.0", "0000:a1:1d.3", "0000:a1:17.2", "0000:a1:17.0", "0000:a1:10.6", "0000:a1:17.5", "0000:a1:18.4", "0000:a1:12.1", "0000:a1:11.7", "0000:a1:19.7", "0000:a1:10.7", "0000:a1:12.3", "0000:a1:1b.2", "0000:a1:15.5", "0000:a1:18.7", "0000:a1:1a.5", "0000:a1:1f.3", "0000:a1:18.3", "0000:a1:17.1", "0000:a1:14.4", "0000:a1:13.4", "0000:a1:1d.6", "0000:a1:11.0", "0000:a1:10.3", "0000:a1:1d.0", "0000:a1:1a.3", "0000:a1:1a.4", "0000:a1:1b.1", "0000:a1:1c.2", "0000:a1:19.2", "0000:a1:1c.5", "0000:a1:19.0", "0000:a1:11.2", "0000:a1:16.5", "0000:a1:10.2", "0000:a1:17.6", "0000:a1:12.0", "0000:a1:1c.1", "0000:a1:17.3", "0000:a1:1f.4", "0000:a1:13.3", "0000:a1:10.5", "0000:a1:14.7", "0000:a1:18.1", "0000:a1:17.7", "0000:a1:1f.2", "0000:a1:1c.0", "0000:a1:1e.6", "0000:a1:19.6", "0000:a1:1c.3", "0000:a1:19.1", "0000:a1:1a.1", "0000:a1:1e.1", "0000:a1:11.3", "0000:a1:19.3", "0000:a1:18.5", "0000:a1:1e.0", "0000:a1:12.7", "0000:a1:16.2", "0000:a1:1f.5", "0000:a1:18.6", "0000:a1:13.6", "0000:a1:1b.6", "0000:a1:15.7"], "mac": ["02:A8:53:AD:CA:D8", "06:12:FC:F2:54:75", "06:40:8C:D6:22:47", "06:64:A9:8D:B7:24", "06:8D:F5:E6:F2:C8", "06:A5:50:3D:63:11", "06:D4:20:05:7D:59", "0A:06:D8:7C:7D:F0", "0A:8D:86:0C:38:71", "0A:8E:8F:8F:DE:3A", "0A:DF:1D:50:29:85", "0A:E8:FB:5C:D1:0E", "0E:5E:84:0D:29:AA", "0E:D0:BF:CA:70:C6", "12:09:C2:10:09:44", "12:63:72:FB:43:ED", "12:A8:79:F7:5E:BB", "12:C4:27:98:C2:64", "16:32:37:FE:30:A5", "16:63:76:8C:B5:41", "16:E2:74:ED:E9:62", "16:E5:74:FA:21:6D", "1E:B8:50:98:70:32", "22:F0:F6:DF:B9:02", "26:FA:29:32:26:BC", "2A:84:A9:EE:F8:19", "2A:B0:22:1C:6A:C4", "2E:03:01:65:EC:1A", "2E:0C:FF:0E:4D:7D", "2E:3F:C6:AE:B5:85", "36:EB:BB:7A:8E:19", "36:FB:90:8F:E4:56", "3A:04:A1:BB:7E:48", "3A:D7:3A:14:A0:F4", "42:06:E0:A4:F8:61", "42:51:B9:4B:79:69", "42:F6:EA:72:A5:DA", "46:0B:8C:47:73:F8", "46:35:29:FA:A6:3A", "4A:07:91:08:DA:DC", "4A:20:A6:EB:57:71", "4A:62:78:4F:CF:8F", "4A:E4:7B:53:B7:DE", "4E:97:D6:79:26:E9", "52:0D:86:17:94:69", "52:55:C3:10:82:60", "56:17:52:5E:43:BF", "56:93:43:D9:7E:9B", "56:B2:46:C5:80:BE", "5A:2E:5D:2C:8F:99", "5E:04:28:3D:65:02", "5E:96:96:0D:02:C6", "5E:CD:9C:F9:1E:3D", "62:BE:09:1F:59:7C", "66:B2:E3:5F:01:77", "6E:F3:9E:1D:2B:01", "72:4B:FF:26:FA:64", "72:AB:5A:00:74:D8", "72:CE:1F:1E:3A:B9", "72:E8:D8:45:D5:FA", "72:ED:AD:71:5C:C2", "76:7A:52:24:09:CD", "7A:7C:FE:4E:CF:93", "7A:A5:9D:1F:5F:86", "7A:E3:49:05:30:A9", "7E:3E:DE:13:64:24", "7E:B4:8B:EA:CE:A2", "82:1B:6C:9E:66:98", "82:B1:A8:5A:71:D9", "8A:01:EB:B4:D9:1F", "8A:EC:B7:A1:4E:CA", "92:CA:9E:50:95:37", "96:0B:54:8E:DB:84", "96:3C:98:B7:5B:45", "96:FD:50:7C:F2:C9", "9A:58:8F:8F:C5:25", "9A:87:BD:04:E2:4A", "9A:A7:33:6D:FE:65", "9E:73:06:C8:D2:1C", "A2:7F:CD:1F:0E:E7", "A2:AC:50:56:8A:CD", "A6:2F:BC:5B:66:CB", "A6:A8:B7:22:EA:83", "AA:61:3C:E6:66:2A", "AA:8F:8B:33:0F:54", "AA:9C:CD:9C:D4:08", "AA:BA:2C:9C:01:48", "AE:82:AE:82:0A:F9", "B2:84:BB:97:10:9A", "B2:91:01:A7:84:00", "B2:D3:AA:A7:65:4E", "B6:13:E9:85:FC:F5", "B6:23:E9:DD:94:50", "B6:2E:57:F8:52:4A", "BA:0F:31:02:71:7F", "BE:2A:76:D6:28:90", "BE:40:43:8B:C8:58", "C2:28:D7:68:A6:4D", "C2:61:EC:46:CA:30", "C2:F4:39:C4:44:27", "C6:D8:9C:76:BD:80", "D2:0B:87:6B:3F:56", "D2:0B:E9:41:26:57", "D2:E6:EB:B0:03:CD", "D6:50:99:08:1F:5A", "D6:81:7B:81:76:43", "D6:86:24:04:6A:01", "D6:8E:78:C5:F9:E0", "DE:59:4F:9D:AB:E0", "DE:8D:29:2F:59:A5", "E2:49:2C:E4:83:B0", "E2:75:6E:53:BA:FD", "E2:AD:03:79:E5:C7", "E2:AD:DC:87:74:B5", "E2:E2:39:2B:A8:BA", "E6:26:46:4E:02:55", "E6:2F:E5:C5:87:DC", "EA:40:31:FA:44:75", "EA:FC:BC:83:F6:58", "EE:E2:02:BC:FF:70", "F6:91:74:97:65:A3", "FE:08:A8:EB:65:D6", "FE:1A:52:F7:B1:58", "FE:3F:02:AF:36:F8", "FE:6A:2D:04:10:48", "FE:88:BF:2D:2F:38", "FE:A3:6A:CB:14:79"], "vlan": ["2051", "2041", "2092", "2000", "2065", "2033", "2054", "2118", "2085", "2019", "2020", "2031", "2113", "2116", "2079", "2094", "2059", "2087", "2099", "2028", "2030", "2024", "2090", "2021", "2091", "2017", "2104", "2115", "2034", "2053", "2048", "2045", "2040", "2110", "2086", "2075", "2013", "2108", "2063", "2076", "2032", "2008", "2012", "2011", "2023", "2119", "2043", "2102", "2050", "2107", "2125", "2047", "2101", "2037", "2126", "2120", "2042", "2025", "2114", "2036", "2081", "2003", "2105", "2039", "2106", "2057", "2055", "2005", "2060", "2067", "2016", "2014", "2078", "2006", "2018", "2089", "2044", "2070", "2084", "2122", "2066", "2056", "2035", "2027", "2109", "2007", "2002", "2103", "2082", "2083", "2088", "2097", "2073", "2100", "2071", "2009", "2052", "2001", "2061", "2015", "2096", "2058", "2123", "2026", "2004", "2038", "2064", "2062", "2121", "2095", "2117", "2077", "2098", "2072", "2080", "2112", "2010", "2074", "2068", "2111", "2022", "2049", "2124", "2069", "2029", "2093", "2046"], "local_name": ["p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1"]}}}</data>
-    </node>
-    <node id="9">
-      <data key="d0">2b44168c-2bc0-4fcc-bb95-1ae2a471e539</data>
+    <node id="871">
+      <data key="d0">98fe2449-ab4a-47bd-ac5c-9a11cf72c8a1</data>
       <data key="d1">NetworkNode</data>
       <data key="d2">3JB0R53</data>
-      <data key="d3">uky-w2.fabric-testbed.net</data>
+      <data key="d3">uky-w2</data>
       <data key="d4">Server</data>
       <data key="d5">R7525</data>
-      <data key="d6">{"core": 64, "cpu": 2, "disk": 4800, "ram": 512, "unit": 1}</data>
+      <data key="d6">{"core": 32, "cpu": 2, "disk": 4800, "ram": 512, "unit": 1}</data>
       <data key="d7">false</data>
       <data key="d8">UKY</data>
-      <data key="d9">{"postal": "301 Hilltop Ave,Lexington, KY 40506"}</data>
-      <data key="d10">{"primary": {"pool_id": "_", "capacities": {"cpu": 2, "core": 64, "ram": 512, "disk": 4800, "unit": 1}}}</data>
+      <data key="d9">{"postal": "301 Hilltop Ave Lexington, KY 40506"}</data>
+      <data key="d10">{"primary": {"pool_id": "_", "capacities": {"cpu": 2, "core": 32, "ram": 512, "disk": 4800, "unit": 1}}}</data>
     </node>
-    <node id="10">
-      <data key="d0">2b44168c-2bc0-4fcc-bb95-1ae2a471e539</data>
+    <node id="872">
+      <data key="d0">98fe2449-ab4a-47bd-ac5c-9a11cf72c8a1</data>
+      <data key="d1">NetworkNode</data>
+      <data key="d2">3JB1R53</data>
+      <data key="d3">uky-w3</data>
+      <data key="d4">Server</data>
+      <data key="d5">R7525</data>
+      <data key="d6">{"core": 32, "cpu": 2, "disk": 4800, "ram": 512, "unit": 1}</data>
+      <data key="d7">false</data>
+      <data key="d8">UKY</data>
+      <data key="d9">{"postal": "301 Hilltop Ave Lexington, KY 40506"}</data>
+      <data key="d10">{"primary": {"pool_id": "_", "capacities": {"cpu": 2, "core": 32, "ram": 512, "disk": 4800, "unit": 1}}}</data>
+    </node>
+    <node id="873">
+      <data key="d0">98fe2449-ab4a-47bd-ac5c-9a11cf72c8a1</data>
       <data key="d1">Component</data>
-      <data key="d2">PHLJ0160047A1P0FGN</data>
-      <data key="d3">uky-w2.fabric-testbed.net-nvme-1</data>
+      <data key="d2">PHLJ0160046A1P0FGN</data>
+      <data key="d3">uky-w1-nvme1</data>
       <data key="d4">NVME</data>
       <data key="d5">P4510</data>
       <data key="d6">{"disk": 1000, "unit": 1}</data>
       <data key="d11">{"bdf": "0000:21:00.0"}</data>
-      <data key="d12">Dell Express Flash NVMe P4510 1TB SFF in PCIe SSD Slot 22 in Bay 2 (0000:21:00.0)</data>
+      <data key="d12">Dell Express Flash NVMe P4510 1TB SFF</data>
       <data key="d7">false</data>
       <data key="d10">{"primary": {"pool_id": "_", "capacities": {"disk": 1000, "unit": 1}}}</data>
       <data key="d13">{"primary": {"pool_id": "_", "labels": {"bdf": "0000:21:00.0"}}}</data>
     </node>
-    <node id="11">
-      <data key="d0">2b44168c-2bc0-4fcc-bb95-1ae2a471e539</data>
+    <node id="874">
+      <data key="d0">98fe2449-ab4a-47bd-ac5c-9a11cf72c8a1</data>
       <data key="d1">Component</data>
-      <data key="d2">PHLJ0160041X1P0FGN</data>
-      <data key="d3">uky-w2.fabric-testbed.net-nvme-2</data>
+      <data key="d2">PHLJ016003SU1P0FGN</data>
+      <data key="d3">uky-w1-nvme2</data>
       <data key="d4">NVME</data>
       <data key="d5">P4510</data>
       <data key="d6">{"disk": 1000, "unit": 1}</data>
       <data key="d11">{"bdf": "0000:22:00.0"}</data>
-      <data key="d12">Dell Express Flash NVMe P4510 1TB SFF in PCIe SSD Slot 23 in Bay 2 (0000:22:00.0)</data>
+      <data key="d12">Dell Express Flash NVMe P4510 1TB SFF</data>
       <data key="d7">false</data>
       <data key="d10">{"primary": {"pool_id": "_", "capacities": {"disk": 1000, "unit": 1}}}</data>
       <data key="d13">{"primary": {"pool_id": "_", "labels": {"bdf": "0000:22:00.0"}}}</data>
     </node>
-    <node id="12">
-      <data key="d0">2b44168c-2bc0-4fcc-bb95-1ae2a471e539</data>
+    <node id="875">
+      <data key="d0">98fe2449-ab4a-47bd-ac5c-9a11cf72c8a1</data>
+      <data key="d1">Component</data>
+      <data key="d2">PHLJ0160047A1P0FGN</data>
+      <data key="d3">uky-w2-nvme1</data>
+      <data key="d4">NVME</data>
+      <data key="d5">P4510</data>
+      <data key="d6">{"disk": 1000, "unit": 1}</data>
+      <data key="d11">{"bdf": "000:21:00.0"}</data>
+      <data key="d12">Dell Express Flash NVMe P4510 1TB SFF</data>
+      <data key="d7">false</data>
+      <data key="d10">{"primary": {"pool_id": "_", "capacities": {"disk": 1000, "unit": 1}}}</data>
+      <data key="d13">{"primary": {"pool_id": "_", "labels": {"bdf": "000:21:00.0"}}}</data>
+    </node>
+    <node id="876">
+      <data key="d0">98fe2449-ab4a-47bd-ac5c-9a11cf72c8a1</data>
+      <data key="d1">Component</data>
+      <data key="d2">PHLJ0160041X1P0FGN</data>
+      <data key="d3">uky-w2-nvme2</data>
+      <data key="d4">NVME</data>
+      <data key="d5">P4510</data>
+      <data key="d6">{"disk": 1000, "unit": 1}</data>
+      <data key="d11">{"bdf": "0000:22:00.0"}</data>
+      <data key="d12">Dell Express Flash NVMe P4510 1TB SFF</data>
+      <data key="d7">false</data>
+      <data key="d10">{"primary": {"pool_id": "_", "capacities": {"disk": 1000, "unit": 1}}}</data>
+      <data key="d13">{"primary": {"pool_id": "_", "labels": {"bdf": "0000:22:00.0"}}}</data>
+    </node>
+    <node id="877">
+      <data key="d0">98fe2449-ab4a-47bd-ac5c-9a11cf72c8a1</data>
       <data key="d1">Component</data>
       <data key="d2">PHLJ016100981P0FGN</data>
-      <data key="d3">uky-w2.fabric-testbed.net-nvme-3</data>
+      <data key="d3">uky-w2-nvme3</data>
       <data key="d4">NVME</data>
       <data key="d5">P4510</data>
       <data key="d6">{"disk": 1000, "unit": 1}</data>
       <data key="d11">{"bdf": "0000:23:00.0"}</data>
-      <data key="d12">Dell Express Flash NVMe P4510 1TB SFF in PCIe SSD Slot 20 in Bay 2 (0000:23:00.0)</data>
+      <data key="d12">Dell Express Flash NVMe P4510 1TB SFF</data>
       <data key="d7">false</data>
       <data key="d10">{"primary": {"pool_id": "_", "capacities": {"disk": 1000, "unit": 1}}}</data>
       <data key="d13">{"primary": {"pool_id": "_", "labels": {"bdf": "0000:23:00.0"}}}</data>
     </node>
-    <node id="13">
-      <data key="d0">2b44168c-2bc0-4fcc-bb95-1ae2a471e539</data>
+    <node id="878">
+      <data key="d0">98fe2449-ab4a-47bd-ac5c-9a11cf72c8a1</data>
       <data key="d1">Component</data>
       <data key="d2">PHLJ0161008L1P0FGN</data>
-      <data key="d3">uky-w2.fabric-testbed.net-nvme-4</data>
+      <data key="d3">uky-w2-nvme4</data>
       <data key="d4">NVME</data>
       <data key="d5">P4510</data>
       <data key="d6">{"disk": 1000, "unit": 1}</data>
       <data key="d11">{"bdf": "0000:24:00.0"}</data>
-      <data key="d12">Dell Express Flash NVMe P4510 1TB SFF in PCIe SSD Slot 21 in Bay 2 (0000:24:00.0)</data>
+      <data key="d12">Dell Express Flash NVMe P4510 1TB SFF</data>
       <data key="d7">false</data>
       <data key="d10">{"primary": {"pool_id": "_", "capacities": {"disk": 1000, "unit": 1}}}</data>
       <data key="d13">{"primary": {"pool_id": "_", "labels": {"bdf": "0000:24:00.0"}}}</data>
     </node>
-    <node id="14">
-      <data key="d0">2b44168c-2bc0-4fcc-bb95-1ae2a471e539</data>
+    <node id="879">
+      <data key="d0">98fe2449-ab4a-47bd-ac5c-9a11cf72c8a1</data>
       <data key="d1">Component</data>
-      <data key="d2">3JB0R53-gpu-1</data>
-      <data key="d3">uky-w2.fabric-testbed.net-gpu-1</data>
+      <data key="d2">PHLJ016100951P0FGN</data>
+      <data key="d3">uky-w3-nvme1</data>
+      <data key="d4">NVME</data>
+      <data key="d5">P4510</data>
+      <data key="d6">{"disk": 1000, "unit": 1}</data>
+      <data key="d11">{"bdf": "0000:21:00.0"}</data>
+      <data key="d12">Dell Express Flash NVMe P4510 1TB SFF</data>
+      <data key="d7">false</data>
+      <data key="d10">{"primary": {"pool_id": "_", "capacities": {"disk": 1000, "unit": 1}}}</data>
+      <data key="d13">{"primary": {"pool_id": "_", "labels": {"bdf": "0000:21:00.0"}}}</data>
+    </node>
+    <node id="880">
+      <data key="d0">98fe2449-ab4a-47bd-ac5c-9a11cf72c8a1</data>
+      <data key="d1">Component</data>
+      <data key="d2">PHLJ0160046F1P0FGN</data>
+      <data key="d3">uky-w3-nvme2</data>
+      <data key="d4">NVME</data>
+      <data key="d5">P4510</data>
+      <data key="d6">{"disk": 1000, "unit": 1}</data>
+      <data key="d11">{"bdf": "0000:22:00.0"}</data>
+      <data key="d12">Dell Express Flash NVMe P4510 1TB SFF</data>
+      <data key="d7">false</data>
+      <data key="d10">{"primary": {"pool_id": "_", "capacities": {"disk": 1000, "unit": 1}}}</data>
+      <data key="d13">{"primary": {"pool_id": "_", "labels": {"bdf": "0000:22:00.0"}}}</data>
+    </node>
+    <node id="881">
+      <data key="d0">98fe2449-ab4a-47bd-ac5c-9a11cf72c8a1</data>
+      <data key="d1">Component</data>
+      <data key="d2">PHLJ0161000L1P0FGN</data>
+      <data key="d3">uky-w3-nvme3</data>
+      <data key="d4">NVME</data>
+      <data key="d5">P4510</data>
+      <data key="d6">{"disk": 1000, "unit": 1}</data>
+      <data key="d11">{"bdf": "0000:23:00.0"}</data>
+      <data key="d12">Dell Express Flash NVMe P4510 1TB SFF</data>
+      <data key="d7">false</data>
+      <data key="d10">{"primary": {"pool_id": "_", "capacities": {"disk": 1000, "unit": 1}}}</data>
+      <data key="d13">{"primary": {"pool_id": "_", "labels": {"bdf": "0000:23:00.0"}}}</data>
+    </node>
+    <node id="882">
+      <data key="d0">98fe2449-ab4a-47bd-ac5c-9a11cf72c8a1</data>
+      <data key="d1">Component</data>
+      <data key="d2">PHLJ015301VG1P0FGN</data>
+      <data key="d3">uky-w3-nvme4</data>
+      <data key="d4">NVME</data>
+      <data key="d5">P4510</data>
+      <data key="d6">{"disk": 1000, "unit": 1}</data>
+      <data key="d11">{"bdf": "0000:24:00.0"}</data>
+      <data key="d12">Dell Express Flash NVMe P4510 1TB SFF</data>
+      <data key="d7">false</data>
+      <data key="d10">{"primary": {"pool_id": "_", "capacities": {"disk": 1000, "unit": 1}}}</data>
+      <data key="d13">{"primary": {"pool_id": "_", "labels": {"bdf": "0000:24:00.0"}}}</data>
+    </node>
+    <node id="883">
+      <data key="d0">98fe2449-ab4a-47bd-ac5c-9a11cf72c8a1</data>
+      <data key="d1">Component</data>
+      <data key="d2">3JB2R53-gpu1</data>
+      <data key="d3">uky-w1-gpu1</data>
+      <data key="d4">GPU</data>
+      <data key="d5">RTX6000</data>
+      <data key="d6">{"unit": 1}</data>
+      <data key="d11">{"bdf": "0000:25:00.0"}</data>
+      <data key="d12">NVIDIA Corporation TU102GL [Quadro RTX 6000/8000] (rev a1)</data>
+      <data key="d7">false</data>
+      <data key="d10">{"primary": {"pool_id": "_", "capacities": {"unit": 1}}}</data>
+      <data key="d13">{"primary": {"pool_id": "_", "labels": {"bdf": "0000:25:00.0"}}}</data>
+    </node>
+    <node id="884">
+      <data key="d0">98fe2449-ab4a-47bd-ac5c-9a11cf72c8a1</data>
+      <data key="d1">Component</data>
+      <data key="d2">3JB2R53-gpu2</data>
+      <data key="d3">uky-w1-gpu2</data>
+      <data key="d4">GPU</data>
+      <data key="d5">RTX6000</data>
+      <data key="d6">{"unit": 1}</data>
+      <data key="d11">{"bdf": "0000:81:00.0"}</data>
+      <data key="d12">NVIDIA Corporation TU102GL [Quadro RTX 6000/8000] (rev a1)</data>
+      <data key="d7">false</data>
+      <data key="d10">{"primary": {"pool_id": "_", "capacities": {"unit": 1}}}</data>
+      <data key="d13">{"primary": {"pool_id": "_", "labels": {"bdf": "0000:81:00.0"}}}</data>
+    </node>
+    <node id="885">
+      <data key="d0">98fe2449-ab4a-47bd-ac5c-9a11cf72c8a1</data>
+      <data key="d1">Component</data>
+      <data key="d2">3JB0R53-gpu1</data>
+      <data key="d3">uky-w2-gpu1</data>
       <data key="d4">GPU</data>
       <data key="d5">Tesla T4</data>
       <data key="d6">{"unit": 1}</data>
@@ -203,11 +237,11 @@
       <data key="d10">{"primary": {"pool_id": "_", "capacities": {"unit": 1}}}</data>
       <data key="d13">{"primary": {"pool_id": "_", "labels": {"bdf": "0000:25:00.0"}}}</data>
     </node>
-    <node id="15">
-      <data key="d0">2b44168c-2bc0-4fcc-bb95-1ae2a471e539</data>
+    <node id="886">
+      <data key="d0">98fe2449-ab4a-47bd-ac5c-9a11cf72c8a1</data>
       <data key="d1">Component</data>
-      <data key="d2">3JB0R53-gpu-2</data>
-      <data key="d3">uky-w2.fabric-testbed.net-gpu-2</data>
+      <data key="d2">3JB0R53-gpu2</data>
+      <data key="d3">uky-w2-gpu2</data>
       <data key="d4">GPU</data>
       <data key="d5">Tesla T4</data>
       <data key="d6">{"unit": 1}</data>
@@ -217,116 +251,167 @@
       <data key="d10">{"primary": {"pool_id": "_", "capacities": {"unit": 1}}}</data>
       <data key="d13">{"primary": {"pool_id": "_", "labels": {"bdf": "0000:81:00.0"}}}</data>
     </node>
-    <node id="16">
-      <data key="d0">2b44168c-2bc0-4fcc-bb95-1ae2a471e539</data>
+    <node id="887">
+      <data key="d0">98fe2449-ab4a-47bd-ac5c-9a11cf72c8a1</data>
       <data key="d1">Component</data>
-      <data key="d2">3JB0R53-slot7</data>
-      <data key="d3">uky-w2.fabric-testbed.net-slot7</data>
-      <data key="d4">SharedNIC</data>
-      <data key="d5">ConnectX-6</data>
-      <data key="d6">{"unit": 127}</data>
-      <data key="d11">{"bdf": ["0000:e2:17.6", "0000:e2:17.0", "0000:e2:11.6", "0000:e2:14.0", "0000:e2:1d.0", "0000:e2:10.1", "0000:e2:1d.2", "0000:e2:1d.3", "0000:e2:14.7", "0000:e2:16.4", "0000:e2:10.2", "0000:e2:12.6", "0000:e2:17.3", "0000:e2:13.4", "0000:e2:1a.6", "0000:e2:1a.7", "0000:e2:11.5", "0000:e2:12.7", "0000:e2:14.4", "0000:e2:10.7", "0000:e2:11.2", "0000:e2:13.5", "0000:e2:1b.7", "0000:e2:1b.4", "0000:e2:1a.5", "0000:e2:1b.0", "0000:e2:1f.0", "0000:e2:13.6", "0000:e2:19.2", "0000:e2:13.1", "0000:e2:17.5", "0000:e2:16.5", "0000:e2:12.5", "0000:e2:11.4", "0000:e2:17.7", "0000:e2:12.1", "0000:e2:14.6", "0000:e2:13.2", "0000:e2:16.3", "0000:e2:13.0", "0000:e2:1f.3", "0000:e2:1c.1", "0000:e2:1d.7", "0000:e2:1c.5", "0000:e2:12.4", "0000:e2:16.2", "0000:e2:17.4", "0000:e2:1a.1", "0000:e2:19.6", "0000:e2:15.3", "0000:e2:1e.4", "0000:e2:15.4", "0000:e2:10.5", "0000:e2:18.3", "0000:e2:1f.1", "0000:e2:1e.2", "0000:e2:1f.5", "0000:e2:16.6", "0000:e2:1b.1", "0000:e2:10.4", "0000:e2:16.0", "0000:e2:1d.6", "0000:e2:1d.5", "0000:e2:1a.4", "0000:e2:15.5", "0000:e2:1b.2", "0000:e2:15.1", "0000:e2:19.1", "0000:e2:1e.0", "0000:e2:18.5", "0000:e2:19.3", "0000:e2:1e.3", "0000:e2:18.1", "0000:e2:1f.6", "0000:e2:19.4", "0000:e2:1c.0", "0000:e2:11.3", "0000:e2:1a.0", "0000:e2:1e.5", "0000:e2:17.2", "0000:e2:14.1", "0000:e2:18.4", "0000:e2:18.6", "0000:e2:1c.4", "0000:e2:10.3", "0000:e2:19.5", "0000:e2:11.0", "0000:e2:19.7", "0000:e2:1f.4", "0000:e2:16.1", "0000:e2:1f.2", "0000:e2:19.0", "0000:e2:1a.2", "0000:e2:14.3", "0000:e2:15.7", "0000:e2:1c.3", "0000:e2:10.6", "0000:e2:1c.7", "0000:e2:1a.3", "0000:e2:17.1", "0000:e2:1e.1", "0000:e2:14.2", "0000:e2:12.3", "0000:e2:15.2", "0000:e2:1c.6", "0000:e2:13.3", "0000:e2:11.7", "0000:e2:1e.6", "0000:e2:12.0", "0000:e2:1f.7", "0000:e2:13.7", "0000:e2:12.2", "0000:e2:16.7", "0000:e2:1d.1", "0000:e2:15.0", "0000:e2:1b.6", "0000:e2:14.5", "0000:e2:1b.5", "0000:e2:18.7", "0000:e2:1b.3", "0000:e2:18.0", "0000:e2:1e.7", "0000:e2:15.6", "0000:e2:1c.2", "0000:e2:11.1", "0000:e2:1d.4", "0000:e2:18.2"]}</data>
-      <data key="d12">Mellanox Technologies MT28908 Family [ConnectX-6] in PCIe Slot 7 (0000:e2:00.1)</data>
-      <data key="d7">false</data>
-      <data key="d10">{"primary": {"pool_id": "_", "capacities": {"unit": 127}}}</data>
-      <data key="d13">{"primary": {"pool_id": "_", "labels": {"bdf": ["0000:e2:17.6", "0000:e2:17.0", "0000:e2:11.6", "0000:e2:14.0", "0000:e2:1d.0", "0000:e2:10.1", "0000:e2:1d.2", "0000:e2:1d.3", "0000:e2:14.7", "0000:e2:16.4", "0000:e2:10.2", "0000:e2:12.6", "0000:e2:17.3", "0000:e2:13.4", "0000:e2:1a.6", "0000:e2:1a.7", "0000:e2:11.5", "0000:e2:12.7", "0000:e2:14.4", "0000:e2:10.7", "0000:e2:11.2", "0000:e2:13.5", "0000:e2:1b.7", "0000:e2:1b.4", "0000:e2:1a.5", "0000:e2:1b.0", "0000:e2:1f.0", "0000:e2:13.6", "0000:e2:19.2", "0000:e2:13.1", "0000:e2:17.5", "0000:e2:16.5", "0000:e2:12.5", "0000:e2:11.4", "0000:e2:17.7", "0000:e2:12.1", "0000:e2:14.6", "0000:e2:13.2", "0000:e2:16.3", "0000:e2:13.0", "0000:e2:1f.3", "0000:e2:1c.1", "0000:e2:1d.7", "0000:e2:1c.5", "0000:e2:12.4", "0000:e2:16.2", "0000:e2:17.4", "0000:e2:1a.1", "0000:e2:19.6", "0000:e2:15.3", "0000:e2:1e.4", "0000:e2:15.4", "0000:e2:10.5", "0000:e2:18.3", "0000:e2:1f.1", "0000:e2:1e.2", "0000:e2:1f.5", "0000:e2:16.6", "0000:e2:1b.1", "0000:e2:10.4", "0000:e2:16.0", "0000:e2:1d.6", "0000:e2:1d.5", "0000:e2:1a.4", "0000:e2:15.5", "0000:e2:1b.2", "0000:e2:15.1", "0000:e2:19.1", "0000:e2:1e.0", "0000:e2:18.5", "0000:e2:19.3", "0000:e2:1e.3", "0000:e2:18.1", "0000:e2:1f.6", "0000:e2:19.4", "0000:e2:1c.0", "0000:e2:11.3", "0000:e2:1a.0", "0000:e2:1e.5", "0000:e2:17.2", "0000:e2:14.1", "0000:e2:18.4", "0000:e2:18.6", "0000:e2:1c.4", "0000:e2:10.3", "0000:e2:19.5", "0000:e2:11.0", "0000:e2:19.7", "0000:e2:1f.4", "0000:e2:16.1", "0000:e2:1f.2", "0000:e2:19.0", "0000:e2:1a.2", "0000:e2:14.3", "0000:e2:15.7", "0000:e2:1c.3", "0000:e2:10.6", "0000:e2:1c.7", "0000:e2:1a.3", "0000:e2:17.1", "0000:e2:1e.1", "0000:e2:14.2", "0000:e2:12.3", "0000:e2:15.2", "0000:e2:1c.6", "0000:e2:13.3", "0000:e2:11.7", "0000:e2:1e.6", "0000:e2:12.0", "0000:e2:1f.7", "0000:e2:13.7", "0000:e2:12.2", "0000:e2:16.7", "0000:e2:1d.1", "0000:e2:15.0", "0000:e2:1b.6", "0000:e2:14.5", "0000:e2:1b.5", "0000:e2:18.7", "0000:e2:1b.3", "0000:e2:18.0", "0000:e2:1e.7", "0000:e2:15.6", "0000:e2:1c.2", "0000:e2:11.1", "0000:e2:1d.4", "0000:e2:18.2"]}}}</data>
-    </node>
-    <node id="17">
-      <data key="d0">2b44168c-2bc0-4fcc-bb95-1ae2a471e539</data>
-      <data key="d1">NetworkService</data>
-      <data key="d2">3JB0R53-slot7-ns</data>
-      <data key="d3">uky-w2.fabric-testbed.net-uky-w2.fabric-testbed.net-slot7-l2ovs</data>
-      <data key="d4">OVS</data>
-      <data key="d7">false</data>
-      <data key="d14">L2</data>
-    </node>
-    <node id="18">
-      <data key="d0">2b44168c-2bc0-4fcc-bb95-1ae2a471e539</data>
-      <data key="d1">ConnectionPoint</data>
-      <data key="d2">node_id-0C-42-A1-EA-C7-E9</data>
-      <data key="d3">uky-w2.fabric-testbed.net-slot7-p1</data>
-      <data key="d4">SharedPort</data>
-      <data key="d6">{"unit": 127}</data>
-      <data key="d11">{"bdf": ["0000:e2:17.6", "0000:e2:17.0", "0000:e2:11.6", "0000:e2:14.0", "0000:e2:1d.0", "0000:e2:10.1", "0000:e2:1d.2", "0000:e2:1d.3", "0000:e2:14.7", "0000:e2:16.4", "0000:e2:10.2", "0000:e2:12.6", "0000:e2:17.3", "0000:e2:13.4", "0000:e2:1a.6", "0000:e2:1a.7", "0000:e2:11.5", "0000:e2:12.7", "0000:e2:14.4", "0000:e2:10.7", "0000:e2:11.2", "0000:e2:13.5", "0000:e2:1b.7", "0000:e2:1b.4", "0000:e2:1a.5", "0000:e2:1b.0", "0000:e2:1f.0", "0000:e2:13.6", "0000:e2:19.2", "0000:e2:13.1", "0000:e2:17.5", "0000:e2:16.5", "0000:e2:12.5", "0000:e2:11.4", "0000:e2:17.7", "0000:e2:12.1", "0000:e2:14.6", "0000:e2:13.2", "0000:e2:16.3", "0000:e2:13.0", "0000:e2:1f.3", "0000:e2:1c.1", "0000:e2:1d.7", "0000:e2:1c.5", "0000:e2:12.4", "0000:e2:16.2", "0000:e2:17.4", "0000:e2:1a.1", "0000:e2:19.6", "0000:e2:15.3", "0000:e2:1e.4", "0000:e2:15.4", "0000:e2:10.5", "0000:e2:18.3", "0000:e2:1f.1", "0000:e2:1e.2", "0000:e2:1f.5", "0000:e2:16.6", "0000:e2:1b.1", "0000:e2:10.4", "0000:e2:16.0", "0000:e2:1d.6", "0000:e2:1d.5", "0000:e2:1a.4", "0000:e2:15.5", "0000:e2:1b.2", "0000:e2:15.1", "0000:e2:19.1", "0000:e2:1e.0", "0000:e2:18.5", "0000:e2:19.3", "0000:e2:1e.3", "0000:e2:18.1", "0000:e2:1f.6", "0000:e2:19.4", "0000:e2:1c.0", "0000:e2:11.3", "0000:e2:1a.0", "0000:e2:1e.5", "0000:e2:17.2", "0000:e2:14.1", "0000:e2:18.4", "0000:e2:18.6", "0000:e2:1c.4", "0000:e2:10.3", "0000:e2:19.5", "0000:e2:11.0", "0000:e2:19.7", "0000:e2:1f.4", "0000:e2:16.1", "0000:e2:1f.2", "0000:e2:19.0", "0000:e2:1a.2", "0000:e2:14.3", "0000:e2:15.7", "0000:e2:1c.3", "0000:e2:10.6", "0000:e2:1c.7", "0000:e2:1a.3", "0000:e2:17.1", "0000:e2:1e.1", "0000:e2:14.2", "0000:e2:12.3", "0000:e2:15.2", "0000:e2:1c.6", "0000:e2:13.3", "0000:e2:11.7", "0000:e2:1e.6", "0000:e2:12.0", "0000:e2:1f.7", "0000:e2:13.7", "0000:e2:12.2", "0000:e2:16.7", "0000:e2:1d.1", "0000:e2:15.0", "0000:e2:1b.6", "0000:e2:14.5", "0000:e2:1b.5", "0000:e2:18.7", "0000:e2:1b.3", "0000:e2:18.0", "0000:e2:1e.7", "0000:e2:15.6", "0000:e2:1c.2", "0000:e2:11.1", "0000:e2:1d.4", "0000:e2:18.2"], "local_name": ["p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1"], "mac": ["02:24:2E:3D:50:F5", "02:C0:F8:D3:A2:55", "06:04:7F:FA:B6:21", "06:0A:09:C5:FF:91", "06:36:F1:A7:A8:98", "06:4C:48:16:F3:C3", "06:81:F6:77:88:31", "06:B4:5C:EF:EF:6F", "06:FF:41:7F:66:88", "0E:41:75:EA:7B:3C", "0E:58:CD:E9:FA:08", "0E:CA:B3:66:EF:07", "0E:E8:3F:A6:BA:A5", "16:51:AF:C2:B8:B6", "16:F6:C8:2E:3C:E0", "1A:34:47:23:B9:61", "1A:62:28:F0:C8:F9", "1A:75:78:77:C5:CF", "1A:8F:A0:C2:CB:70", "1E:84:F5:82:31:40", "22:E0:97:9C:1A:03", "26:9C:CD:E9:E6:6F", "26:B1:5F:86:F4:07", "26:DC:BC:CC:57:FA", "26:E0:4F:CC:82:D8", "2E:9A:18:D8:91:89", "32:06:68:44:04:AF", "32:4B:EE:37:5C:35", "32:5C:E3:FC:55:A7", "32:FD:18:B0:84:38", "36:BA:89:4C:2C:DD", "3A:1A:C2:7C:9D:74", "3A:4A:D2:5A:BE:B7", "3E:B9:83:3B:94:C6", "3E:BE:BD:D2:3A:2D", "3E:DB:6D:61:21:D6", "3E:E4:16:81:D2:8C", "42:D3:D6:54:62:5E", "42:EB:B7:00:1E:2D", "46:71:B1:D6:A5:F4", "4E:29:FC:77:D5:59", "4E:85:67:23:78:63", "4E:C3:B8:0A:8B:B3", "56:10:DC:24:84:84", "56:38:4D:7F:04:C9", "56:3C:B7:28:B5:9B", "56:83:1F:76:C2:CB", "56:A3:E9:AE:34:B6", "5A:94:70:CF:EA:7A", "5A:BC:5C:E9:84:48", "5E:2D:C8:63:7F:73", "5E:32:03:06:B1:6E", "5E:64:CC:4C:7C:36", "62:FF:4D:76:24:6F", "66:4B:ED:12:6B:07", "6A:15:6F:79:71:53", "6A:2E:33:3E:D7:97", "6A:A5:17:E7:6F:52", "6E:60:3C:97:81:E0", "6E:C6:47:9A:2E:27", "72:30:80:5C:C3:2A", "72:CE:96:1D:74:E8", "76:36:E1:FD:3C:60", "76:46:97:58:D8:8F", "76:63:81:79:A2:82", "7A:D0:DA:BF:C7:53", "7A:EA:8B:92:D1:ED", "7E:25:82:13:6A:27", "82:27:EF:7D:82:7D", "82:4A:51:CC:D1:46", "82:81:F8:93:29:FB", "82:9E:43:1E:43:5A", "86:1C:8F:B3:A2:22", "86:40:26:37:C2:47", "86:73:B4:9C:8D:CE", "8A:15:9C:28:6A:46", "8A:16:45:AF:EE:89", "8A:18:B0:F0:C3:1C", "8A:43:20:7C:4F:E3", "8E:9A:59:E8:B3:63", "92:DB:99:71:84:4B", "92:E6:9E:D7:C7:7F", "96:D5:3A:38:70:8C", "9A:0A:83:DF:DB:1D", "9A:6D:01:E0:6C:38", "9E:3D:A1:78:AD:CF", "9E:DE:64:79:7E:34", "9E:E0:AE:8D:2A:19", "A6:D1:EC:64:B5:65", "A6:ED:52:93:B5:BE", "A6:EF:62:E7:DD:4B", "B6:AF:C5:1C:81:BD", "B6:F0:0E:87:F8:F6", "BA:49:DC:5F:FD:A9", "BA:A6:6A:7C:8D:41", "BE:96:32:E3:4D:C1", "BE:B3:CE:EE:36:D3", "C2:06:FB:B1:15:08", "C6:2E:AA:05:A3:C3", "C6:68:F9:A9:D1:D1", "C6:B0:24:40:31:92", "C6:D3:24:DA:2C:83", "CA:77:81:13:3C:1D", "CE:93:30:59:AF:20", "CE:D9:93:FF:63:B9", "D2:6A:D3:F0:6B:F0", "D6:56:7C:64:96:90", "DA:74:7F:D5:9F:FE", "DE:05:4E:4C:50:B9", "DE:58:83:68:37:81", "E6:21:46:48:B3:5C", "E6:78:3E:B7:40:1F", "E6:86:5C:A7:5B:73", "E6:B5:54:F2:82:79", "E6:BF:6C:51:E2:0A", "EA:00:4A:70:A0:23", "EA:27:04:09:7A:E9", "EA:78:11:A0:BE:99", "EA:B6:D7:DF:A5:DD", "EE:73:15:36:34:CB", "EE:FB:CA:CE:3D:00", "F6:2B:51:59:D5:5B", "F6:7F:38:2C:2A:A0", "F6:B9:4E:E7:D0:DE", "FA:6F:65:FD:ED:63", "FE:42:70:44:7D:2A", "FE:AB:EC:13:17:3A"], "vlan": ["2061", "2055", "2013", "2031", "2103", "2000", "2105", "2106", "2038", "2051", "2001", "2021", "2058", "2027", "2085", "2086", "2012", "2022", "2035", "2006", "2009", "2028", "2094", "2091", "2084", "2087", "2119", "2029", "2073", "2024", "2060", "2052", "2020", "2011", "2062", "2016", "2037", "2025", "2050", "2023", "2122", "2096", "2110", "2100", "2019", "2049", "2059", "2080", "2077", "2042", "2115", "2043", "2004", "2066", "2120", "2113", "2124", "2053", "2088", "2003", "2047", "2109", "2108", "2083", "2044", "2089", "2040", "2072", "2111", "2068", "2074", "2114", "2064", "2125", "2075", "2095", "2010", "2079", "2116", "2057", "2032", "2067", "2069", "2099", "2002", "2076", "2007", "2078", "2123", "2048", "2121", "2071", "2081", "2034", "2046", "2098", "2005", "2102", "2082", "2056", "2112", "2033", "2018", "2041", "2101", "2026", "2014", "2117", "2015", "2126", "2030", "2017", "2054", "2104", "2039", "2093", "2036", "2092", "2070", "2090", "2063", "2118", "2045", "2097", "2008", "2107", "2065"]}</data>
-      <data key="d7">false</data>
-      <data key="d10">{"primary": {"pool_id": "_", "capacities": {"unit": 127}}}</data>
-      <data key="d13">{"primary": {"pool_id": "_", "labels": {"bdf": ["0000:e2:17.6", "0000:e2:17.0", "0000:e2:11.6", "0000:e2:14.0", "0000:e2:1d.0", "0000:e2:10.1", "0000:e2:1d.2", "0000:e2:1d.3", "0000:e2:14.7", "0000:e2:16.4", "0000:e2:10.2", "0000:e2:12.6", "0000:e2:17.3", "0000:e2:13.4", "0000:e2:1a.6", "0000:e2:1a.7", "0000:e2:11.5", "0000:e2:12.7", "0000:e2:14.4", "0000:e2:10.7", "0000:e2:11.2", "0000:e2:13.5", "0000:e2:1b.7", "0000:e2:1b.4", "0000:e2:1a.5", "0000:e2:1b.0", "0000:e2:1f.0", "0000:e2:13.6", "0000:e2:19.2", "0000:e2:13.1", "0000:e2:17.5", "0000:e2:16.5", "0000:e2:12.5", "0000:e2:11.4", "0000:e2:17.7", "0000:e2:12.1", "0000:e2:14.6", "0000:e2:13.2", "0000:e2:16.3", "0000:e2:13.0", "0000:e2:1f.3", "0000:e2:1c.1", "0000:e2:1d.7", "0000:e2:1c.5", "0000:e2:12.4", "0000:e2:16.2", "0000:e2:17.4", "0000:e2:1a.1", "0000:e2:19.6", "0000:e2:15.3", "0000:e2:1e.4", "0000:e2:15.4", "0000:e2:10.5", "0000:e2:18.3", "0000:e2:1f.1", "0000:e2:1e.2", "0000:e2:1f.5", "0000:e2:16.6", "0000:e2:1b.1", "0000:e2:10.4", "0000:e2:16.0", "0000:e2:1d.6", "0000:e2:1d.5", "0000:e2:1a.4", "0000:e2:15.5", "0000:e2:1b.2", "0000:e2:15.1", "0000:e2:19.1", "0000:e2:1e.0", "0000:e2:18.5", "0000:e2:19.3", "0000:e2:1e.3", "0000:e2:18.1", "0000:e2:1f.6", "0000:e2:19.4", "0000:e2:1c.0", "0000:e2:11.3", "0000:e2:1a.0", "0000:e2:1e.5", "0000:e2:17.2", "0000:e2:14.1", "0000:e2:18.4", "0000:e2:18.6", "0000:e2:1c.4", "0000:e2:10.3", "0000:e2:19.5", "0000:e2:11.0", "0000:e2:19.7", "0000:e2:1f.4", "0000:e2:16.1", "0000:e2:1f.2", "0000:e2:19.0", "0000:e2:1a.2", "0000:e2:14.3", "0000:e2:15.7", "0000:e2:1c.3", "0000:e2:10.6", "0000:e2:1c.7", "0000:e2:1a.3", "0000:e2:17.1", "0000:e2:1e.1", "0000:e2:14.2", "0000:e2:12.3", "0000:e2:15.2", "0000:e2:1c.6", "0000:e2:13.3", "0000:e2:11.7", "0000:e2:1e.6", "0000:e2:12.0", "0000:e2:1f.7", "0000:e2:13.7", "0000:e2:12.2", "0000:e2:16.7", "0000:e2:1d.1", "0000:e2:15.0", "0000:e2:1b.6", "0000:e2:14.5", "0000:e2:1b.5", "0000:e2:18.7", "0000:e2:1b.3", "0000:e2:18.0", "0000:e2:1e.7", "0000:e2:15.6", "0000:e2:1c.2", "0000:e2:11.1", "0000:e2:1d.4", "0000:e2:18.2"], "mac": ["02:24:2E:3D:50:F5", "02:C0:F8:D3:A2:55", "06:04:7F:FA:B6:21", "06:0A:09:C5:FF:91", "06:36:F1:A7:A8:98", "06:4C:48:16:F3:C3", "06:81:F6:77:88:31", "06:B4:5C:EF:EF:6F", "06:FF:41:7F:66:88", "0E:41:75:EA:7B:3C", "0E:58:CD:E9:FA:08", "0E:CA:B3:66:EF:07", "0E:E8:3F:A6:BA:A5", "16:51:AF:C2:B8:B6", "16:F6:C8:2E:3C:E0", "1A:34:47:23:B9:61", "1A:62:28:F0:C8:F9", "1A:75:78:77:C5:CF", "1A:8F:A0:C2:CB:70", "1E:84:F5:82:31:40", "22:E0:97:9C:1A:03", "26:9C:CD:E9:E6:6F", "26:B1:5F:86:F4:07", "26:DC:BC:CC:57:FA", "26:E0:4F:CC:82:D8", "2E:9A:18:D8:91:89", "32:06:68:44:04:AF", "32:4B:EE:37:5C:35", "32:5C:E3:FC:55:A7", "32:FD:18:B0:84:38", "36:BA:89:4C:2C:DD", "3A:1A:C2:7C:9D:74", "3A:4A:D2:5A:BE:B7", "3E:B9:83:3B:94:C6", "3E:BE:BD:D2:3A:2D", "3E:DB:6D:61:21:D6", "3E:E4:16:81:D2:8C", "42:D3:D6:54:62:5E", "42:EB:B7:00:1E:2D", "46:71:B1:D6:A5:F4", "4E:29:FC:77:D5:59", "4E:85:67:23:78:63", "4E:C3:B8:0A:8B:B3", "56:10:DC:24:84:84", "56:38:4D:7F:04:C9", "56:3C:B7:28:B5:9B", "56:83:1F:76:C2:CB", "56:A3:E9:AE:34:B6", "5A:94:70:CF:EA:7A", "5A:BC:5C:E9:84:48", "5E:2D:C8:63:7F:73", "5E:32:03:06:B1:6E", "5E:64:CC:4C:7C:36", "62:FF:4D:76:24:6F", "66:4B:ED:12:6B:07", "6A:15:6F:79:71:53", "6A:2E:33:3E:D7:97", "6A:A5:17:E7:6F:52", "6E:60:3C:97:81:E0", "6E:C6:47:9A:2E:27", "72:30:80:5C:C3:2A", "72:CE:96:1D:74:E8", "76:36:E1:FD:3C:60", "76:46:97:58:D8:8F", "76:63:81:79:A2:82", "7A:D0:DA:BF:C7:53", "7A:EA:8B:92:D1:ED", "7E:25:82:13:6A:27", "82:27:EF:7D:82:7D", "82:4A:51:CC:D1:46", "82:81:F8:93:29:FB", "82:9E:43:1E:43:5A", "86:1C:8F:B3:A2:22", "86:40:26:37:C2:47", "86:73:B4:9C:8D:CE", "8A:15:9C:28:6A:46", "8A:16:45:AF:EE:89", "8A:18:B0:F0:C3:1C", "8A:43:20:7C:4F:E3", "8E:9A:59:E8:B3:63", "92:DB:99:71:84:4B", "92:E6:9E:D7:C7:7F", "96:D5:3A:38:70:8C", "9A:0A:83:DF:DB:1D", "9A:6D:01:E0:6C:38", "9E:3D:A1:78:AD:CF", "9E:DE:64:79:7E:34", "9E:E0:AE:8D:2A:19", "A6:D1:EC:64:B5:65", "A6:ED:52:93:B5:BE", "A6:EF:62:E7:DD:4B", "B6:AF:C5:1C:81:BD", "B6:F0:0E:87:F8:F6", "BA:49:DC:5F:FD:A9", "BA:A6:6A:7C:8D:41", "BE:96:32:E3:4D:C1", "BE:B3:CE:EE:36:D3", "C2:06:FB:B1:15:08", "C6:2E:AA:05:A3:C3", "C6:68:F9:A9:D1:D1", "C6:B0:24:40:31:92", "C6:D3:24:DA:2C:83", "CA:77:81:13:3C:1D", "CE:93:30:59:AF:20", "CE:D9:93:FF:63:B9", "D2:6A:D3:F0:6B:F0", "D6:56:7C:64:96:90", "DA:74:7F:D5:9F:FE", "DE:05:4E:4C:50:B9", "DE:58:83:68:37:81", "E6:21:46:48:B3:5C", "E6:78:3E:B7:40:1F", "E6:86:5C:A7:5B:73", "E6:B5:54:F2:82:79", "E6:BF:6C:51:E2:0A", "EA:00:4A:70:A0:23", "EA:27:04:09:7A:E9", "EA:78:11:A0:BE:99", "EA:B6:D7:DF:A5:DD", "EE:73:15:36:34:CB", "EE:FB:CA:CE:3D:00", "F6:2B:51:59:D5:5B", "F6:7F:38:2C:2A:A0", "F6:B9:4E:E7:D0:DE", "FA:6F:65:FD:ED:63", "FE:42:70:44:7D:2A", "FE:AB:EC:13:17:3A"], "vlan": ["2061", "2055", "2013", "2031", "2103", "2000", "2105", "2106", "2038", "2051", "2001", "2021", "2058", "2027", "2085", "2086", "2012", "2022", "2035", "2006", "2009", "2028", "2094", "2091", "2084", "2087", "2119", "2029", "2073", "2024", "2060", "2052", "2020", "2011", "2062", "2016", "2037", "2025", "2050", "2023", "2122", "2096", "2110", "2100", "2019", "2049", "2059", "2080", "2077", "2042", "2115", "2043", "2004", "2066", "2120", "2113", "2124", "2053", "2088", "2003", "2047", "2109", "2108", "2083", "2044", "2089", "2040", "2072", "2111", "2068", "2074", "2114", "2064", "2125", "2075", "2095", "2010", "2079", "2116", "2057", "2032", "2067", "2069", "2099", "2002", "2076", "2007", "2078", "2123", "2048", "2121", "2071", "2081", "2034", "2046", "2098", "2005", "2102", "2082", "2056", "2112", "2033", "2018", "2041", "2101", "2026", "2014", "2117", "2015", "2126", "2030", "2017", "2054", "2104", "2039", "2093", "2036", "2092", "2070", "2090", "2063", "2118", "2045", "2097", "2008", "2107", "2065"], "local_name": ["p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1"]}}}</data>
-    </node>
-    <node id="19">
-      <data key="d0">2b44168c-2bc0-4fcc-bb95-1ae2a471e539</data>
-      <data key="d1">Component</data>
-      <data key="d2">3JB0R53-slot6</data>
-      <data key="d3">uky-w2.fabric-testbed.net-slot6</data>
-      <data key="d4">SmartNIC</data>
-      <data key="d5">ConnectX-6</data>
+      <data key="d2">3JB1R53-gpu1</data>
+      <data key="d3">uky-w3-gpu1</data>
+      <data key="d4">GPU</data>
+      <data key="d5">Tesla T4</data>
       <data key="d6">{"unit": 1}</data>
-      <data key="d11">{"bdf": ["0000:a1:00.0", "0000:a1:00.1"]}</data>
-      <data key="d12">Mellanox Technologies MT28908 Family [ConnectX-6] in PCIe Slot 6 (0000:a1:00.0)</data>
+      <data key="d11">{"bdf": "0000:25:00.0"}</data>
+      <data key="d12">NVIDIA Corporation TU104GL [Tesla T4] (rev a1)</data>
       <data key="d7">false</data>
       <data key="d10">{"primary": {"pool_id": "_", "capacities": {"unit": 1}}}</data>
-      <data key="d13">{"primary": {"pool_id": "_", "labels": {"bdf": ["0000:a1:00.0", "0000:a1:00.1"]}}}</data>
+      <data key="d13">{"primary": {"pool_id": "_", "labels": {"bdf": "0000:25:00.0"}}}</data>
     </node>
-    <node id="20">
-      <data key="d0">2b44168c-2bc0-4fcc-bb95-1ae2a471e539</data>
+    <node id="888">
+      <data key="d0">98fe2449-ab4a-47bd-ac5c-9a11cf72c8a1</data>
+      <data key="d1">Component</data>
+      <data key="d2">3JB1R53-gpu2</data>
+      <data key="d3">uky-w3-gpu2</data>
+      <data key="d4">GPU</data>
+      <data key="d5">Tesla T4</data>
+      <data key="d6">{"unit": 1}</data>
+      <data key="d11">{"bdf": "0000:81:00.0"}</data>
+      <data key="d12">NVIDIA Corporation TU104GL [Tesla T4] (rev a1)</data>
+      <data key="d7">false</data>
+      <data key="d10">{"primary": {"pool_id": "_", "capacities": {"unit": 1}}}</data>
+      <data key="d13">{"primary": {"pool_id": "_", "labels": {"bdf": "0000:81:00.0"}}}</data>
+    </node>
+    <node id="889">
+      <data key="d0">98fe2449-ab4a-47bd-ac5c-9a11cf72c8a1</data>
+      <data key="d1">Component</data>
+      <data key="d2">3JB2R53-shnic</data>
+      <data key="d3">uky-w1-shnic</data>
+      <data key="d4">SharedNIC</data>
+      <data key="d5">ConnectX-6</data>
+      <data key="d6">{"unit": 4}</data>
+      <data key="d11">{"bdf": ["0000:a1:00.2", "0000:a1:00.3", "0000:a1:00.4", "0000:a1:00.5"]}</data>
+      <data key="d12">Shared NIC: Mellanox Technologies MT28908 Family [ConnectX-6]</data>
+      <data key="d7">false</data>
+      <data key="d10">{"primary": {"pool_id": "_", "capacities": {"unit": 4}}}</data>
+      <data key="d13">{"primary": {"pool_id": "_", "labels": {"bdf": ["0000:a1:00.2", "0000:a1:00.3", "0000:a1:00.4", "0000:a1:00.5"]}}}</data>
+    </node>
+    <node id="890">
+      <data key="d0">98fe2449-ab4a-47bd-ac5c-9a11cf72c8a1</data>
       <data key="d1">NetworkService</data>
-      <data key="d2">3JB0R53-slot6-ns</data>
-      <data key="d3">uky-w2.fabric-testbed.net-uky-w2.fabric-testbed.net-slot6-l2ovs</data>
+      <data key="d2">3JB2R53-shnic-sf</data>
+      <data key="d3">uky-w1-uky-w1-shnic-l2ovs</data>
       <data key="d4">OVS</data>
       <data key="d7">false</data>
       <data key="d14">L2</data>
     </node>
-    <node id="21">
-      <data key="d0">2b44168c-2bc0-4fcc-bb95-1ae2a471e539</data>
+    <node id="891">
+      <data key="d0">98fe2449-ab4a-47bd-ac5c-9a11cf72c8a1</data>
       <data key="d1">ConnectionPoint</data>
-      <data key="d2">node_id-0C-42-A1-78-F8-04</data>
-      <data key="d3">uky-w2.fabric-testbed.net-slot6-p1</data>
-      <data key="d4">DedicatedPort</data>
-      <data key="d6">{"bw": 100, "unit": 1}</data>
-      <data key="d11">{"local_name": "p1", "mac": "0C:42:A1:78:F8:04", "vlan_range": "1-4096"}</data>
+      <data key="d2">node_id-0C-42-A1-EA-C7-60</data>
+      <data key="d3">uky-w1-shnic-p1</data>
+      <data key="d4">SharedPort</data>
+      <data key="d6">{"unit": 4}</data>
+      <data key="d11">{"bdf": ["0000:a1:00.2", "0000:a1:00.3", "0000:a1:00.4", "0000:a1:00.5"], "local_name": ["p1", "p1", "p1", "p1"], "mac": ["0C:42:A1:EA:C7:61", "0C:42:A1:EA:C7:62", "0C:42:A1:EA:C7:63", "0C:42:A1:EA:C7:64"], "vlan": ["1001", "1002", "1003", "1004"]}</data>
       <data key="d7">false</data>
-      <data key="d10">{"primary": {"pool_id": "_", "capacities": {"bw": 100, "unit": 1}}}</data>
-      <data key="d13">{"primary": {"pool_id": "_", "labels": {"mac": "0C:42:A1:78:F8:04", "vlan_range": "1-4096", "local_name": "p1"}}}</data>
+      <data key="d10">{"primary": {"pool_id": "_", "capacities": {"unit": 4}}}</data>
+      <data key="d13">{"primary": {"pool_id": "_", "labels": {"bdf": ["0000:a1:00.2", "0000:a1:00.3", "0000:a1:00.4", "0000:a1:00.5"], "mac": ["0C:42:A1:EA:C7:61", "0C:42:A1:EA:C7:62", "0C:42:A1:EA:C7:63", "0C:42:A1:EA:C7:64"], "vlan": ["1001", "1002", "1003", "1004"], "local_name": ["p1", "p1", "p1", "p1"]}}}</data>
     </node>
-    <node id="22">
-      <data key="d0">2b44168c-2bc0-4fcc-bb95-1ae2a471e539</data>
-      <data key="d1">ConnectionPoint</data>
-      <data key="d2">node_id-0C-42-A1-78-F8-05</data>
-      <data key="d3">uky-w2.fabric-testbed.net-slot6-p2</data>
-      <data key="d4">DedicatedPort</data>
-      <data key="d6">{"bw": 100, "unit": 1}</data>
-      <data key="d11">{"local_name": "p2", "mac": "0C:42:A1:78:F8:05", "vlan_range": "1-4096"}</data>
-      <data key="d7">false</data>
-      <data key="d10">{"primary": {"pool_id": "_", "capacities": {"bw": 100, "unit": 1}}}</data>
-      <data key="d13">{"primary": {"pool_id": "_", "labels": {"mac": "0C:42:A1:78:F8:05", "vlan_range": "1-4096", "local_name": "p2"}}}</data>
-    </node>
-    <node id="23">
-      <data key="d0">2b44168c-2bc0-4fcc-bb95-1ae2a471e539</data>
+    <node id="892">
+      <data key="d0">98fe2449-ab4a-47bd-ac5c-9a11cf72c8a1</data>
       <data key="d1">Component</data>
-      <data key="d2">3JB0R53-slot3</data>
-      <data key="d3">uky-w2.fabric-testbed.net-slot3</data>
+      <data key="d2">3JB0R53-shnic</data>
+      <data key="d3">uky-w2-shnic</data>
+      <data key="d4">SharedNIC</data>
+      <data key="d5">ConnectX-6</data>
+      <data key="d6">{"unit": 4}</data>
+      <data key="d11">{"bdf": ["0000:e2:00.2", "0000:e2:00.3", "0000:e2:00.4", "0000:e2:00.5"]}</data>
+      <data key="d12">Shared NIC: Mellanox Technologies MT28908 Family [ConnectX-6]</data>
+      <data key="d7">false</data>
+      <data key="d10">{"primary": {"pool_id": "_", "capacities": {"unit": 4}}}</data>
+      <data key="d13">{"primary": {"pool_id": "_", "labels": {"bdf": ["0000:e2:00.2", "0000:e2:00.3", "0000:e2:00.4", "0000:e2:00.5"]}}}</data>
+    </node>
+    <node id="893">
+      <data key="d0">98fe2449-ab4a-47bd-ac5c-9a11cf72c8a1</data>
+      <data key="d1">NetworkService</data>
+      <data key="d2">3JB0R53-shnic-sf</data>
+      <data key="d3">uky-w2-uky-w2-shnic-l2ovs</data>
+      <data key="d4">OVS</data>
+      <data key="d7">false</data>
+      <data key="d14">L2</data>
+    </node>
+    <node id="894">
+      <data key="d0">98fe2449-ab4a-47bd-ac5c-9a11cf72c8a1</data>
+      <data key="d1">ConnectionPoint</data>
+      <data key="d2">node_id-0C-42-A1-EA-C7-E8</data>
+      <data key="d3">uky-w2-shnic-p1</data>
+      <data key="d4">SharedPort</data>
+      <data key="d6">{"unit": 4}</data>
+      <data key="d11">{"bdf": ["0000:e2:00.2", "0000:e2:00.3", "0000:e2:00.4", "0000:e2:00.5"], "local_name": ["p1", "p1", "p1", "p1"], "mac": ["0C:42:A1:EA:C7:E9", "0C:42:A1:EA:C7:EA", "0C:42:A1:EA:C7:EB", "0C:42:A1:EA:C7:EC"], "vlan": ["1001", "1002", "1003", "1004"]}</data>
+      <data key="d7">false</data>
+      <data key="d10">{"primary": {"pool_id": "_", "capacities": {"unit": 4}}}</data>
+      <data key="d13">{"primary": {"pool_id": "_", "labels": {"bdf": ["0000:e2:00.2", "0000:e2:00.3", "0000:e2:00.4", "0000:e2:00.5"], "mac": ["0C:42:A1:EA:C7:E9", "0C:42:A1:EA:C7:EA", "0C:42:A1:EA:C7:EB", "0C:42:A1:EA:C7:EC"], "vlan": ["1001", "1002", "1003", "1004"], "local_name": ["p1", "p1", "p1", "p1"]}}}</data>
+    </node>
+    <node id="895">
+      <data key="d0">98fe2449-ab4a-47bd-ac5c-9a11cf72c8a1</data>
+      <data key="d1">Component</data>
+      <data key="d2">3JB1R53-shnic</data>
+      <data key="d3">uky-w3-shnic</data>
+      <data key="d4">SharedNIC</data>
+      <data key="d5">ConnectX-6</data>
+      <data key="d6">{"unit": 4}</data>
+      <data key="d11">{"bdf": ["0000:e2:00.2", "0000:e2:00.3", "0000:e2:00.4", "0000:e2:00.5"]}</data>
+      <data key="d12">Shared NIC: Mellanox Technologies MT28908 Family [ConnectX-6]</data>
+      <data key="d7">false</data>
+      <data key="d10">{"primary": {"pool_id": "_", "capacities": {"unit": 4}}}</data>
+      <data key="d13">{"primary": {"pool_id": "_", "labels": {"bdf": ["0000:e2:00.2", "0000:e2:00.3", "0000:e2:00.4", "0000:e2:00.5"]}}}</data>
+    </node>
+    <node id="896">
+      <data key="d0">98fe2449-ab4a-47bd-ac5c-9a11cf72c8a1</data>
+      <data key="d1">NetworkService</data>
+      <data key="d2">3JB1R53-shnic-sf</data>
+      <data key="d3">uky-w3-uky-w3-shnic-l2ovs</data>
+      <data key="d4">OVS</data>
+      <data key="d7">false</data>
+      <data key="d14">L2</data>
+    </node>
+    <node id="897">
+      <data key="d0">98fe2449-ab4a-47bd-ac5c-9a11cf72c8a1</data>
+      <data key="d1">ConnectionPoint</data>
+      <data key="d2">node_id-0C-42-A1-78-F8-1C</data>
+      <data key="d3">uky-w3-shnic-p1</data>
+      <data key="d4">SharedPort</data>
+      <data key="d6">{"unit": 4}</data>
+      <data key="d11">{"bdf": ["0000:e2:00.2", "0000:e2:00.3", "0000:e2:00.4", "0000:e2:00.5"], "local_name": ["p1", "p1", "p1", "p1"], "mac": ["0C:42:A1:78:F8:1D", "0C:42:A1:78:F8:1E", "0C:42:A1:78:F8:1F", "0C:42:A1:78:F8:20"], "vlan": ["1001", "1002", "1003", "1004"]}</data>
+      <data key="d7">false</data>
+      <data key="d10">{"primary": {"pool_id": "_", "capacities": {"unit": 4}}}</data>
+      <data key="d13">{"primary": {"pool_id": "_", "labels": {"bdf": ["0000:e2:00.2", "0000:e2:00.3", "0000:e2:00.4", "0000:e2:00.5"], "mac": ["0C:42:A1:78:F8:1D", "0C:42:A1:78:F8:1E", "0C:42:A1:78:F8:1F", "0C:42:A1:78:F8:20"], "vlan": ["1001", "1002", "1003", "1004"], "local_name": ["p1", "p1", "p1", "p1"]}}}</data>
+    </node>
+    <node id="898">
+      <data key="d0">98fe2449-ab4a-47bd-ac5c-9a11cf72c8a1</data>
+      <data key="d1">Component</data>
+      <data key="d2">3JB0R53-nic1</data>
+      <data key="d3">uky-w2-nic1</data>
       <data key="d4">SmartNIC</data>
       <data key="d5">ConnectX-6</data>
       <data key="d6">{"unit": 1}</data>
       <data key="d11">{"bdf": ["0000:41:00.0", "0000:41:00.1"]}</data>
-      <data key="d12">Mellanox Technologies MT28908 Family [ConnectX-6] in PCIe Slot 3 (0000:41:00.0)</data>
+      <data key="d12">Mellanox Technologies MT28908 Family [ConnectX-6]</data>
       <data key="d7">false</data>
       <data key="d10">{"primary": {"pool_id": "_", "capacities": {"unit": 1}}}</data>
       <data key="d13">{"primary": {"pool_id": "_", "labels": {"bdf": ["0000:41:00.0", "0000:41:00.1"]}}}</data>
     </node>
-    <node id="24">
-      <data key="d0">2b44168c-2bc0-4fcc-bb95-1ae2a471e539</data>
+    <node id="899">
+      <data key="d0">98fe2449-ab4a-47bd-ac5c-9a11cf72c8a1</data>
       <data key="d1">NetworkService</data>
-      <data key="d2">3JB0R53-slot3-ns</data>
-      <data key="d3">uky-w2.fabric-testbed.net-uky-w2.fabric-testbed.net-slot3-l2ovs</data>
+      <data key="d2">3JB0R53-nic1-sf</data>
+      <data key="d3">uky-w2-uky-w2-nic1-l2ovs</data>
       <data key="d4">OVS</data>
       <data key="d7">false</data>
       <data key="d14">L2</data>
     </node>
-    <node id="25">
-      <data key="d0">2b44168c-2bc0-4fcc-bb95-1ae2a471e539</data>
+    <node id="900">
+      <data key="d0">98fe2449-ab4a-47bd-ac5c-9a11cf72c8a1</data>
       <data key="d1">ConnectionPoint</data>
       <data key="d2">node_id-0C-42-A1-EA-C7-50</data>
-      <data key="d3">uky-w2.fabric-testbed.net-slot3-p1</data>
+      <data key="d3">uky-w2-nic1-p1</data>
       <data key="d4">DedicatedPort</data>
       <data key="d6">{"bw": 100, "unit": 1}</data>
       <data key="d11">{"local_name": "p1", "mac": "0C:42:A1:EA:C7:50", "vlan_range": "1-4096"}</data>
@@ -334,11 +419,11 @@
       <data key="d10">{"primary": {"pool_id": "_", "capacities": {"bw": 100, "unit": 1}}}</data>
       <data key="d13">{"primary": {"pool_id": "_", "labels": {"mac": "0C:42:A1:EA:C7:50", "vlan_range": "1-4096", "local_name": "p1"}}}</data>
     </node>
-    <node id="26">
-      <data key="d0">2b44168c-2bc0-4fcc-bb95-1ae2a471e539</data>
+    <node id="901">
+      <data key="d0">98fe2449-ab4a-47bd-ac5c-9a11cf72c8a1</data>
       <data key="d1">ConnectionPoint</data>
       <data key="d2">node_id-0C-42-A1-EA-C7-51</data>
-      <data key="d3">uky-w2.fabric-testbed.net-slot3-p2</data>
+      <data key="d3">uky-w2-nic1-p2</data>
       <data key="d4">DedicatedPort</data>
       <data key="d6">{"bw": 100, "unit": 1}</data>
       <data key="d11">{"local_name": "p2", "mac": "0C:42:A1:EA:C7:51", "vlan_range": "1-4096"}</data>
@@ -346,213 +431,81 @@
       <data key="d10">{"primary": {"pool_id": "_", "capacities": {"bw": 100, "unit": 1}}}</data>
       <data key="d13">{"primary": {"pool_id": "_", "labels": {"mac": "0C:42:A1:EA:C7:51", "vlan_range": "1-4096", "local_name": "p2"}}}</data>
     </node>
-    <node id="27">
-      <data key="d0">2b44168c-2bc0-4fcc-bb95-1ae2a471e539</data>
-      <data key="d1">NetworkNode</data>
-      <data key="d2">3JB1R53</data>
-      <data key="d3">uky-w3.fabric-testbed.net</data>
-      <data key="d4">Server</data>
-      <data key="d5">R7525</data>
-      <data key="d6">{"core": 64, "cpu": 2, "disk": 4800, "ram": 512, "unit": 1}</data>
-      <data key="d7">false</data>
-      <data key="d8">UKY</data>
-      <data key="d9">{"postal": "301 Hilltop Ave,Lexington, KY 40506"}</data>
-      <data key="d10">{"primary": {"pool_id": "_", "capacities": {"cpu": 2, "core": 64, "ram": 512, "disk": 4800, "unit": 1}}}</data>
-    </node>
-    <node id="28">
-      <data key="d0">2b44168c-2bc0-4fcc-bb95-1ae2a471e539</data>
+    <node id="902">
+      <data key="d0">98fe2449-ab4a-47bd-ac5c-9a11cf72c8a1</data>
       <data key="d1">Component</data>
-      <data key="d2">PHLJ016100951P0FGN</data>
-      <data key="d3">uky-w3.fabric-testbed.net-nvme-1</data>
-      <data key="d4">NVME</data>
-      <data key="d5">P4510</data>
-      <data key="d6">{"disk": 1000, "unit": 1}</data>
-      <data key="d11">{"bdf": "0000:21:00.0"}</data>
-      <data key="d12">Dell Express Flash NVMe P4510 1TB SFF in PCIe SSD Slot 22 in Bay 2 (0000:21:00.0)</data>
-      <data key="d7">false</data>
-      <data key="d10">{"primary": {"pool_id": "_", "capacities": {"disk": 1000, "unit": 1}}}</data>
-      <data key="d13">{"primary": {"pool_id": "_", "labels": {"bdf": "0000:21:00.0"}}}</data>
-    </node>
-    <node id="29">
-      <data key="d0">2b44168c-2bc0-4fcc-bb95-1ae2a471e539</data>
-      <data key="d1">Component</data>
-      <data key="d2">PHLJ0160046F1P0FGN</data>
-      <data key="d3">uky-w3.fabric-testbed.net-nvme-2</data>
-      <data key="d4">NVME</data>
-      <data key="d5">P4510</data>
-      <data key="d6">{"disk": 1000, "unit": 1}</data>
-      <data key="d11">{"bdf": "0000:22:00.0"}</data>
-      <data key="d12">Dell Express Flash NVMe P4510 1TB SFF in PCIe SSD Slot 23 in Bay 2 (0000:22:00.0)</data>
-      <data key="d7">false</data>
-      <data key="d10">{"primary": {"pool_id": "_", "capacities": {"disk": 1000, "unit": 1}}}</data>
-      <data key="d13">{"primary": {"pool_id": "_", "labels": {"bdf": "0000:22:00.0"}}}</data>
-    </node>
-    <node id="30">
-      <data key="d0">2b44168c-2bc0-4fcc-bb95-1ae2a471e539</data>
-      <data key="d1">Component</data>
-      <data key="d2">PHLJ0161000L1P0FGN</data>
-      <data key="d3">uky-w3.fabric-testbed.net-nvme-3</data>
-      <data key="d4">NVME</data>
-      <data key="d5">P4510</data>
-      <data key="d6">{"disk": 1000, "unit": 1}</data>
-      <data key="d11">{"bdf": "0000:23:00.0"}</data>
-      <data key="d12">Dell Express Flash NVMe P4510 1TB SFF in PCIe SSD Slot 20 in Bay 2 (0000:23:00.0)</data>
-      <data key="d7">false</data>
-      <data key="d10">{"primary": {"pool_id": "_", "capacities": {"disk": 1000, "unit": 1}}}</data>
-      <data key="d13">{"primary": {"pool_id": "_", "labels": {"bdf": "0000:23:00.0"}}}</data>
-    </node>
-    <node id="31">
-      <data key="d0">2b44168c-2bc0-4fcc-bb95-1ae2a471e539</data>
-      <data key="d1">Component</data>
-      <data key="d2">PHLJ015301VG1P0FGN</data>
-      <data key="d3">uky-w3.fabric-testbed.net-nvme-4</data>
-      <data key="d4">NVME</data>
-      <data key="d5">P4510</data>
-      <data key="d6">{"disk": 1000, "unit": 1}</data>
-      <data key="d11">{"bdf": "0000:24:00.0"}</data>
-      <data key="d12">Dell Express Flash NVMe P4510 1TB SFF in PCIe SSD Slot 21 in Bay 2 (0000:24:00.0)</data>
-      <data key="d7">false</data>
-      <data key="d10">{"primary": {"pool_id": "_", "capacities": {"disk": 1000, "unit": 1}}}</data>
-      <data key="d13">{"primary": {"pool_id": "_", "labels": {"bdf": "0000:24:00.0"}}}</data>
-    </node>
-    <node id="32">
-      <data key="d0">2b44168c-2bc0-4fcc-bb95-1ae2a471e539</data>
-      <data key="d1">Component</data>
-      <data key="d2">3JB1R53-gpu-1</data>
-      <data key="d3">uky-w3.fabric-testbed.net-gpu-1</data>
-      <data key="d4">GPU</data>
-      <data key="d5">Tesla T4</data>
-      <data key="d6">{"unit": 1}</data>
-      <data key="d11">{"bdf": "0000:25:00.0"}</data>
-      <data key="d12">NVIDIA Corporation TU104GL [Tesla T4] (rev a1)</data>
-      <data key="d7">false</data>
-      <data key="d10">{"primary": {"pool_id": "_", "capacities": {"unit": 1}}}</data>
-      <data key="d13">{"primary": {"pool_id": "_", "labels": {"bdf": "0000:25:00.0"}}}</data>
-    </node>
-    <node id="33">
-      <data key="d0">2b44168c-2bc0-4fcc-bb95-1ae2a471e539</data>
-      <data key="d1">Component</data>
-      <data key="d2">3JB1R53-gpu-2</data>
-      <data key="d3">uky-w3.fabric-testbed.net-gpu-2</data>
-      <data key="d4">GPU</data>
-      <data key="d5">Tesla T4</data>
-      <data key="d6">{"unit": 1}</data>
-      <data key="d11">{"bdf": "0000:81:00.0"}</data>
-      <data key="d12">NVIDIA Corporation TU104GL [Tesla T4] (rev a1)</data>
-      <data key="d7">false</data>
-      <data key="d10">{"primary": {"pool_id": "_", "capacities": {"unit": 1}}}</data>
-      <data key="d13">{"primary": {"pool_id": "_", "labels": {"bdf": "0000:81:00.0"}}}</data>
-    </node>
-    <node id="34">
-      <data key="d0">2b44168c-2bc0-4fcc-bb95-1ae2a471e539</data>
-      <data key="d1">Component</data>
-      <data key="d2">3JB1R53-slot7</data>
-      <data key="d3">uky-w3.fabric-testbed.net-slot7</data>
-      <data key="d4">SharedNIC</data>
-      <data key="d5">ConnectX-6</data>
-      <data key="d6">{"unit": 127}</data>
-      <data key="d11">{"bdf": ["0000:e2:1e.4", "0000:e2:14.4", "0000:e2:1f.5", "0000:e2:1d.6", "0000:e2:16.1", "0000:e2:19.6", "0000:e2:1c.4", "0000:e2:11.2", "0000:e2:1c.6", "0000:e2:12.6", "0000:e2:1c.3", "0000:e2:15.6", "0000:e2:14.7", "0000:e2:1b.0", "0000:e2:13.4", "0000:e2:1c.2", "0000:e2:14.5", "0000:e2:18.7", "0000:e2:12.3", "0000:e2:10.3", "0000:e2:11.7", "0000:e2:1e.5", "0000:e2:1a.6", "0000:e2:13.6", "0000:e2:1f.1", "0000:e2:10.1", "0000:e2:1e.7", "0000:e2:13.5", "0000:e2:15.3", "0000:e2:18.4", "0000:e2:11.5", "0000:e2:14.6", "0000:e2:18.2", "0000:e2:12.5", "0000:e2:12.7", "0000:e2:1f.4", "0000:e2:1b.3", "0000:e2:13.7", "0000:e2:17.2", "0000:e2:13.2", "0000:e2:14.2", "0000:e2:12.0", "0000:e2:1e.1", "0000:e2:1a.4", "0000:e2:1e.6", "0000:e2:13.0", "0000:e2:1f.7", "0000:e2:13.1", "0000:e2:18.3", "0000:e2:17.1", "0000:e2:10.4", "0000:e2:1f.0", "0000:e2:19.3", "0000:e2:1c.0", "0000:e2:18.5", "0000:e2:16.2", "0000:e2:14.3", "0000:e2:1c.7", "0000:e2:17.7", "0000:e2:1d.7", "0000:e2:10.2", "0000:e2:10.7", "0000:e2:1d.1", "0000:e2:17.6", "0000:e2:1d.5", "0000:e2:1a.2", "0000:e2:15.7", "0000:e2:1e.0", "0000:e2:18.1", "0000:e2:1a.0", "0000:e2:12.1", "0000:e2:19.5", "0000:e2:11.3", "0000:e2:1b.1", "0000:e2:15.2", "0000:e2:15.1", "0000:e2:17.5", "0000:e2:11.0", "0000:e2:11.6", "0000:e2:1d.3", "0000:e2:1e.2", "0000:e2:10.5", "0000:e2:12.2", "0000:e2:1b.4", "0000:e2:19.0", "0000:e2:11.4", "0000:e2:16.3", "0000:e2:1e.3", "0000:e2:1b.2", "0000:e2:1b.5", "0000:e2:1b.7", "0000:e2:17.3", "0000:e2:11.1", "0000:e2:16.6", "0000:e2:15.4", "0000:e2:19.4", "0000:e2:1c.5", "0000:e2:1a.1", "0000:e2:1d.0", "0000:e2:18.0", "0000:e2:15.0", "0000:e2:1d.4", "0000:e2:18.6", "0000:e2:16.0", "0000:e2:1f.6", "0000:e2:1a.7", "0000:e2:10.6", "0000:e2:15.5", "0000:e2:13.3", "0000:e2:1a.3", "0000:e2:19.7", "0000:e2:1b.6", "0000:e2:1f.2", "0000:e2:19.2", "0000:e2:19.1", "0000:e2:17.4", "0000:e2:16.4", "0000:e2:1c.1", "0000:e2:1f.3", "0000:e2:1d.2", "0000:e2:16.5", "0000:e2:1a.5", "0000:e2:16.7", "0000:e2:17.0", "0000:e2:12.4", "0000:e2:14.0", "0000:e2:14.1"]}</data>
-      <data key="d12">Mellanox Technologies MT28908 Family [ConnectX-6] in PCIe Slot 7 (0000:e2:00.1)</data>
-      <data key="d7">false</data>
-      <data key="d10">{"primary": {"pool_id": "_", "capacities": {"unit": 127}}}</data>
-      <data key="d13">{"primary": {"pool_id": "_", "labels": {"bdf": ["0000:e2:1e.4", "0000:e2:14.4", "0000:e2:1f.5", "0000:e2:1d.6", "0000:e2:16.1", "0000:e2:19.6", "0000:e2:1c.4", "0000:e2:11.2", "0000:e2:1c.6", "0000:e2:12.6", "0000:e2:1c.3", "0000:e2:15.6", "0000:e2:14.7", "0000:e2:1b.0", "0000:e2:13.4", "0000:e2:1c.2", "0000:e2:14.5", "0000:e2:18.7", "0000:e2:12.3", "0000:e2:10.3", "0000:e2:11.7", "0000:e2:1e.5", "0000:e2:1a.6", "0000:e2:13.6", "0000:e2:1f.1", "0000:e2:10.1", "0000:e2:1e.7", "0000:e2:13.5", "0000:e2:15.3", "0000:e2:18.4", "0000:e2:11.5", "0000:e2:14.6", "0000:e2:18.2", "0000:e2:12.5", "0000:e2:12.7", "0000:e2:1f.4", "0000:e2:1b.3", "0000:e2:13.7", "0000:e2:17.2", "0000:e2:13.2", "0000:e2:14.2", "0000:e2:12.0", "0000:e2:1e.1", "0000:e2:1a.4", "0000:e2:1e.6", "0000:e2:13.0", "0000:e2:1f.7", "0000:e2:13.1", "0000:e2:18.3", "0000:e2:17.1", "0000:e2:10.4", "0000:e2:1f.0", "0000:e2:19.3", "0000:e2:1c.0", "0000:e2:18.5", "0000:e2:16.2", "0000:e2:14.3", "0000:e2:1c.7", "0000:e2:17.7", "0000:e2:1d.7", "0000:e2:10.2", "0000:e2:10.7", "0000:e2:1d.1", "0000:e2:17.6", "0000:e2:1d.5", "0000:e2:1a.2", "0000:e2:15.7", "0000:e2:1e.0", "0000:e2:18.1", "0000:e2:1a.0", "0000:e2:12.1", "0000:e2:19.5", "0000:e2:11.3", "0000:e2:1b.1", "0000:e2:15.2", "0000:e2:15.1", "0000:e2:17.5", "0000:e2:11.0", "0000:e2:11.6", "0000:e2:1d.3", "0000:e2:1e.2", "0000:e2:10.5", "0000:e2:12.2", "0000:e2:1b.4", "0000:e2:19.0", "0000:e2:11.4", "0000:e2:16.3", "0000:e2:1e.3", "0000:e2:1b.2", "0000:e2:1b.5", "0000:e2:1b.7", "0000:e2:17.3", "0000:e2:11.1", "0000:e2:16.6", "0000:e2:15.4", "0000:e2:19.4", "0000:e2:1c.5", "0000:e2:1a.1", "0000:e2:1d.0", "0000:e2:18.0", "0000:e2:15.0", "0000:e2:1d.4", "0000:e2:18.6", "0000:e2:16.0", "0000:e2:1f.6", "0000:e2:1a.7", "0000:e2:10.6", "0000:e2:15.5", "0000:e2:13.3", "0000:e2:1a.3", "0000:e2:19.7", "0000:e2:1b.6", "0000:e2:1f.2", "0000:e2:19.2", "0000:e2:19.1", "0000:e2:17.4", "0000:e2:16.4", "0000:e2:1c.1", "0000:e2:1f.3", "0000:e2:1d.2", "0000:e2:16.5", "0000:e2:1a.5", "0000:e2:16.7", "0000:e2:17.0", "0000:e2:12.4", "0000:e2:14.0", "0000:e2:14.1"]}}}</data>
-    </node>
-    <node id="35">
-      <data key="d0">2b44168c-2bc0-4fcc-bb95-1ae2a471e539</data>
-      <data key="d1">NetworkService</data>
-      <data key="d2">3JB1R53-slot7-ns</data>
-      <data key="d3">uky-w3.fabric-testbed.net-uky-w3.fabric-testbed.net-slot7-l2ovs</data>
-      <data key="d4">OVS</data>
-      <data key="d7">false</data>
-      <data key="d14">L2</data>
-    </node>
-    <node id="36">
-      <data key="d0">2b44168c-2bc0-4fcc-bb95-1ae2a471e539</data>
-      <data key="d1">ConnectionPoint</data>
-      <data key="d2">node_id-0C-42-A1-78-F8-1D</data>
-      <data key="d3">uky-w3.fabric-testbed.net-slot7-p1</data>
-      <data key="d4">SharedPort</data>
-      <data key="d6">{"unit": 127}</data>
-      <data key="d11">{"bdf": ["0000:e2:1e.4", "0000:e2:14.4", "0000:e2:1f.5", "0000:e2:1d.6", "0000:e2:16.1", "0000:e2:19.6", "0000:e2:1c.4", "0000:e2:11.2", "0000:e2:1c.6", "0000:e2:12.6", "0000:e2:1c.3", "0000:e2:15.6", "0000:e2:14.7", "0000:e2:1b.0", "0000:e2:13.4", "0000:e2:1c.2", "0000:e2:14.5", "0000:e2:18.7", "0000:e2:12.3", "0000:e2:10.3", "0000:e2:11.7", "0000:e2:1e.5", "0000:e2:1a.6", "0000:e2:13.6", "0000:e2:1f.1", "0000:e2:10.1", "0000:e2:1e.7", "0000:e2:13.5", "0000:e2:15.3", "0000:e2:18.4", "0000:e2:11.5", "0000:e2:14.6", "0000:e2:18.2", "0000:e2:12.5", "0000:e2:12.7", "0000:e2:1f.4", "0000:e2:1b.3", "0000:e2:13.7", "0000:e2:17.2", "0000:e2:13.2", "0000:e2:14.2", "0000:e2:12.0", "0000:e2:1e.1", "0000:e2:1a.4", "0000:e2:1e.6", "0000:e2:13.0", "0000:e2:1f.7", "0000:e2:13.1", "0000:e2:18.3", "0000:e2:17.1", "0000:e2:10.4", "0000:e2:1f.0", "0000:e2:19.3", "0000:e2:1c.0", "0000:e2:18.5", "0000:e2:16.2", "0000:e2:14.3", "0000:e2:1c.7", "0000:e2:17.7", "0000:e2:1d.7", "0000:e2:10.2", "0000:e2:10.7", "0000:e2:1d.1", "0000:e2:17.6", "0000:e2:1d.5", "0000:e2:1a.2", "0000:e2:15.7", "0000:e2:1e.0", "0000:e2:18.1", "0000:e2:1a.0", "0000:e2:12.1", "0000:e2:19.5", "0000:e2:11.3", "0000:e2:1b.1", "0000:e2:15.2", "0000:e2:15.1", "0000:e2:17.5", "0000:e2:11.0", "0000:e2:11.6", "0000:e2:1d.3", "0000:e2:1e.2", "0000:e2:10.5", "0000:e2:12.2", "0000:e2:1b.4", "0000:e2:19.0", "0000:e2:11.4", "0000:e2:16.3", "0000:e2:1e.3", "0000:e2:1b.2", "0000:e2:1b.5", "0000:e2:1b.7", "0000:e2:17.3", "0000:e2:11.1", "0000:e2:16.6", "0000:e2:15.4", "0000:e2:19.4", "0000:e2:1c.5", "0000:e2:1a.1", "0000:e2:1d.0", "0000:e2:18.0", "0000:e2:15.0", "0000:e2:1d.4", "0000:e2:18.6", "0000:e2:16.0", "0000:e2:1f.6", "0000:e2:1a.7", "0000:e2:10.6", "0000:e2:15.5", "0000:e2:13.3", "0000:e2:1a.3", "0000:e2:19.7", "0000:e2:1b.6", "0000:e2:1f.2", "0000:e2:19.2", "0000:e2:19.1", "0000:e2:17.4", "0000:e2:16.4", "0000:e2:1c.1", "0000:e2:1f.3", "0000:e2:1d.2", "0000:e2:16.5", "0000:e2:1a.5", "0000:e2:16.7", "0000:e2:17.0", "0000:e2:12.4", "0000:e2:14.0", "0000:e2:14.1"], "local_name": ["p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1"], "mac": ["02:DB:CA:74:E3:76", "06:3A:E0:5E:34:AE", "06:5E:81:96:D5:9A", "0A:9D:CD:A0:EA:25", "12:04:38:E1:8F:AC", "12:48:0C:D1:5E:63", "16:3F:3D:ED:C4:31", "16:DF:EE:4E:10:3F", "1E:2F:A2:C7:BE:F9", "1E:D6:A1:47:78:84", "22:0A:2D:FC:23:61", "22:3F:A6:BF:2F:37", "22:93:6D:C0:25:4D", "22:CB:98:B3:F8:E7", "26:04:74:5E:48:FE", "26:5A:C8:9A:21:55", "26:A4:FC:78:16:62", "2A:BA:02:11:4C:42", "2E:45:A6:12:AD:3E", "32:10:B3:28:E6:9D", "32:5A:4F:E5:51:9D", "32:66:8D:91:42:C2", "32:7B:E9:FF:1E:04", "36:BF:EA:94:A7:55", "3A:46:25:0D:E0:0A", "3A:63:9C:9C:E0:78", "3E:BD:C5:E3:DB:5A", "3E:BE:49:F4:14:0B", "42:C9:6B:49:4A:DC", "46:1F:85:F1:29:26", "46:96:99:DE:7B:0D", "46:9A:1E:E8:0F:3E", "46:A3:3D:13:82:01", "4A:2D:10:34:2A:90", "4A:5E:46:3D:60:38", "4A:9F:19:CA:42:53", "4E:04:27:EB:EC:BA", "4E:1F:1A:DC:BF:6E", "4E:9B:C8:9D:28:7E", "52:3C:59:B8:B2:25", "52:61:8A:1A:89:19", "52:BA:59:27:4D:20", "52:C3:57:F7:56:62", "52:E3:D6:05:32:EB", "52:F1:9C:41:57:D0", "52:FF:7F:E3:B5:40", "56:4F:1A:77:02:EB", "56:B3:7E:D5:99:C0", "56:C2:1A:5A:81:AE", "5A:4A:DF:3A:20:B7", "5A:6F:32:FB:8A:1C", "5A:95:E9:C2:66:D4", "5A:A6:4F:1E:88:27", "5A:C4:58:F5:82:4A", "5A:F0:D4:CF:FF:1D", "62:20:6E:14:88:BB", "62:64:90:1D:A6:30", "6A:43:F0:7C:7D:68", "6A:73:39:3B:9A:0B", "6E:BB:19:E6:27:E0", "72:7A:E5:33:4B:5A", "72:7E:85:4C:F4:E1", "76:B4:B6:3C:FF:32", "7A:DB:AD:F0:E4:20", "7E:5B:95:DC:A3:51", "7E:AA:02:7D:68:6F", "86:87:92:B2:1F:6B", "86:A5:01:D3:15:CB", "86:B3:13:36:6A:89", "86:CB:22:D2:A0:5F", "86:F6:76:32:E4:94", "8E:12:DF:D8:6F:E7", "8E:38:F6:89:14:44", "8E:62:A7:E9:3B:9C", "92:80:F2:45:03:44", "96:06:EA:54:89:86", "96:28:92:10:CB:00", "96:3B:DB:C2:36:17", "96:3E:87:78:E1:94", "96:72:68:70:76:D0", "9E:13:8E:28:6A:DD", "9E:14:D1:4B:CE:67", "9E:CB:F2:E1:55:32", "A2:1A:A4:67:58:86", "A2:81:D5:B2:0E:54", "A2:F1:F0:C6:1D:34", "A6:38:D2:06:ED:7F", "AA:F0:B2:4C:D7:91", "AE:50:7B:DC:7D:9B", "AE:E1:98:49:63:22", "B2:83:29:34:E0:E2", "B2:D4:D7:CD:29:29", "B6:5A:6D:B0:29:0D", "B6:8A:D1:AB:D0:D3", "B6:BF:3E:E4:D3:38", "BA:B6:17:F4:0C:91", "BE:03:0B:FE:0B:09", "BE:AA:F8:1B:1A:93", "C2:84:A0:01:A0:7B", "C2:C3:55:B6:AE:AB", "C6:73:50:12:EF:EF", "C6:91:A7:D2:C9:59", "C6:9C:40:C8:46:DE", "CE:3A:B9:AC:53:62", "CE:61:83:CE:5E:EC", "CE:9A:B2:A9:0B:8C", "D2:CC:1D:6E:45:48", "D6:08:5C:6C:B8:E2", "D6:4E:0B:76:6B:56", "D6:D7:26:88:4F:1A", "DA:0B:00:B7:E1:46", "DA:BA:51:9D:F2:AE", "E2:06:A7:C9:87:9E", "E2:CF:FE:48:12:2B", "E6:9A:04:43:B9:89", "E6:F9:49:22:B3:73", "E6:FC:1B:57:36:DA", "EA:90:E5:16:EC:84", "EE:25:41:CB:85:5F", "F2:36:CD:CF:C8:1C", "F2:6B:EA:9C:36:20", "F6:1E:5C:AC:FF:3A", "F6:4C:AE:07:64:33", "F6:87:A9:73:68:93", "F6:DB:4C:12:8C:E0", "FE:8A:5C:45:15:A2", "FE:ED:BD:0D:5D:23"], "vlan": ["2115", "2035", "2124", "2109", "2048", "2077", "2099", "2009", "2101", "2021", "2098", "2045", "2038", "2087", "2027", "2097", "2036", "2070", "2018", "2002", "2014", "2116", "2085", "2029", "2120", "2000", "2118", "2028", "2042", "2067", "2012", "2037", "2065", "2020", "2022", "2123", "2090", "2030", "2057", "2025", "2033", "2015", "2112", "2083", "2117", "2023", "2126", "2024", "2066", "2056", "2003", "2119", "2074", "2095", "2068", "2049", "2034", "2102", "2062", "2110", "2001", "2006", "2104", "2061", "2108", "2081", "2046", "2111", "2064", "2079", "2016", "2076", "2010", "2088", "2041", "2040", "2060", "2007", "2013", "2106", "2113", "2004", "2017", "2091", "2071", "2011", "2050", "2114", "2089", "2092", "2094", "2058", "2008", "2053", "2043", "2075", "2100", "2080", "2103", "2063", "2039", "2107", "2069", "2047", "2125", "2086", "2005", "2044", "2026", "2082", "2078", "2093", "2121", "2073", "2072", "2059", "2051", "2096", "2122", "2105", "2052", "2084", "2054", "2055", "2019", "2031", "2032"]}</data>
-      <data key="d7">false</data>
-      <data key="d10">{"primary": {"pool_id": "_", "capacities": {"unit": 127}}}</data>
-      <data key="d13">{"primary": {"pool_id": "_", "labels": {"bdf": ["0000:e2:1e.4", "0000:e2:14.4", "0000:e2:1f.5", "0000:e2:1d.6", "0000:e2:16.1", "0000:e2:19.6", "0000:e2:1c.4", "0000:e2:11.2", "0000:e2:1c.6", "0000:e2:12.6", "0000:e2:1c.3", "0000:e2:15.6", "0000:e2:14.7", "0000:e2:1b.0", "0000:e2:13.4", "0000:e2:1c.2", "0000:e2:14.5", "0000:e2:18.7", "0000:e2:12.3", "0000:e2:10.3", "0000:e2:11.7", "0000:e2:1e.5", "0000:e2:1a.6", "0000:e2:13.6", "0000:e2:1f.1", "0000:e2:10.1", "0000:e2:1e.7", "0000:e2:13.5", "0000:e2:15.3", "0000:e2:18.4", "0000:e2:11.5", "0000:e2:14.6", "0000:e2:18.2", "0000:e2:12.5", "0000:e2:12.7", "0000:e2:1f.4", "0000:e2:1b.3", "0000:e2:13.7", "0000:e2:17.2", "0000:e2:13.2", "0000:e2:14.2", "0000:e2:12.0", "0000:e2:1e.1", "0000:e2:1a.4", "0000:e2:1e.6", "0000:e2:13.0", "0000:e2:1f.7", "0000:e2:13.1", "0000:e2:18.3", "0000:e2:17.1", "0000:e2:10.4", "0000:e2:1f.0", "0000:e2:19.3", "0000:e2:1c.0", "0000:e2:18.5", "0000:e2:16.2", "0000:e2:14.3", "0000:e2:1c.7", "0000:e2:17.7", "0000:e2:1d.7", "0000:e2:10.2", "0000:e2:10.7", "0000:e2:1d.1", "0000:e2:17.6", "0000:e2:1d.5", "0000:e2:1a.2", "0000:e2:15.7", "0000:e2:1e.0", "0000:e2:18.1", "0000:e2:1a.0", "0000:e2:12.1", "0000:e2:19.5", "0000:e2:11.3", "0000:e2:1b.1", "0000:e2:15.2", "0000:e2:15.1", "0000:e2:17.5", "0000:e2:11.0", "0000:e2:11.6", "0000:e2:1d.3", "0000:e2:1e.2", "0000:e2:10.5", "0000:e2:12.2", "0000:e2:1b.4", "0000:e2:19.0", "0000:e2:11.4", "0000:e2:16.3", "0000:e2:1e.3", "0000:e2:1b.2", "0000:e2:1b.5", "0000:e2:1b.7", "0000:e2:17.3", "0000:e2:11.1", "0000:e2:16.6", "0000:e2:15.4", "0000:e2:19.4", "0000:e2:1c.5", "0000:e2:1a.1", "0000:e2:1d.0", "0000:e2:18.0", "0000:e2:15.0", "0000:e2:1d.4", "0000:e2:18.6", "0000:e2:16.0", "0000:e2:1f.6", "0000:e2:1a.7", "0000:e2:10.6", "0000:e2:15.5", "0000:e2:13.3", "0000:e2:1a.3", "0000:e2:19.7", "0000:e2:1b.6", "0000:e2:1f.2", "0000:e2:19.2", "0000:e2:19.1", "0000:e2:17.4", "0000:e2:16.4", "0000:e2:1c.1", "0000:e2:1f.3", "0000:e2:1d.2", "0000:e2:16.5", "0000:e2:1a.5", "0000:e2:16.7", "0000:e2:17.0", "0000:e2:12.4", "0000:e2:14.0", "0000:e2:14.1"], "mac": ["02:DB:CA:74:E3:76", "06:3A:E0:5E:34:AE", "06:5E:81:96:D5:9A", "0A:9D:CD:A0:EA:25", "12:04:38:E1:8F:AC", "12:48:0C:D1:5E:63", "16:3F:3D:ED:C4:31", "16:DF:EE:4E:10:3F", "1E:2F:A2:C7:BE:F9", "1E:D6:A1:47:78:84", "22:0A:2D:FC:23:61", "22:3F:A6:BF:2F:37", "22:93:6D:C0:25:4D", "22:CB:98:B3:F8:E7", "26:04:74:5E:48:FE", "26:5A:C8:9A:21:55", "26:A4:FC:78:16:62", "2A:BA:02:11:4C:42", "2E:45:A6:12:AD:3E", "32:10:B3:28:E6:9D", "32:5A:4F:E5:51:9D", "32:66:8D:91:42:C2", "32:7B:E9:FF:1E:04", "36:BF:EA:94:A7:55", "3A:46:25:0D:E0:0A", "3A:63:9C:9C:E0:78", "3E:BD:C5:E3:DB:5A", "3E:BE:49:F4:14:0B", "42:C9:6B:49:4A:DC", "46:1F:85:F1:29:26", "46:96:99:DE:7B:0D", "46:9A:1E:E8:0F:3E", "46:A3:3D:13:82:01", "4A:2D:10:34:2A:90", "4A:5E:46:3D:60:38", "4A:9F:19:CA:42:53", "4E:04:27:EB:EC:BA", "4E:1F:1A:DC:BF:6E", "4E:9B:C8:9D:28:7E", "52:3C:59:B8:B2:25", "52:61:8A:1A:89:19", "52:BA:59:27:4D:20", "52:C3:57:F7:56:62", "52:E3:D6:05:32:EB", "52:F1:9C:41:57:D0", "52:FF:7F:E3:B5:40", "56:4F:1A:77:02:EB", "56:B3:7E:D5:99:C0", "56:C2:1A:5A:81:AE", "5A:4A:DF:3A:20:B7", "5A:6F:32:FB:8A:1C", "5A:95:E9:C2:66:D4", "5A:A6:4F:1E:88:27", "5A:C4:58:F5:82:4A", "5A:F0:D4:CF:FF:1D", "62:20:6E:14:88:BB", "62:64:90:1D:A6:30", "6A:43:F0:7C:7D:68", "6A:73:39:3B:9A:0B", "6E:BB:19:E6:27:E0", "72:7A:E5:33:4B:5A", "72:7E:85:4C:F4:E1", "76:B4:B6:3C:FF:32", "7A:DB:AD:F0:E4:20", "7E:5B:95:DC:A3:51", "7E:AA:02:7D:68:6F", "86:87:92:B2:1F:6B", "86:A5:01:D3:15:CB", "86:B3:13:36:6A:89", "86:CB:22:D2:A0:5F", "86:F6:76:32:E4:94", "8E:12:DF:D8:6F:E7", "8E:38:F6:89:14:44", "8E:62:A7:E9:3B:9C", "92:80:F2:45:03:44", "96:06:EA:54:89:86", "96:28:92:10:CB:00", "96:3B:DB:C2:36:17", "96:3E:87:78:E1:94", "96:72:68:70:76:D0", "9E:13:8E:28:6A:DD", "9E:14:D1:4B:CE:67", "9E:CB:F2:E1:55:32", "A2:1A:A4:67:58:86", "A2:81:D5:B2:0E:54", "A2:F1:F0:C6:1D:34", "A6:38:D2:06:ED:7F", "AA:F0:B2:4C:D7:91", "AE:50:7B:DC:7D:9B", "AE:E1:98:49:63:22", "B2:83:29:34:E0:E2", "B2:D4:D7:CD:29:29", "B6:5A:6D:B0:29:0D", "B6:8A:D1:AB:D0:D3", "B6:BF:3E:E4:D3:38", "BA:B6:17:F4:0C:91", "BE:03:0B:FE:0B:09", "BE:AA:F8:1B:1A:93", "C2:84:A0:01:A0:7B", "C2:C3:55:B6:AE:AB", "C6:73:50:12:EF:EF", "C6:91:A7:D2:C9:59", "C6:9C:40:C8:46:DE", "CE:3A:B9:AC:53:62", "CE:61:83:CE:5E:EC", "CE:9A:B2:A9:0B:8C", "D2:CC:1D:6E:45:48", "D6:08:5C:6C:B8:E2", "D6:4E:0B:76:6B:56", "D6:D7:26:88:4F:1A", "DA:0B:00:B7:E1:46", "DA:BA:51:9D:F2:AE", "E2:06:A7:C9:87:9E", "E2:CF:FE:48:12:2B", "E6:9A:04:43:B9:89", "E6:F9:49:22:B3:73", "E6:FC:1B:57:36:DA", "EA:90:E5:16:EC:84", "EE:25:41:CB:85:5F", "F2:36:CD:CF:C8:1C", "F2:6B:EA:9C:36:20", "F6:1E:5C:AC:FF:3A", "F6:4C:AE:07:64:33", "F6:87:A9:73:68:93", "F6:DB:4C:12:8C:E0", "FE:8A:5C:45:15:A2", "FE:ED:BD:0D:5D:23"], "vlan": ["2115", "2035", "2124", "2109", "2048", "2077", "2099", "2009", "2101", "2021", "2098", "2045", "2038", "2087", "2027", "2097", "2036", "2070", "2018", "2002", "2014", "2116", "2085", "2029", "2120", "2000", "2118", "2028", "2042", "2067", "2012", "2037", "2065", "2020", "2022", "2123", "2090", "2030", "2057", "2025", "2033", "2015", "2112", "2083", "2117", "2023", "2126", "2024", "2066", "2056", "2003", "2119", "2074", "2095", "2068", "2049", "2034", "2102", "2062", "2110", "2001", "2006", "2104", "2061", "2108", "2081", "2046", "2111", "2064", "2079", "2016", "2076", "2010", "2088", "2041", "2040", "2060", "2007", "2013", "2106", "2113", "2004", "2017", "2091", "2071", "2011", "2050", "2114", "2089", "2092", "2094", "2058", "2008", "2053", "2043", "2075", "2100", "2080", "2103", "2063", "2039", "2107", "2069", "2047", "2125", "2086", "2005", "2044", "2026", "2082", "2078", "2093", "2121", "2073", "2072", "2059", "2051", "2096", "2122", "2105", "2052", "2084", "2054", "2055", "2019", "2031", "2032"], "local_name": ["p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1", "p1"]}}}</data>
-    </node>
-    <node id="37">
-      <data key="d0">2b44168c-2bc0-4fcc-bb95-1ae2a471e539</data>
-      <data key="d1">Component</data>
-      <data key="d2">3JB1R53-slot6</data>
-      <data key="d3">uky-w3.fabric-testbed.net-slot6</data>
+      <data key="d2">3JB0R53-nic2</data>
+      <data key="d3">uky-w2-nic2</data>
       <data key="d4">SmartNIC</data>
-      <data key="d5">ConnectX-5</data>
+      <data key="d5">ConnectX-6</data>
       <data key="d6">{"unit": 1}</data>
       <data key="d11">{"bdf": ["0000:a1:00.0", "0000:a1:00.1"]}</data>
-      <data key="d12">Mellanox Technologies MT27800 Family [ConnectX-5] in PCIe Slot 6 (0000:a1:00.0)</data>
+      <data key="d12">Mellanox Technologies MT28908 Family [ConnectX-6]</data>
       <data key="d7">false</data>
       <data key="d10">{"primary": {"pool_id": "_", "capacities": {"unit": 1}}}</data>
       <data key="d13">{"primary": {"pool_id": "_", "labels": {"bdf": ["0000:a1:00.0", "0000:a1:00.1"]}}}</data>
     </node>
-    <node id="38">
-      <data key="d0">2b44168c-2bc0-4fcc-bb95-1ae2a471e539</data>
+    <node id="903">
+      <data key="d0">98fe2449-ab4a-47bd-ac5c-9a11cf72c8a1</data>
       <data key="d1">NetworkService</data>
-      <data key="d2">3JB1R53-slot6-ns</data>
-      <data key="d3">uky-w3.fabric-testbed.net-uky-w3.fabric-testbed.net-slot6-l2ovs</data>
+      <data key="d2">3JB0R53-nic2-sf</data>
+      <data key="d3">uky-w2-uky-w2-nic2-l2ovs</data>
       <data key="d4">OVS</data>
       <data key="d7">false</data>
       <data key="d14">L2</data>
     </node>
-    <node id="39">
-      <data key="d0">2b44168c-2bc0-4fcc-bb95-1ae2a471e539</data>
+    <node id="904">
+      <data key="d0">98fe2449-ab4a-47bd-ac5c-9a11cf72c8a1</data>
       <data key="d1">ConnectionPoint</data>
-      <data key="d2">node_id-0C-42-A1-BE-8F-DC</data>
-      <data key="d3">uky-w3.fabric-testbed.net-slot6-p1</data>
+      <data key="d2">node_id-0C-42-A1-78-F8-04</data>
+      <data key="d3">uky-w2-nic2-p1</data>
       <data key="d4">DedicatedPort</data>
-      <data key="d6">{"bw": 25, "unit": 1}</data>
-      <data key="d11">{"local_name": "p1", "mac": "0C:42:A1:BE:8F:DC", "vlan_range": "1-4096"}</data>
+      <data key="d6">{"bw": 100, "unit": 1}</data>
+      <data key="d11">{"local_name": "p1", "mac": "0C:42:A1:78:F8:04", "vlan_range": "1-4096"}</data>
       <data key="d7">false</data>
-      <data key="d10">{"primary": {"pool_id": "_", "capacities": {"bw": 25, "unit": 1}}}</data>
-      <data key="d13">{"primary": {"pool_id": "_", "labels": {"mac": "0C:42:A1:BE:8F:DC", "vlan_range": "1-4096", "local_name": "p1"}}}</data>
+      <data key="d10">{"primary": {"pool_id": "_", "capacities": {"bw": 100, "unit": 1}}}</data>
+      <data key="d13">{"primary": {"pool_id": "_", "labels": {"mac": "0C:42:A1:78:F8:04", "vlan_range": "1-4096", "local_name": "p1"}}}</data>
     </node>
-    <node id="40">
-      <data key="d0">2b44168c-2bc0-4fcc-bb95-1ae2a471e539</data>
+    <node id="905">
+      <data key="d0">98fe2449-ab4a-47bd-ac5c-9a11cf72c8a1</data>
       <data key="d1">ConnectionPoint</data>
-      <data key="d2">node_id-0C-42-A1-BE-8F-DD</data>
-      <data key="d3">uky-w3.fabric-testbed.net-slot6-p2</data>
+      <data key="d2">node_id-0C-42-A1-78-F8-05</data>
+      <data key="d3">uky-w2-nic2-p2</data>
       <data key="d4">DedicatedPort</data>
-      <data key="d6">{"bw": 25, "unit": 1}</data>
-      <data key="d11">{"local_name": "p2", "mac": "0C:42:A1:BE:8F:DD", "vlan_range": "1-4096"}</data>
+      <data key="d6">{"bw": 100, "unit": 1}</data>
+      <data key="d11">{"local_name": "p2", "mac": "0C:42:A1:78:F8:05", "vlan_range": "1-4096"}</data>
       <data key="d7">false</data>
-      <data key="d10">{"primary": {"pool_id": "_", "capacities": {"bw": 25, "unit": 1}}}</data>
-      <data key="d13">{"primary": {"pool_id": "_", "labels": {"mac": "0C:42:A1:BE:8F:DD", "vlan_range": "1-4096", "local_name": "p2"}}}</data>
+      <data key="d10">{"primary": {"pool_id": "_", "capacities": {"bw": 100, "unit": 1}}}</data>
+      <data key="d13">{"primary": {"pool_id": "_", "labels": {"mac": "0C:42:A1:78:F8:05", "vlan_range": "1-4096", "local_name": "p2"}}}</data>
     </node>
-    <node id="41">
-      <data key="d0">2b44168c-2bc0-4fcc-bb95-1ae2a471e539</data>
+    <node id="906">
+      <data key="d0">98fe2449-ab4a-47bd-ac5c-9a11cf72c8a1</data>
       <data key="d1">Component</data>
-      <data key="d2">3JB1R53-slot3</data>
-      <data key="d3">uky-w3.fabric-testbed.net-slot3</data>
+      <data key="d2">3JB1R53-nic1</data>
+      <data key="d3">uky-w3-nic1</data>
       <data key="d4">SmartNIC</data>
       <data key="d5">ConnectX-5</data>
       <data key="d6">{"unit": 1}</data>
       <data key="d11">{"bdf": ["0000:41:00.0", "0000:41:00.1"]}</data>
-      <data key="d12">Mellanox Technologies MT27800 Family [ConnectX-5] in PCIe Slot 3 (0000:41:00.0)</data>
+      <data key="d12">Mellanox Technologies MT27800 Family [ConnectX-5]</data>
       <data key="d7">false</data>
       <data key="d10">{"primary": {"pool_id": "_", "capacities": {"unit": 1}}}</data>
       <data key="d13">{"primary": {"pool_id": "_", "labels": {"bdf": ["0000:41:00.0", "0000:41:00.1"]}}}</data>
     </node>
-    <node id="42">
-      <data key="d0">2b44168c-2bc0-4fcc-bb95-1ae2a471e539</data>
+    <node id="907">
+      <data key="d0">98fe2449-ab4a-47bd-ac5c-9a11cf72c8a1</data>
       <data key="d1">NetworkService</data>
-      <data key="d2">3JB1R53-slot3-ns</data>
-      <data key="d3">uky-w3.fabric-testbed.net-uky-w3.fabric-testbed.net-slot3-l2ovs</data>
+      <data key="d2">3JB1R53-nic1-sf</data>
+      <data key="d3">uky-w3-uky-w3-nic1-l2ovs</data>
       <data key="d4">OVS</data>
       <data key="d7">false</data>
       <data key="d14">L2</data>
     </node>
-    <node id="43">
-      <data key="d0">2b44168c-2bc0-4fcc-bb95-1ae2a471e539</data>
+    <node id="908">
+      <data key="d0">98fe2449-ab4a-47bd-ac5c-9a11cf72c8a1</data>
       <data key="d1">ConnectionPoint</data>
       <data key="d2">node_id-0C-42-A1-BE-8F-F8</data>
-      <data key="d3">uky-w3.fabric-testbed.net-slot3-p1</data>
+      <data key="d3">uky-w3-nic1-p1</data>
       <data key="d4">DedicatedPort</data>
       <data key="d6">{"bw": 25, "unit": 1}</data>
       <data key="d11">{"local_name": "p1", "mac": "0C:42:A1:BE:8F:F8", "vlan_range": "1-4096"}</data>
@@ -560,11 +513,11 @@
       <data key="d10">{"primary": {"pool_id": "_", "capacities": {"bw": 25, "unit": 1}}}</data>
       <data key="d13">{"primary": {"pool_id": "_", "labels": {"mac": "0C:42:A1:BE:8F:F8", "vlan_range": "1-4096", "local_name": "p1"}}}</data>
     </node>
-    <node id="44">
-      <data key="d0">2b44168c-2bc0-4fcc-bb95-1ae2a471e539</data>
+    <node id="909">
+      <data key="d0">98fe2449-ab4a-47bd-ac5c-9a11cf72c8a1</data>
       <data key="d1">ConnectionPoint</data>
       <data key="d2">node_id-0C-42-A1-BE-8F-F9</data>
-      <data key="d3">uky-w3.fabric-testbed.net-slot3-p2</data>
+      <data key="d3">uky-w3-nic1-p2</data>
       <data key="d4">DedicatedPort</data>
       <data key="d6">{"bw": 25, "unit": 1}</data>
       <data key="d11">{"local_name": "p2", "mac": "0C:42:A1:BE:8F:F9", "vlan_range": "1-4096"}</data>
@@ -572,20 +525,67 @@
       <data key="d10">{"primary": {"pool_id": "_", "capacities": {"bw": 25, "unit": 1}}}</data>
       <data key="d13">{"primary": {"pool_id": "_", "labels": {"mac": "0C:42:A1:BE:8F:F9", "vlan_range": "1-4096", "local_name": "p2"}}}</data>
     </node>
-    <node id="45">
-      <data key="d0">2b44168c-2bc0-4fcc-bb95-1ae2a471e539</data>
+    <node id="910">
+      <data key="d0">98fe2449-ab4a-47bd-ac5c-9a11cf72c8a1</data>
+      <data key="d1">Component</data>
+      <data key="d2">3JB1R53-nic2</data>
+      <data key="d3">uky-w3-nic2</data>
+      <data key="d4">SmartNIC</data>
+      <data key="d5">ConnectX-5</data>
+      <data key="d6">{"unit": 1}</data>
+      <data key="d11">{"bdf": ["0000:a1:00.0", "0000:a1:00.1"]}</data>
+      <data key="d12">Mellanox Technologies MT27800 Family [ConnectX-5]</data>
+      <data key="d7">false</data>
+      <data key="d10">{"primary": {"pool_id": "_", "capacities": {"unit": 1}}}</data>
+      <data key="d13">{"primary": {"pool_id": "_", "labels": {"bdf": ["0000:a1:00.0", "0000:a1:00.1"]}}}</data>
+    </node>
+    <node id="911">
+      <data key="d0">98fe2449-ab4a-47bd-ac5c-9a11cf72c8a1</data>
+      <data key="d1">NetworkService</data>
+      <data key="d2">3JB1R53-nic2-sf</data>
+      <data key="d3">uky-w3-uky-w3-nic2-l2ovs</data>
+      <data key="d4">OVS</data>
+      <data key="d7">false</data>
+      <data key="d14">L2</data>
+    </node>
+    <node id="912">
+      <data key="d0">98fe2449-ab4a-47bd-ac5c-9a11cf72c8a1</data>
+      <data key="d1">ConnectionPoint</data>
+      <data key="d2">node_id-0C-42-A1-BE-8F-DC</data>
+      <data key="d3">uky-w3-nic2-p1</data>
+      <data key="d4">DedicatedPort</data>
+      <data key="d6">{"bw": 25, "unit": 1}</data>
+      <data key="d11">{"local_name": "p1", "mac": "0C:42:A1:BE:8F:DC", "vlan_range": "1-4096"}</data>
+      <data key="d7">false</data>
+      <data key="d10">{"primary": {"pool_id": "_", "capacities": {"bw": 25, "unit": 1}}}</data>
+      <data key="d13">{"primary": {"pool_id": "_", "labels": {"mac": "0C:42:A1:BE:8F:DC", "vlan_range": "1-4096", "local_name": "p1"}}}</data>
+    </node>
+    <node id="913">
+      <data key="d0">98fe2449-ab4a-47bd-ac5c-9a11cf72c8a1</data>
+      <data key="d1">ConnectionPoint</data>
+      <data key="d2">node_id-0C-42-A1-BE-8F-DD</data>
+      <data key="d3">uky-w3-nic2-p2</data>
+      <data key="d4">DedicatedPort</data>
+      <data key="d6">{"bw": 25, "unit": 1}</data>
+      <data key="d11">{"local_name": "p2", "mac": "0C:42:A1:BE:8F:DD", "vlan_range": "1-4096"}</data>
+      <data key="d7">false</data>
+      <data key="d10">{"primary": {"pool_id": "_", "capacities": {"bw": 25, "unit": 1}}}</data>
+      <data key="d13">{"primary": {"pool_id": "_", "labels": {"mac": "0C:42:A1:BE:8F:DD", "vlan_range": "1-4096", "local_name": "p2"}}}</data>
+    </node>
+    <node id="914">
+      <data key="d0">98fe2449-ab4a-47bd-ac5c-9a11cf72c8a1</data>
       <data key="d1">NetworkNode</data>
       <data key="d2">3DB3R53</data>
-      <data key="d3">uky-storage.fabric-testbed.net</data>
+      <data key="d3">nas</data>
       <data key="d4">NAS</data>
       <data key="d5">ME4084</data>
-      <data key="d6">{"disk": 336000, "unit": 1}</data>
+      <data key="d6">{"disk": 100000, "unit": 1}</data>
       <data key="d7">false</data>
       <data key="d8">UKY</data>
-      <data key="d10">{"primary": {"pool_id": "_", "capacities": {"disk": 336000, "unit": 1}}}</data>
+      <data key="d10">{"primary": {"pool_id": "_", "capacities": {"disk": 100000, "unit": 1}}}</data>
     </node>
-    <node id="46">
-      <data key="d0">2b44168c-2bc0-4fcc-bb95-1ae2a471e539</data>
+    <node id="915">
+      <data key="d0">98fe2449-ab4a-47bd-ac5c-9a11cf72c8a1</data>
       <data key="d1">NetworkNode</data>
       <data key="d2">node+uky-data-sw:ip+192.168.12.3</data>
       <data key="d3">uky-data-sw</data>
@@ -593,8 +593,8 @@
       <data key="d7">true</data>
       <data key="d8">UKY</data>
     </node>
-    <node id="47">
-      <data key="d0">2b44168c-2bc0-4fcc-bb95-1ae2a471e539</data>
+    <node id="916">
+      <data key="d0">98fe2449-ab4a-47bd-ac5c-9a11cf72c8a1</data>
       <data key="d1">NetworkService</data>
       <data key="d2">node+uky-data-sw:ip+192.168.12.3-ns</data>
       <data key="d3">uky-data-sw-ns</data>
@@ -602,16 +602,16 @@
       <data key="d7">true</data>
       <data key="d14">L2</data>
     </node>
-    <node id="48">
-      <data key="d0">2b44168c-2bc0-4fcc-bb95-1ae2a471e539</data>
+    <node id="917">
+      <data key="d0">98fe2449-ab4a-47bd-ac5c-9a11cf72c8a1</data>
       <data key="d1">ConnectionPoint</data>
       <data key="d2">port+uky-data-sw:HundredGigE0/0/0/5</data>
       <data key="d3">HundredGigE0/0/0/5</data>
       <data key="d4">TrunkPort</data>
       <data key="d7">true</data>
     </node>
-    <node id="49">
-      <data key="d0">2b44168c-2bc0-4fcc-bb95-1ae2a471e539</data>
+    <node id="918">
+      <data key="d0">98fe2449-ab4a-47bd-ac5c-9a11cf72c8a1</data>
       <data key="d1">Link</data>
       <data key="d2">port+uky-data-sw:HundredGigE0/0/0/5-DAC</data>
       <data key="d3">l1</data>
@@ -619,101 +619,101 @@
       <data key="d7">false</data>
       <data key="d14">L2</data>
     </node>
-    <node id="50">
-      <data key="d0">2b44168c-2bc0-4fcc-bb95-1ae2a471e539</data>
-      <data key="d1">ConnectionPoint</data>
-      <data key="d2">port+uky-data-sw:HundredGigE0/0/0/9</data>
-      <data key="d3">HundredGigE0/0/0/9</data>
-      <data key="d4">TrunkPort</data>
-      <data key="d7">true</data>
-    </node>
-    <node id="51">
-      <data key="d0">2b44168c-2bc0-4fcc-bb95-1ae2a471e539</data>
-      <data key="d1">Link</data>
-      <data key="d2">port+uky-data-sw:HundredGigE0/0/0/9-DAC</data>
-      <data key="d3">l2</data>
-      <data key="d4">Patch</data>
-      <data key="d7">false</data>
-      <data key="d14">L2</data>
-    </node>
-    <node id="52">
-      <data key="d0">2b44168c-2bc0-4fcc-bb95-1ae2a471e539</data>
-      <data key="d1">ConnectionPoint</data>
-      <data key="d2">port+uky-data-sw:HundredGigE0/0/0/19</data>
-      <data key="d3">HundredGigE0/0/0/19</data>
-      <data key="d4">TrunkPort</data>
-      <data key="d7">true</data>
-    </node>
-    <node id="53">
-      <data key="d0">2b44168c-2bc0-4fcc-bb95-1ae2a471e539</data>
-      <data key="d1">Link</data>
-      <data key="d2">port+uky-data-sw:HundredGigE0/0/0/19-DAC</data>
-      <data key="d3">l3</data>
-      <data key="d4">Patch</data>
-      <data key="d7">false</data>
-      <data key="d14">L2</data>
-    </node>
-    <node id="54">
-      <data key="d0">2b44168c-2bc0-4fcc-bb95-1ae2a471e539</data>
-      <data key="d1">ConnectionPoint</data>
-      <data key="d2">port+uky-data-sw:HundredGigE0/0/0/17</data>
-      <data key="d3">HundredGigE0/0/0/17</data>
-      <data key="d4">TrunkPort</data>
-      <data key="d7">true</data>
-    </node>
-    <node id="55">
-      <data key="d0">2b44168c-2bc0-4fcc-bb95-1ae2a471e539</data>
-      <data key="d1">Link</data>
-      <data key="d2">port+uky-data-sw:HundredGigE0/0/0/17-DAC</data>
-      <data key="d3">l4</data>
-      <data key="d4">Patch</data>
-      <data key="d7">false</data>
-      <data key="d14">L2</data>
-    </node>
-    <node id="56">
-      <data key="d0">2b44168c-2bc0-4fcc-bb95-1ae2a471e539</data>
+    <node id="919">
+      <data key="d0">98fe2449-ab4a-47bd-ac5c-9a11cf72c8a1</data>
       <data key="d1">ConnectionPoint</data>
       <data key="d2">port+uky-data-sw:HundredGigE0/0/0/13</data>
       <data key="d3">HundredGigE0/0/0/13</data>
       <data key="d4">TrunkPort</data>
       <data key="d7">true</data>
     </node>
-    <node id="57">
-      <data key="d0">2b44168c-2bc0-4fcc-bb95-1ae2a471e539</data>
+    <node id="920">
+      <data key="d0">98fe2449-ab4a-47bd-ac5c-9a11cf72c8a1</data>
       <data key="d1">Link</data>
       <data key="d2">port+uky-data-sw:HundredGigE0/0/0/13-DAC</data>
-      <data key="d3">l5</data>
+      <data key="d3">l2</data>
       <data key="d4">Patch</data>
       <data key="d7">false</data>
       <data key="d14">L2</data>
     </node>
-    <node id="58">
-      <data key="d0">2b44168c-2bc0-4fcc-bb95-1ae2a471e539</data>
+    <node id="921">
+      <data key="d0">98fe2449-ab4a-47bd-ac5c-9a11cf72c8a1</data>
       <data key="d1">ConnectionPoint</data>
       <data key="d2">port+uky-data-sw:HundredGigE0/0/0/15</data>
       <data key="d3">HundredGigE0/0/0/15</data>
       <data key="d4">TrunkPort</data>
       <data key="d7">true</data>
     </node>
-    <node id="59">
-      <data key="d0">2b44168c-2bc0-4fcc-bb95-1ae2a471e539</data>
+    <node id="922">
+      <data key="d0">98fe2449-ab4a-47bd-ac5c-9a11cf72c8a1</data>
       <data key="d1">Link</data>
       <data key="d2">port+uky-data-sw:HundredGigE0/0/0/15-DAC</data>
+      <data key="d3">l3</data>
+      <data key="d4">Patch</data>
+      <data key="d7">false</data>
+      <data key="d14">L2</data>
+    </node>
+    <node id="923">
+      <data key="d0">98fe2449-ab4a-47bd-ac5c-9a11cf72c8a1</data>
+      <data key="d1">ConnectionPoint</data>
+      <data key="d2">port+uky-data-sw:HundredGigE0/0/0/9</data>
+      <data key="d3">HundredGigE0/0/0/9</data>
+      <data key="d4">TrunkPort</data>
+      <data key="d7">true</data>
+    </node>
+    <node id="924">
+      <data key="d0">98fe2449-ab4a-47bd-ac5c-9a11cf72c8a1</data>
+      <data key="d1">Link</data>
+      <data key="d2">port+uky-data-sw:HundredGigE0/0/0/9-DAC</data>
+      <data key="d3">l4</data>
+      <data key="d4">Patch</data>
+      <data key="d7">false</data>
+      <data key="d14">L2</data>
+    </node>
+    <node id="925">
+      <data key="d0">98fe2449-ab4a-47bd-ac5c-9a11cf72c8a1</data>
+      <data key="d1">ConnectionPoint</data>
+      <data key="d2">port+uky-data-sw:HundredGigE0/0/0/17</data>
+      <data key="d3">HundredGigE0/0/0/17</data>
+      <data key="d4">TrunkPort</data>
+      <data key="d7">true</data>
+    </node>
+    <node id="926">
+      <data key="d0">98fe2449-ab4a-47bd-ac5c-9a11cf72c8a1</data>
+      <data key="d1">Link</data>
+      <data key="d2">port+uky-data-sw:HundredGigE0/0/0/17-DAC</data>
+      <data key="d3">l5</data>
+      <data key="d4">Patch</data>
+      <data key="d7">false</data>
+      <data key="d14">L2</data>
+    </node>
+    <node id="927">
+      <data key="d0">98fe2449-ab4a-47bd-ac5c-9a11cf72c8a1</data>
+      <data key="d1">ConnectionPoint</data>
+      <data key="d2">port+uky-data-sw:HundredGigE0/0/0/19</data>
+      <data key="d3">HundredGigE0/0/0/19</data>
+      <data key="d4">TrunkPort</data>
+      <data key="d7">true</data>
+    </node>
+    <node id="928">
+      <data key="d0">98fe2449-ab4a-47bd-ac5c-9a11cf72c8a1</data>
+      <data key="d1">Link</data>
+      <data key="d2">port+uky-data-sw:HundredGigE0/0/0/19-DAC</data>
       <data key="d3">l6</data>
       <data key="d4">Patch</data>
       <data key="d7">false</data>
       <data key="d14">L2</data>
     </node>
-    <node id="60">
-      <data key="d0">2b44168c-2bc0-4fcc-bb95-1ae2a471e539</data>
+    <node id="929">
+      <data key="d0">98fe2449-ab4a-47bd-ac5c-9a11cf72c8a1</data>
       <data key="d1">ConnectionPoint</data>
       <data key="d2">port+uky-data-sw:HundredGigE0/0/0/21</data>
       <data key="d3">HundredGigE0/0/0/21</data>
       <data key="d4">TrunkPort</data>
       <data key="d7">true</data>
     </node>
-    <node id="61">
-      <data key="d0">2b44168c-2bc0-4fcc-bb95-1ae2a471e539</data>
+    <node id="930">
+      <data key="d0">98fe2449-ab4a-47bd-ac5c-9a11cf72c8a1</data>
       <data key="d1">Link</data>
       <data key="d2">port+uky-data-sw:HundredGigE0/0/0/21-DAC</data>
       <data key="d3">l7</data>
@@ -721,297 +721,297 @@
       <data key="d7">false</data>
       <data key="d14">L2</data>
     </node>
-    <node id="62">
-      <data key="d0">2b44168c-2bc0-4fcc-bb95-1ae2a471e539</data>
+    <node id="931">
+      <data key="d0">98fe2449-ab4a-47bd-ac5c-9a11cf72c8a1</data>
       <data key="d1">ConnectionPoint</data>
-      <data key="d2">port+uky-data-sw:TwentyFiveGigE0/0/0/23/2</data>
-      <data key="d3">TwentyFiveGigE0/0/0/23/2</data>
+      <data key="d2">port+uky-data-sw:HundredGigE0/0/0/25.1</data>
+      <data key="d3">HundredGigE0/0/0/25.1</data>
       <data key="d4">TrunkPort</data>
       <data key="d7">true</data>
     </node>
-    <node id="63">
-      <data key="d0">2b44168c-2bc0-4fcc-bb95-1ae2a471e539</data>
+    <node id="932">
+      <data key="d0">98fe2449-ab4a-47bd-ac5c-9a11cf72c8a1</data>
       <data key="d1">Link</data>
-      <data key="d2">port+uky-data-sw:TwentyFiveGigE0/0/0/23/2-DAC</data>
+      <data key="d2">port+uky-data-sw:HundredGigE0/0/0/25.1-DAC</data>
       <data key="d3">l8</data>
       <data key="d4">Patch</data>
       <data key="d7">false</data>
       <data key="d14">L2</data>
     </node>
-    <node id="64">
-      <data key="d0">2b44168c-2bc0-4fcc-bb95-1ae2a471e539</data>
+    <node id="933">
+      <data key="d0">98fe2449-ab4a-47bd-ac5c-9a11cf72c8a1</data>
       <data key="d1">ConnectionPoint</data>
-      <data key="d2">port+uky-data-sw:TwentyFiveGigE0/0/0/23/3</data>
-      <data key="d3">TwentyFiveGigE0/0/0/23/3</data>
+      <data key="d2">port+uky-data-sw:HundredGigE0/0/0/25.2</data>
+      <data key="d3">HundredGigE0/0/0/25.2</data>
       <data key="d4">TrunkPort</data>
       <data key="d7">true</data>
     </node>
-    <node id="65">
-      <data key="d0">2b44168c-2bc0-4fcc-bb95-1ae2a471e539</data>
+    <node id="934">
+      <data key="d0">98fe2449-ab4a-47bd-ac5c-9a11cf72c8a1</data>
       <data key="d1">Link</data>
-      <data key="d2">port+uky-data-sw:TwentyFiveGigE0/0/0/23/3-DAC</data>
+      <data key="d2">port+uky-data-sw:HundredGigE0/0/0/25.2-DAC</data>
       <data key="d3">l9</data>
       <data key="d4">Patch</data>
       <data key="d7">false</data>
       <data key="d14">L2</data>
     </node>
-    <node id="66">
-      <data key="d0">2b44168c-2bc0-4fcc-bb95-1ae2a471e539</data>
+    <node id="935">
+      <data key="d0">98fe2449-ab4a-47bd-ac5c-9a11cf72c8a1</data>
       <data key="d1">ConnectionPoint</data>
-      <data key="d2">port+uky-data-sw:TwentyFiveGigE0/0/0/23/0</data>
-      <data key="d3">TwentyFiveGigE0/0/0/23/0</data>
+      <data key="d2">port+uky-data-sw:HundredGigE0/0/0/25.3</data>
+      <data key="d3">HundredGigE0/0/0/25.3</data>
       <data key="d4">TrunkPort</data>
       <data key="d7">true</data>
     </node>
-    <node id="67">
-      <data key="d0">2b44168c-2bc0-4fcc-bb95-1ae2a471e539</data>
+    <node id="936">
+      <data key="d0">98fe2449-ab4a-47bd-ac5c-9a11cf72c8a1</data>
       <data key="d1">Link</data>
-      <data key="d2">port+uky-data-sw:TwentyFiveGigE0/0/0/23/0-DAC</data>
+      <data key="d2">port+uky-data-sw:HundredGigE0/0/0/25.3-DAC</data>
       <data key="d3">l10</data>
       <data key="d4">Patch</data>
       <data key="d7">false</data>
       <data key="d14">L2</data>
     </node>
-    <node id="68">
-      <data key="d0">2b44168c-2bc0-4fcc-bb95-1ae2a471e539</data>
+    <node id="937">
+      <data key="d0">98fe2449-ab4a-47bd-ac5c-9a11cf72c8a1</data>
       <data key="d1">ConnectionPoint</data>
-      <data key="d2">port+uky-data-sw:TwentyFiveGigE0/0/0/23/1</data>
-      <data key="d3">TwentyFiveGigE0/0/0/23/1</data>
+      <data key="d2">port+uky-data-sw:HundredGigE0/0/0/25.4</data>
+      <data key="d3">HundredGigE0/0/0/25.4</data>
       <data key="d4">TrunkPort</data>
       <data key="d7">true</data>
     </node>
-    <node id="69">
-      <data key="d0">2b44168c-2bc0-4fcc-bb95-1ae2a471e539</data>
+    <node id="938">
+      <data key="d0">98fe2449-ab4a-47bd-ac5c-9a11cf72c8a1</data>
       <data key="d1">Link</data>
-      <data key="d2">port+uky-data-sw:TwentyFiveGigE0/0/0/23/1-DAC</data>
+      <data key="d2">port+uky-data-sw:HundredGigE0/0/0/25.4-DAC</data>
       <data key="d3">l11</data>
       <data key="d4">Patch</data>
       <data key="d7">false</data>
       <data key="d14">L2</data>
     </node>
-    <edge source="1" target="2">
+    <edge source="870" target="873">
       <data key="d15">has</data>
     </edge>
-    <edge source="1" target="3">
+    <edge source="870" target="874">
       <data key="d15">has</data>
     </edge>
-    <edge source="1" target="4">
+    <edge source="870" target="883">
       <data key="d15">has</data>
     </edge>
-    <edge source="1" target="5">
+    <edge source="870" target="884">
       <data key="d15">has</data>
     </edge>
-    <edge source="1" target="6">
+    <edge source="870" target="889">
       <data key="d15">has</data>
     </edge>
-    <edge source="6" target="7">
+    <edge source="871" target="875">
       <data key="d15">has</data>
     </edge>
-    <edge source="7" target="8">
-      <data key="d15">connects</data>
-    </edge>
-    <edge source="8" target="49">
-      <data key="d15">connects</data>
-    </edge>
-    <edge source="9" target="10">
+    <edge source="871" target="876">
       <data key="d15">has</data>
     </edge>
-    <edge source="9" target="11">
+    <edge source="871" target="877">
       <data key="d15">has</data>
     </edge>
-    <edge source="9" target="12">
+    <edge source="871" target="878">
       <data key="d15">has</data>
     </edge>
-    <edge source="9" target="13">
+    <edge source="871" target="885">
       <data key="d15">has</data>
     </edge>
-    <edge source="9" target="14">
+    <edge source="871" target="886">
       <data key="d15">has</data>
     </edge>
-    <edge source="9" target="15">
+    <edge source="871" target="892">
       <data key="d15">has</data>
     </edge>
-    <edge source="9" target="16">
+    <edge source="871" target="898">
       <data key="d15">has</data>
     </edge>
-    <edge source="9" target="19">
+    <edge source="871" target="902">
       <data key="d15">has</data>
     </edge>
-    <edge source="9" target="23">
+    <edge source="872" target="879">
       <data key="d15">has</data>
     </edge>
-    <edge source="16" target="17">
+    <edge source="872" target="880">
       <data key="d15">has</data>
     </edge>
-    <edge source="17" target="18">
-      <data key="d15">connects</data>
-    </edge>
-    <edge source="18" target="51">
-      <data key="d15">connects</data>
-    </edge>
-    <edge source="19" target="20">
+    <edge source="872" target="881">
       <data key="d15">has</data>
     </edge>
-    <edge source="20" target="21">
-      <data key="d15">connects</data>
-    </edge>
-    <edge source="20" target="22">
-      <data key="d15">connects</data>
-    </edge>
-    <edge source="21" target="53">
-      <data key="d15">connects</data>
-    </edge>
-    <edge source="22" target="55">
-      <data key="d15">connects</data>
-    </edge>
-    <edge source="23" target="24">
+    <edge source="872" target="882">
       <data key="d15">has</data>
     </edge>
-    <edge source="24" target="25">
-      <data key="d15">connects</data>
-    </edge>
-    <edge source="24" target="26">
-      <data key="d15">connects</data>
-    </edge>
-    <edge source="25" target="57">
-      <data key="d15">connects</data>
-    </edge>
-    <edge source="26" target="59">
-      <data key="d15">connects</data>
-    </edge>
-    <edge source="27" target="28">
+    <edge source="872" target="887">
       <data key="d15">has</data>
     </edge>
-    <edge source="27" target="29">
+    <edge source="872" target="888">
       <data key="d15">has</data>
     </edge>
-    <edge source="27" target="30">
+    <edge source="872" target="895">
       <data key="d15">has</data>
     </edge>
-    <edge source="27" target="31">
+    <edge source="872" target="906">
       <data key="d15">has</data>
     </edge>
-    <edge source="27" target="32">
+    <edge source="872" target="910">
       <data key="d15">has</data>
     </edge>
-    <edge source="27" target="33">
+    <edge source="889" target="890">
       <data key="d15">has</data>
     </edge>
-    <edge source="27" target="34">
+    <edge source="890" target="891">
+      <data key="d15">connects</data>
+    </edge>
+    <edge source="891" target="918">
+      <data key="d15">connects</data>
+    </edge>
+    <edge source="892" target="893">
       <data key="d15">has</data>
     </edge>
-    <edge source="27" target="37">
+    <edge source="893" target="894">
+      <data key="d15">connects</data>
+    </edge>
+    <edge source="894" target="920">
+      <data key="d15">connects</data>
+    </edge>
+    <edge source="895" target="896">
       <data key="d15">has</data>
     </edge>
-    <edge source="27" target="41">
+    <edge source="896" target="897">
+      <data key="d15">connects</data>
+    </edge>
+    <edge source="897" target="930">
+      <data key="d15">connects</data>
+    </edge>
+    <edge source="898" target="899">
       <data key="d15">has</data>
     </edge>
-    <edge source="34" target="35">
+    <edge source="899" target="900">
+      <data key="d15">connects</data>
+    </edge>
+    <edge source="899" target="901">
+      <data key="d15">connects</data>
+    </edge>
+    <edge source="900" target="922">
+      <data key="d15">connects</data>
+    </edge>
+    <edge source="901" target="924">
+      <data key="d15">connects</data>
+    </edge>
+    <edge source="902" target="903">
       <data key="d15">has</data>
     </edge>
-    <edge source="35" target="36">
+    <edge source="903" target="904">
       <data key="d15">connects</data>
     </edge>
-    <edge source="36" target="61">
+    <edge source="903" target="905">
       <data key="d15">connects</data>
     </edge>
-    <edge source="37" target="38">
+    <edge source="904" target="926">
+      <data key="d15">connects</data>
+    </edge>
+    <edge source="905" target="928">
+      <data key="d15">connects</data>
+    </edge>
+    <edge source="906" target="907">
       <data key="d15">has</data>
     </edge>
-    <edge source="38" target="39">
+    <edge source="907" target="908">
       <data key="d15">connects</data>
     </edge>
-    <edge source="38" target="40">
+    <edge source="907" target="909">
       <data key="d15">connects</data>
     </edge>
-    <edge source="39" target="65">
+    <edge source="908" target="932">
       <data key="d15">connects</data>
     </edge>
-    <edge source="40" target="63">
+    <edge source="909" target="934">
       <data key="d15">connects</data>
     </edge>
-    <edge source="41" target="42">
+    <edge source="910" target="911">
       <data key="d15">has</data>
     </edge>
-    <edge source="42" target="43">
+    <edge source="911" target="912">
       <data key="d15">connects</data>
     </edge>
-    <edge source="42" target="44">
+    <edge source="911" target="913">
       <data key="d15">connects</data>
     </edge>
-    <edge source="43" target="67">
+    <edge source="912" target="936">
       <data key="d15">connects</data>
     </edge>
-    <edge source="44" target="69">
+    <edge source="913" target="938">
       <data key="d15">connects</data>
     </edge>
-    <edge source="46" target="47">
+    <edge source="915" target="916">
       <data key="d15">has</data>
     </edge>
-    <edge source="47" target="48">
+    <edge source="916" target="917">
       <data key="d15">connects</data>
     </edge>
-    <edge source="47" target="50">
+    <edge source="916" target="919">
       <data key="d15">connects</data>
     </edge>
-    <edge source="47" target="52">
+    <edge source="916" target="921">
       <data key="d15">connects</data>
     </edge>
-    <edge source="47" target="54">
+    <edge source="916" target="923">
       <data key="d15">connects</data>
     </edge>
-    <edge source="47" target="56">
+    <edge source="916" target="925">
       <data key="d15">connects</data>
     </edge>
-    <edge source="47" target="58">
+    <edge source="916" target="927">
       <data key="d15">connects</data>
     </edge>
-    <edge source="47" target="60">
+    <edge source="916" target="929">
       <data key="d15">connects</data>
     </edge>
-    <edge source="47" target="62">
+    <edge source="916" target="931">
       <data key="d15">connects</data>
     </edge>
-    <edge source="47" target="64">
+    <edge source="916" target="933">
       <data key="d15">connects</data>
     </edge>
-    <edge source="47" target="66">
+    <edge source="916" target="935">
       <data key="d15">connects</data>
     </edge>
-    <edge source="47" target="68">
+    <edge source="916" target="937">
       <data key="d15">connects</data>
     </edge>
-    <edge source="48" target="49">
+    <edge source="917" target="918">
       <data key="d15">connects</data>
     </edge>
-    <edge source="50" target="51">
+    <edge source="919" target="920">
       <data key="d15">connects</data>
     </edge>
-    <edge source="52" target="53">
+    <edge source="921" target="922">
       <data key="d15">connects</data>
     </edge>
-    <edge source="54" target="55">
+    <edge source="923" target="924">
       <data key="d15">connects</data>
     </edge>
-    <edge source="56" target="57">
+    <edge source="925" target="926">
       <data key="d15">connects</data>
     </edge>
-    <edge source="58" target="59">
+    <edge source="927" target="928">
       <data key="d15">connects</data>
     </edge>
-    <edge source="60" target="61">
+    <edge source="929" target="930">
       <data key="d15">connects</data>
     </edge>
-    <edge source="62" target="63">
+    <edge source="931" target="932">
       <data key="d15">connects</data>
     </edge>
-    <edge source="64" target="65">
+    <edge source="933" target="934">
       <data key="d15">connects</data>
     </edge>
-    <edge source="66" target="67">
+    <edge source="935" target="936">
       <data key="d15">connects</data>
     </edge>
-    <edge source="68" target="69">
+    <edge source="937" target="938">
       <data key="d15">connects</data>
     </edge>
   </graph>

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ cryptography==3.3.2
 psycopg2-binary
 sqlalchemy
 fabric-message-bus==1.0.6
-fabric-fim==1.1rc3
+fabric-fim==1.1rc5
 waitress
 prometheus_client
 connexion==2.7.0


### PR DESCRIPTION
This completes the FIM side of the changes for facility ports (barring any bug fixes). Facilities now look like nodes of type 'Facility' that are attached via a 'VLAN' NetworkService to a 'FacilityPort' type ConnectionPoint. The CP then is connected via a Link to some port in the site switch. Facility nodes can have a site that is different than the site that is specified on the switch node. 