### PR TITLE
copy component label allocations to labels after broker allocation

### DIFF
--- a/fabric_cf/actor/core/policy/network_node_inventory.py
+++ b/fabric_cf/actor/core/policy/network_node_inventory.py
@@ -269,6 +269,8 @@ class NetworkNodeInventory(InventoryForType):
 
         node_map = tuple([graph_id, available_component.node_id])
         requested_component.set_node_map(node_map=node_map)
+        if requested_component.labels is None:
+            requested_component.labels = Labels.update(lab=requested_component.get_label_allocations())
 
         return requested_component
 


### PR DESCRIPTION
https://github.com/fabric-testbed/ControlFramework/issues/208

On a ticketed sliver, copy the allocated BDF in labels as well as label_allocations
AM uses the value from labels.bdf to attach/detac
AM updates label_allocations.bdf to the PCI address from inside the VM