### PR TITLE
Improve Create Slice Response Time and Storage Support

### DIFF
--- a/Dockerfile-auth
+++ b/Dockerfile-auth
@@ -1,7 +1,7 @@
 FROM python:3.9.0
 MAINTAINER Komal Thareja<komal.thareja@gmail.com>
 
-ARG HANDLERS_VER=1.3rc2
+ARG HANDLERS_VER=1.3rc4
 
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app

--- a/Dockerfile-auth
+++ b/Dockerfile-auth
@@ -1,7 +1,7 @@
 FROM python:3.9.0
 MAINTAINER Komal Thareja<komal.thareja@gmail.com>
 
-ARG HANDLERS_VER=1.2.2
+ARG HANDLERS_VER=1.3rc2
 
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app

--- a/fabric_cf/actor/core/common/constants.py
+++ b/fabric_cf/actor/core/common/constants.py
@@ -249,6 +249,7 @@ class Constants:
     CLAIMS_SUB = "sub"
     CLAIMS_EMAIL = "email"
     CLAIMS_PROJECTS = "projects"
+    PROJECT_ID = "project_id"
 
     PROPERTY_EXCEPTION_MESSAGE = "exception.message"
     PROPERTY_TARGET_NAME = "target.name"

--- a/fabric_cf/actor/core/core/unit.py
+++ b/fabric_cf/actor/core/core/unit.py
@@ -504,5 +504,8 @@ class Unit(ConfigToken):
             self.sliver.set_label_allocations(sliver.get_label_allocations())
             if isinstance(self.sliver, NodeSliver) and isinstance(sliver, NodeSliver):
                 self.sliver.management_ip = sliver.management_ip
+                if sliver.attached_components_info is not None:
+                    for device in sliver.attached_components_info.devices.values():
+                        self.sliver.attached_components_info.devices[device.get_name()].label_allocations = device.label_allocations
         finally:
             self.lock.release()

