### PR TITLE
Retry kafka messages on KAFKA Local Timeout error

### DIFF
--- a/fabric_cf/actor/boot/configuration.py
+++ b/fabric_cf/actor/boot/configuration.py
@@ -455,6 +455,9 @@ class Configuration:
 
         return None
 
+    def get_rpc_retries(self) -> int:
+        return self.global_config.runtime.get(Constants.PROPERTY_CONF_RPC_RETRIES, 5)
+
     def get_kafka_key_schema_location(self) -> str or None:
         return self.global_config.runtime.get(Constants.PROPERTY_CONF_KAFKA_KEY_SCHEMA, None)
 

--- a/fabric_cf/actor/core/common/constants.py
+++ b/fabric_cf/actor/core/common/constants.py
@@ -133,6 +133,7 @@ class Constants:
     PROPERTY_CONF_CONTROLLER_REST_PORT = "orchestrator.rest.port"
     PROPERTY_CONF_CONTROLLER_CREATE_WAIT_TIME = "orchestrator.create.wait.time"
     PROPERTY_CONF_RPC_REQUEST_TIMEOUT_SECONDS = "rpc.request.timeout.seconds"
+    PROPERTY_CONF_RPC_RETRIES = "rpc.retries"
 
     PROPERTY_SUBSTRATE_FILE = "substrate.file"
     PROPERTY_AGGREGATE_RESOURCE_MODEL = "AggregateResourceModel"

--- a/fabric_cf/actor/core/container/globals.py
+++ b/fabric_cf/actor/core/container/globals.py
@@ -324,7 +324,8 @@ class Globals:
 
         from fabric_cf.actor.core.container.rpc_producer import RPCProducer
         producer = RPCProducer(producer_conf=conf, key_schema_location=key_schema_file,
-                               value_schema_location=value_schema_file, logger=self.get_logger(), actor=actor)
+                               value_schema_location=value_schema_file, logger=self.get_logger(),
+                               actor=actor, retries=self.config.get_rpc_retries())
         return producer
 
     def get_simple_kafka_producer(self):

--- a/fabric_cf/actor/core/kernel/retry_rpc.py
+++ b/fabric_cf/actor/core/kernel/retry_rpc.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+# MIT License
+#
+# Copyright (c) 2020 FABRIC Testbed
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+#
+# Author: Komal Thareja (kthare10@renci.org)
+from fabric_mb.message_bus.messages.abc_message_avro import AbcMessageAvro
+
+
+class RetryRPC:
+    """
+    Represents Retry RPC Message
+    """
+    def __init__(self, *, avro_message: AbcMessageAvro, kafka_topic: str):
+        self.avro_message = avro_message
+        self.kafka_topic = kafka_topic
+
+    def message(self) -> AbcMessageAvro:
+        return self.avro_message
+
+    def topic(self) -> str:
+        return self.kafka_topic

--- a/fabric_cf/actor/core/kernel/retry_rpc_event.py
+++ b/fabric_cf/actor/core/kernel/retry_rpc_event.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+# MIT License
+#
+# Copyright (c) 2020 FABRIC Testbed
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+#
+# Author: Komal Thareja (kthare10@renci.org)
+from __future__ import annotations
+from typing import TYPE_CHECKING
+
+
+from fabric_cf.actor.core.apis.abc_actor_event import ABCActorEvent
+
+if TYPE_CHECKING:
+    from fabric_cf.actor.core.apis.abc_actor_mixin import ABCActorMixin
+    from fabric_cf.actor.core.kernel.retry_rpc import RetryRPC
+
+
+class RetryRPCEvent(ABCActorEvent):
+    """
+    Represents Retry RPC Event
+    """
+    def __init__(self, *, actor: ABCActorMixin, rpc: RetryRPC):
+        self.actor = actor
+        self.rpc = rpc
+
+    def process(self):
+        """
+        Process Retry RPC Event
+        """
+        from fabric_cf.actor.core.kernel.rpc_manager_singleton import RPCManagerSingleton
+        RPCManagerSingleton.get().retry_rpc(rpc=self.rpc)

--- a/fabric_cf/authority/config.site.am.geni.yaml
+++ b/fabric_cf/authority/config.site.am.geni.yaml
@@ -47,6 +47,7 @@ runtime:
   kafka.request.timeout.ms: 120000
   rpc.request.timeout.seconds: 1200
   message.max.bytes: 2097176
