### PR TITLE
ignore update lease response for a duplicate redeem from AM

### DIFF
--- a/fabric_cf/actor/core/common/constants.py
+++ b/fabric_cf/actor/core/common/constants.py
@@ -247,9 +247,9 @@ class Constants:
     NOT_IMPLEMENTED = "Not Implemented"
 
     UNSUPPORTED_RESOURCE_TYPE = "Unsupported resource type: {}"
-
     CLOSURE_BY_TICKET_REVIEW_POLICY = "TicketReviewPolicy: Closing reservation due to failure in slice"
     MAINTENANCE_MODE_ERROR = "Testbed is in maintenance mode: Create, Modify and Renew Slice(s) are disabled!"
+    PENDING_OPERATION_ERROR = "Reservation has a pending operation"
 
     CLAIMS_SUB = "sub"
     CLAIMS_EMAIL = "email"

--- a/fabric_cf/actor/core/kernel/kernel.py
+++ b/fabric_cf/actor/core/kernel/kernel.py
@@ -358,7 +358,7 @@ class Kernel:
             real.lock()
             # check for a pending operation: we cannot service the extend if there is another operation in progress.
             if real.get_pending_state() != ReservationPendingStates.None_:
-                raise KernelException(f"Reservation has a pending operation")
+                raise KernelException(Constants.PENDING_OPERATION_ERROR)
 
             if isinstance(real, ReservationClient) and dependencies is not None:
                 real.redeem_predecessors.clear()

--- a/fabric_cf/actor/core/kernel/reservation.py
+++ b/fabric_cf/actor/core/kernel/reservation.py
@@ -33,6 +33,7 @@ from datetime import datetime, timezone
 from fim.slivers.capacities_labels import ReservationInfo
 
 from fabric_cf.actor.core.apis.abc_reservation_mixin import ABCReservationMixin, ReservationCategory
+from fabric_cf.actor.core.common.constants import Constants
 from fabric_cf.actor.core.common.event_logger import EventLogger
 from fabric_cf.actor.core.common.exceptions import ReservationException
 from fabric_cf.actor.core.kernel.reservation_states import ReservationStates, ReservationPendingStates, JoinState
@@ -477,7 +478,7 @@ class Reservation(ABCReservationMixin):
         @throws Exception if the reservation has a pending operation.
         """
         if self.pending_state != ReservationPendingStates.None_:
-            self.error(err="reservation has a pending operation")
+            self.error(err=Constants.PENDING_OPERATION_ERROR)
 
     def prepare_probe(self):
         return

--- a/fabric_cf/actor/core/kernel/reservation_client.py
+++ b/fabric_cf/actor/core/kernel/reservation_client.py
@@ -319,6 +319,9 @@ class ReservationClient(Reservation, ABCControllerReservation):
         # Alternative: could transition to (state, None) to allow retry of the
         # redeem/extend by a higher level.
         if update_data.failed:
+            if self.is_redeeming() and Constants.PENDING_OPERATION_ERROR in update_data.get_message():
+                self.logger.info("Ignoring Update Lease, likely duplicate redeem received at the AM")
+                return True
             self.fail(message=f"failed lease update- {update_data.get_message()}",
                       sliver=incoming.get_resources().get_sliver())
             #self.transition(prefix="failed lease update", state=ReservationStates.Failed,


### PR DESCRIPTION
#253 
Issue: Redeem message is being received twice at the AM occasionally due to Kafka failures.
Results in second redeem being rejected with error 'Reservation has pending operation' in UpdateLease
However, Orchestrator treats this as a failure and closes the reservation and triggers close at the broker. But the VM comes up later at the AM for the first Redeem and results in a leaked VM.

Fix:
Modified the handling to ignore 'Reservation has pending operation' in Redeeming state