--- a/fabric_cf/actor/core/policy/network_node_control.py
+++ b/fabric_cf/actor/core/policy/network_node_control.py
@@ -98,6 +98,8 @@ class NetworkNodeControl(ResourceControl):
         """
         self.logger.debug(f"requested_components: {requested_components} for reservation# {rid}")
         for name, c in requested_components.devices.items():
+            if c.get_type() == ComponentType.Storage:
+                continue
             node_map = c.get_node_map()
             if node_map is None:
                 raise AuthorityException(f"Component of type: {c.get_type()} "

--- a/fabric_cf/actor/core/policy/network_node_inventory.py
+++ b/fabric_cf/actor/core/policy/network_node_inventory.py
@@ -395,6 +395,9 @@ class NetworkNodeInventory(InventoryForType):
             self.logger.debug(f"==========Allocating component: {requested_component}")
             resource_type = requested_component.get_type()
             resource_model = requested_component.get_model()
+            if resource_type == ComponentType.Storage:
+                requested_component.capacity_allocations = Capacities(unit=1)
+                continue
             available_components = graph_node.attached_components_info.get_devices_by_type(resource_type=resource_type)
             self.logger.debug(f"available_components after excluding allocated components: {available_components}")
 

--- a/fabric_cf/actor/core/policy/network_node_inventory.py
+++ b/fabric_cf/actor/core/policy/network_node_inventory.py
@@ -397,6 +397,8 @@ class NetworkNodeInventory(InventoryForType):
             resource_model = requested_component.get_model()
             if resource_type == ComponentType.Storage:
                 requested_component.capacity_allocations = Capacities(unit=1)
+                requested_component.label_allocations = Labels()
+                requested_component.label_allocations = Labels.update(lab=requested_component.get_labels())
                 continue
             available_components = graph_node.attached_components_info.get_devices_by_type(resource_type=resource_type)
             self.logger.debug(f"available_components after excluding allocated components: {available_components}")
@@ -472,7 +474,7 @@ class NetworkNodeInventory(InventoryForType):
                 existing_reservations=existing_reservations)
 
         requested_sliver.capacity_allocations = Capacities()
-        requested_sliver.capacity_allocations = Labels.update(lab=requested_capacities)
+        requested_sliver.capacity_allocations = Capacities.update(lab=requested_capacities)
         requested_sliver.label_allocations = Labels(instance_parent=graph_node.get_name())
 
         requested_sliver.set_node_map(node_map=(graph_id, graph_node.node_id))

--- a/fabric_cf/authority/docker-compose.yml
+++ b/fabric_cf/authority/docker-compose.yml
@@ -48,6 +48,7 @@ services:
   am:
     init: true
     build:
+      network: host
       context: ../../../
       dockerfile: Dockerfile-auth
     image: authority:1.3

--- a/fabric_cf/authority/docker-compose.yml
+++ b/fabric_cf/authority/docker-compose.yml
@@ -50,7 +50,7 @@ services:
     build:
       context: ../../../
       dockerfile: Dockerfile-auth
-    image: authority:1.2
+    image: authority:1.3
     container_name: site1-am
     restart: always
     depends_on:

--- a/fabric_cf/broker/docker-compose.yml
+++ b/fabric_cf/broker/docker-compose.yml
@@ -53,7 +53,7 @@ services:
     build:
       context: ../../../
       dockerfile: Dockerfile-broker
-    image: broker:1.2
+    image: broker:1.3
     container_name: broker
     restart: always
     networks:

--- a/fabric_cf/orchestrator/core/orchestrator_handler.py
+++ b/fabric_cf/orchestrator/core/orchestrator_handler.py
@@ -264,7 +264,8 @@ class OrchestratorHandler:
             slice_obj.set_client_slice(True)
             slice_obj.set_description("Description")
             slice_obj.graph_id = asm_graph.get_graph_id()
-            slice_obj.set_config_properties(value={Constants.USER_SSH_KEY: ssh_key})
+            slice_obj.set_config_properties(value={Constants.USER_SSH_KEY: ssh_key,
+                                                   Constants.PROJECT_ID: project})
             slice_obj.set_lease_end(lease_end=end_time)
             auth = AuthAvro()
             auth.oidc_sub_claim = fabric_token.get_subject()

--- a/fabric_cf/orchestrator/core/orchestrator_kernel.py
+++ b/fabric_cf/orchestrator/core/orchestrator_kernel.py
@@ -24,19 +24,17 @@
 #
 # Author: Komal Thareja (kthare10@renci.org)
 import threading
-import traceback
 
 from fim.user import GraphFormat
 
 from fabric_cf.actor.core.apis.abc_mgmt_controller_mixin import ABCMgmtControllerMixin
 from fabric_cf.actor.core.common.constants import Constants
-from fabric_cf.actor.core.kernel.reservation_states import ReservationStates
 from fabric_cf.actor.core.manage.management_utils import ManagementUtils
 from fabric_cf.actor.core.util.id import ID
 from fabric_cf.orchestrator.core.bqm_wrapper import BqmWrapper
 from fabric_cf.orchestrator.core.exceptions import OrchestratorException
-from fabric_cf.orchestrator.core.orchestrator_slice_wrapper import OrchestratorSliceWrapper
 from fabric_cf.orchestrator.core.reservation_status_update_thread import ReservationStatusUpdateThread
+from fabric_cf.orchestrator.core.slice_demand_thread import SliceDemandThread
 
 
 class OrchestratorKernel:
@@ -46,6 +44,7 @@ class OrchestratorKernel:
 
     def __init__(self):
         self.lock = threading.Lock()
+        self.demand_thread = None
         self.sut = None
         self.broker = None
         self.logger = None
@@ -79,31 +78,6 @@ class OrchestratorKernel:
         finally:
             self.lock.release()
 
-    def demand_slice(self, *, controller_slice: OrchestratorSliceWrapper):
-        """
-        Demand slice reservations.
-        :param controller_slice:
-        """
-        computed_reservations = controller_slice.get_computed_reservations()
-
-        try:
-            self.lock.acquire()
-            for reservation in computed_reservations:
-                self.get_logger().debug(f"Issuing demand for reservation: {reservation.get_reservation_id()}")
-
-                if reservation.get_state() != ReservationStates.Unknown.value:
-                    self.get_logger().debug(f"Reservation not in {reservation.get_state()} state, ignoring it")
-                    continue
-
-                if not self.controller.demand_reservation(reservation=reservation):
-                    raise OrchestratorException(f"Could not demand resources: {self.controller.get_last_error()}")
-                self.get_logger().debug(f"Reservation #{reservation.get_reservation_id()} demanded successfully")
-        except Exception as e:
-            self.get_logger().error(traceback.format_exc())
-            self.get_logger().error("Unable to get orchestrator or demand reservation: {}".format(e))
-        finally:
-            self.lock.release()
-
     def set_broker(self, *, broker: ID):
         """
         Set Broker