+  rpc.retries: 5
 
 logging:
   ## The directory in which actor should create log files.

--- a/fabric_cf/authority/config.site.am.yaml
+++ b/fabric_cf/authority/config.site.am.yaml
@@ -47,6 +47,7 @@ runtime:
   kafka.request.timeout.ms: 120000
   rpc.request.timeout.seconds: 1200
   message.max.bytes: 1048588
+  rpc.retries: 5
 
 logging:
   ## The directory in which actor should create log files.

--- a/fabric_cf/authority/test/test-netam.yaml
+++ b/fabric_cf/authority/test/test-netam.yaml
@@ -47,6 +47,7 @@ runtime:
   kafka.request.timeout.ms: 120000
   rpc.request.timeout.seconds: 900
   message.max.bytes: 1048588
+  rpc.retries: 5
 
 logging:
   ## The directory in which actor should create log files.

--- a/fabric_cf/authority/test/test.geni.yaml
+++ b/fabric_cf/authority/test/test.geni.yaml
@@ -47,6 +47,7 @@ runtime:
   kafka.request.timeout.ms: 120000
   rpc.request.timeout.seconds: 900
   message.max.bytes: 2097176
+  rpc.retries: 5
 
 logging:
   ## The directory in which actor should create log files.

--- a/fabric_cf/authority/test/test.yaml
+++ b/fabric_cf/authority/test/test.yaml
@@ -47,6 +47,7 @@ runtime:
   kafka.request.timeout.ms: 120000
   rpc.request.timeout.seconds: 900
   message.max.bytes: 1048588
+  rpc.retries: 5
 
 logging:
   ## The directory in which actor should create log files.

--- a/fabric_cf/broker/config.broker.yaml
+++ b/fabric_cf/broker/config.broker.yaml
@@ -47,6 +47,7 @@ runtime:
   kafka.request.timeout.ms: 120000
   rpc.request.timeout.seconds: 1200
   message.max.bytes: 1048588
+  rpc.retries: 5
 
 logging:
   ## The directory in which actor should create log files.

--- a/fabric_cf/broker/test/test.yaml
+++ b/fabric_cf/broker/test/test.yaml
@@ -47,6 +47,7 @@ runtime:
   kafka.request.timeout.ms: 120000
   rpc.request.timeout.seconds: 900
   message.max.bytes: 1048588
+  rpc.retries: 5
 
 logging:
   ## The directory in which actor should create log files.

--- a/fabric_cf/orchestrator/config.orchestrator.yaml
+++ b/fabric_cf/orchestrator/config.orchestrator.yaml
@@ -49,6 +49,7 @@ runtime:
   rpc.request.timeout.seconds: 1200
   maint.project.id: 990d8a8b-7e50-4d13-a3be-0f133ffa8653
   message.max.bytes: 1048588
+  rpc.retries: 5
 
 logging:
   ## The directory in which actor should create log files.

--- a/fabric_cf/orchestrator/test/test.yaml
+++ b/fabric_cf/orchestrator/test/test.yaml
@@ -44,6 +44,7 @@ runtime:
   rpc.request.timeout.seconds: 900
   maint.project.id: 10c0094a-abaf-4ef9-a532-2be53e2a896b
   message.max.bytes: 1048588
+  rpc.retries: 5
 
 logging:
   ## The directory in which actor should create log files.

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,5 +8,5 @@ connexion
 swagger-ui-bundle
 fabric_fss_utils==1.4.0
 PyYAML
-fabric-message-bus==1.4.0b6
+fabric-message-bus==1.4.0b7
 fabric-fim==1.4.0


### PR DESCRIPTION
Kafka Producer throws an error `Kafka Local Timeout` when the message could not be written to the topic.
Since the message never makes it out of the producer, any of the Kafka TCP retries do not help.

Added application level retries to handle this failure more gracefully.

This error is observed for the messages written by the AMs on the Orchestrator topic. This is because several producers (AMs) are trying to write to a single topic Orchestrator. This fix only improves the failure handling.

The topic contention would be addressed in a separate PR where Orchestrator listens on multiple topics. AMs are then split across the multiple topics to reduce the contention.

#231 