@@ -118,6 +92,9 @@ class OrchestratorKernel:
         :return:
         """
         return self.broker
+
+    def get_demand_thread(self) -> SliceDemandThread:
+        return self.demand_thread
 
     def get_sut(self) -> ReservationStatusUpdateThread:
         """
@@ -150,6 +127,8 @@ class OrchestratorKernel:
         Stop threads
         :return:
         """
+        if self.demand_thread is not None:
+            self.demand_thread.stop()
         if self.sut is not None:
             self.sut.stop()
 
@@ -158,6 +137,9 @@ class OrchestratorKernel:
         Start threads
         :return:
         """
+        self.get_logger().debug("Starting SliceDemandThread")
+        self.demand_thread = SliceDemandThread(kernel=self)
+        self.demand_thread.start()
         self.get_logger().debug("Starting ReservationStatusUpdateThread")
         self.sut = ReservationStatusUpdateThread()
         self.sut.start()

--- a/fabric_cf/orchestrator/core/slice_demand_thread.py
+++ b/fabric_cf/orchestrator/core/slice_demand_thread.py
@@ -1,0 +1,182 @@
+#!/usr/bin/env python3
+# MIT License
+#
+# Copyright (c) 2020 FABRIC Testbed
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+#
+# Author: Komal Thareja (kthare10@renci.org)
+import queue
+import threading
+import traceback
+
+from fabric_cf.actor.core.kernel.reservation_states import ReservationStates
+from fabric_cf.actor.core.util.id import ID
+from fabric_cf.actor.core.util.iterable_queue import IterableQueue
+from fabric_cf.orchestrator.core.exceptions import OrchestratorException
+from fabric_cf.orchestrator.core.orchestrator_slice_wrapper import OrchestratorSliceWrapper
+from fabric_cf.orchestrator.core.reservation_status_update import ReservationStatusUpdate
+
+
+class SliceDemandThread:
+    """
+    This runs as a standalone thread started by Orchestrator and deals with issuing demand for the slivers for
+    the newly created slices. The purpose of this thread is to help orchestrator respond back to the create
+    without waiting for the slivers to be demanded
+    """
+
+    def __init__(self, *, kernel):
+        self.slice_queue = queue.Queue()
+        self.slice_avail_condition = threading.Condition()
+        self.thread_lock = threading.Lock()
+        self.thread = None
+        self.stopped = False
+        from fabric_cf.actor.core.container.globals import GlobalsSingleton
+        self.logger = GlobalsSingleton.get().get_logger()
+        self.mgmt_actor = kernel.get_management_actor()
+        self.sut = kernel.get_sut()
+
+    def queue_slice(self, *, controller_slice: OrchestratorSliceWrapper):
+        """
+        Queue a slice
+        :param controller_slice:
+        :return:
+        """
+        with self.slice_avail_condition:
+            self.slice_queue.put_nowait(controller_slice)
+            self.logger.debug(f"Added slice to slices queue {controller_slice.get_slice_id()}")
+            self.slice_avail_condition.notify_all()
+
+    def start(self):
+        """
+        Start thread
+        :return:
+        """
+        try:
+            self.thread_lock.acquire()
+            if self.thread is not None:
+                raise OrchestratorException("This SliceDemandThread has already been started")
+
+            self.thread = threading.Thread(target=self.run)
+            self.thread.setName(self.__class__.__name__)
+            self.thread.setDaemon(True)
+            self.thread.start()
+
+        finally:
+            self.thread_lock.release()
+
+    def stop(self):
+        """
+        Stop thread
+        :return:
+        """
+        self.stopped = True
+        try:
+            self.thread_lock.acquire()
+            temp = self.thread
+            self.thread = None
+            if temp is not None:
+                self.logger.warning("It seems that the SliceDemandThread is running. Interrupting it")
+                try:
+                    # TODO find equivalent of interrupt
+                    with self.slice_avail_condition:
+                        self.slice_avail_condition.notify_all()
+                    temp.join()
+                except Exception as e:
+                    self.logger.error(f"Could not join SliceDemandThread thread {e}")
+                finally:
+                    self.thread_lock.release()
+        finally:
+            if self.thread_lock is not None and self.thread_lock.locked():
+                self.thread_lock.release()
+
+    def run(self):
+        """
+        Thread main loop
+        :return:
+        """
+        self.logger.debug("SliceDemandThread started")
+        while True:
+            slices = []
+            with self.slice_avail_condition:
+
+                while self.slice_queue.empty() and not self.stopped:
+                    try:
+                        self.slice_avail_condition.wait()
+                    except InterruptedError as e:
+                        self.logger.info("Slice Demand thread interrupted. Exiting")
+                        return
+
+                if self.stopped:
+                    self.logger.info("Slice Demand Thread exiting")
+                    return
+
+                if not self.slice_queue.empty():
+                    try:
+                        for s in IterableQueue(source_queue=self.slice_queue):
+                            slices.append(s)
+                    except Exception as e:
+                        self.logger.error(f"Error while adding slice to slice queue! e: {e}")
+                        self.logger.error(traceback.format_exc())
+
+                self.slice_avail_condition.notify_all()
+
+            if len(slices) > 0:
+                self.logger.debug(f"Processing {len(slices)} slices")
+                for s in slices:
+                    try:
+                        # Process the Slice i.e. Demand the computed reservations i.e. Add them to the policy
+                        # Once added to the policy; Actor Tick Handler will do following asynchronously:
+                        # 1. Ticket message exchange with broker and
+                        # 2. Redeem message exchange with AM once ticket is granted by Broker
+                        self.demand_slice(controller_slice=s)
+                    except Exception as e:
+                        self.logger.error(f"Error while processing slice {type(s)}, {e}")
+                        self.logger.error(traceback.format_exc())
+
+    def demand_slice(self, *, controller_slice: OrchestratorSliceWrapper):
+        """
+        Demand slice reservations.
+        :param controller_slice:
+        """
+        computed_reservations = controller_slice.get_computed_reservations()
+
+        try:
+            controller_slice.lock()
+            for reservation in computed_reservations:
+                self.logger.debug(f"Issuing demand for reservation: {reservation.get_reservation_id()}")
+
+                if reservation.get_state() != ReservationStates.Unknown.value:
+                    self.logger.debug(f"Reservation not in {reservation.get_state()} state, ignoring it")
+                    continue
+
+                if not self.mgmt_actor.demand_reservation(reservation=reservation):
+                    raise OrchestratorException(f"Could not demand resources: {self.mgmt_actor.get_last_error()}")
+                self.logger.debug(f"Reservation #{reservation.get_reservation_id()} demanded successfully")
+
+            for r in controller_slice.computed_l3_reservations:
+                res_status_update = ReservationStatusUpdate(logger=self.logger)
+                self.sut.add_active_status_watch(watch=ID(uid=r.get_reservation_id()),
+                                                 callback=res_status_update)
+        except Exception as e:
+            self.logger.error(traceback.format_exc())
+            self.logger.error("Unable to get orchestrator or demand reservation: {}".format(e))
+        finally:
+            controller_slice.unlock()

--- a/fabric_cf/orchestrator/docker-compose.yml
+++ b/fabric_cf/orchestrator/docker-compose.yml
@@ -67,7 +67,7 @@ services:
     build:
       context: ../../../
       dockerfile: Dockerfile-orchestrator
-    image: orchestrator:1.2
+    image: orchestrator:1.3
     container_name: orchestrator
     restart: always
     depends_on:


### PR DESCRIPTION
- Create Response Time (https://github.com/fabric-testbed/ControlFramework/issues/186)
  - Modified the create slice to just create reservations and respond back to the user
  - Created Reservations are then demanded by a new thread Slice_Demand_Thread. 
  - This helps HTTP API to be responded without waiting for Orchestrator to push reservations to the policy etc.
- Storage Support (https://github.com/fabric-testbed/ControlFramework/issues/187)
   - By pass Broker validation to always allow Storage Slivers 
