### PR TITLE
Performance Improvements

### DIFF
--- a/fabric_cf/actor/boot/configuration_processor.py
+++ b/fabric_cf/actor/boot/configuration_processor.py
@@ -459,7 +459,6 @@ class ConfigurationProcessor:
 
         container = ManagementUtils.connect(caller=self.actor.get_identity())
         mgmt_actor = container.get_actor(guid=actor_guid)
-        self.logger.info(f"Management Actor: {mgmt_actor} === {type(mgmt_actor)}")
         if mgmt_actor is None and container.get_last_error() is not None:
             self.logger.error(container.get_last_error())
 

--- a/fabric_cf/actor/core/apis/abc_database.py
+++ b/fabric_cf/actor/core/apis/abc_database.py
@@ -159,7 +159,8 @@ class ABCDatabase(ABC):
     @abstractmethod
     def get_reservations(self, *, slice_id: ID = None, graph_node_id: str = None, project_id: str = None,
                          email: str = None, oidc_sub: str = None, rid: ID = None,
-                         states: list[int] = None, site: str = None, rsv_type: str = None) -> List[ABCReservationMixin]:
+                         states: list[int] = None, site: str = None,
+                         rsv_type: list[str] = None) -> List[ABCReservationMixin]:
         """
         Retrieves the reservations.
 

--- a/fabric_cf/actor/core/container/db/container_database.py
+++ b/fabric_cf/actor/core/container/db/container_database.py
@@ -143,10 +143,10 @@ class ContainerDatabase(ABCContainerDatabase):
             self.logger.error(e)
         return result
 
-    def get_actor(self, *, actor_name: str) -> dict:
+    def get_actor(self, *, actor_name: str) -> ABCActorMixin or None:
         """
         Get Actor
-        @param name actor name
+        @param actor_name actor name
         @return actor
         """
         result = None
@@ -159,7 +159,7 @@ class ContainerDatabase(ABCContainerDatabase):
             self.logger.error(e)
         return result
 
-    def get_actor_id(self, *, actor_name: str) -> dict:
+    def get_actor_id(self, *, actor_name: str) -> int or None:
         """
         Get Actor
         @param name actor name
@@ -200,7 +200,7 @@ class ContainerDatabase(ABCContainerDatabase):
         """
         self.db.add_miscellaneous(name=self.PropertyContainer, properties=properties)
 
-    def get_container_properties(self) -> dict:
+    def get_container_properties(self) -> dict or None:
         """
         Get Container Properties
         @return properties

--- a/fabric_cf/actor/core/core/actor.py
+++ b/fabric_cf/actor/core/core/actor.py
@@ -40,7 +40,7 @@ from fabric_cf.actor.core.apis.abc_reservation_mixin import ABCReservationMixin
 from fabric_cf.actor.core.apis.abc_slice import ABCSlice
 from fabric_cf.actor.core.common.exceptions import ActorException
 from fabric_cf.actor.core.container.message_service import MessageService
-from fabric_cf.actor.core.core.event_processor import TickEvent, EventType, EventProcessor, CloseEvent, RedeemEvent
+from fabric_cf.actor.core.core.event_processor import TickEvent, EventType, EventProcessor
 from fabric_cf.actor.core.kernel.failed_rpc import FailedRPC
 from fabric_cf.actor.core.kernel.kernel_wrapper import KernelWrapper
 from fabric_cf.actor.core.kernel.rpc_manager_singleton import RPCManagerSingleton
@@ -188,10 +188,6 @@ class ActorMixin(ABCActorMixin):
     def external_tick(self, *, cycle: int):
         self.logger.info("External Tick start cycle: {}".format(cycle))
         self.queue_event(incoming=TickEvent(actor=self, cycle=cycle))
-        if self.get_type() == ActorType.Orchestrator:
-            self.queue_event(incoming=CloseEvent(actor=self))
-            self.queue_event(incoming=RedeemEvent(actor=self))
-
         self.logger.info("External Tick end cycle: {}".format(cycle))
 
     def actor_tick(self, *, cycle: int):
@@ -850,10 +846,6 @@ class ActorMixin(ABCActorMixin):
         try:
             if isinstance(incoming, TickEvent):
                 self.event_processors[EventType.TickEvent].enqueue(incoming=incoming)
-            elif isinstance(incoming, CloseEvent):
-                self.event_processors[EventType.CloseEvent].enqueue(incoming=incoming)
-            elif isinstance(incoming, RedeemEvent):
-                self.event_processors[EventType.RedeemEvent].enqueue(incoming=incoming)
             else:
                 self.event_processors[EventType.InterActorEvent].enqueue(incoming=incoming)
             self.logger.debug("Added event to event queue {}".format(incoming.__class__.__name__))

--- a/fabric_cf/actor/core/core/actor.py
+++ b/fabric_cf/actor/core/core/actor.py
@@ -188,6 +188,10 @@ class ActorMixin(ABCActorMixin):
     def external_tick(self, *, cycle: int):
         self.logger.info("External Tick start cycle: {}".format(cycle))
         self.queue_event(incoming=TickEvent(actor=self, cycle=cycle))
+        if self.get_type() == ActorType.Orchestrator:
+            self.queue_event(incoming=CloseEvent(actor=self))
+            self.queue_event(incoming=RedeemEvent(actor=self))
+
         self.logger.info("External Tick end cycle: {}".format(cycle))
 
     def actor_tick(self, *, cycle: int):

--- a/fabric_cf/actor/core/core/actor.py
+++ b/fabric_cf/actor/core/core/actor.py
@@ -153,10 +153,10 @@ class ActorMixin(ABCActorMixin):
     def close(self, *, reservation: ABCReservationMixin):
         if reservation is not None:
             if not self.recovered:
-                self.logger.debug("Adding reservation: {} to closing list".format(reservation.get_reservation_id()))
+                #self.logger.debug("Adding reservation: {} to closing list".format(reservation.get_reservation_id()))
                 self.closing.add(reservation=reservation)
             else:
-                self.logger.debug("Closing reservation: {}".format(reservation.get_reservation_id()))
+                #self.logger.debug("Closing reservation: {}".format(reservation.get_reservation_id()))
                 self.wrapper.close(rid=reservation.get_reservation_id())
 
     def close_slice_reservations(self, *, slice_id: ID):
@@ -165,7 +165,7 @@ class ActorMixin(ABCActorMixin):
     def close_reservations(self, *, reservations: ReservationSet):
         for reservation in reservations.reservations.values():
             try:
-                self.logger.debug("Closing reservation: {}".format(reservation.get_reservation_id()))
+                #self.logger.debug("Closing reservation: {}".format(reservation.get_reservation_id()))
                 self.close(reservation=reservation)
             except Exception as e:
                 self.logger.error(traceback.format_exc())

--- a/fabric_cf/actor/core/core/actor.py
+++ b/fabric_cf/actor/core/core/actor.py
@@ -28,7 +28,7 @@ import traceback
 from typing import List, Dict
 
 from fabric_cf.actor.boot.configuration import ActorConfig
-from fabric_cf.actor.core.apis.abc_delegation import ABCDelegation, DelegationState
+from fabric_cf.actor.core.apis.abc_delegation import ABCDelegation
 from fabric_cf.actor.core.apis.abc_policy import ABCPolicy
 from fabric_cf.actor.core.apis.abc_timer_task import ABCTimerTask
 from fabric_cf.actor.core.apis.abc_actor_mixin import ABCActorMixin, ActorType
@@ -40,8 +40,7 @@ from fabric_cf.actor.core.apis.abc_reservation_mixin import ABCReservationMixin
 from fabric_cf.actor.core.apis.abc_slice import ABCSlice
 from fabric_cf.actor.core.common.exceptions import ActorException
 from fabric_cf.actor.core.container.message_service import MessageService
-from fabric_cf.actor.core.core.event_processor import TickEvent, EventType, EventProcessor
-from fabric_cf.actor.core.delegation.delegation_factory import DelegationFactory
+from fabric_cf.actor.core.core.event_processor import TickEvent, EventType, EventProcessor, CloseEvent, RedeemEvent
 from fabric_cf.actor.core.kernel.failed_rpc import FailedRPC
 from fabric_cf.actor.core.kernel.kernel_wrapper import KernelWrapper
 from fabric_cf.actor.core.kernel.rpc_manager_singleton import RPCManagerSingleton
@@ -847,6 +846,10 @@ class ActorMixin(ABCActorMixin):
         try:
             if isinstance(incoming, TickEvent):
                 self.event_processors[EventType.TickEvent].enqueue(incoming=incoming)
+            elif isinstance(incoming, CloseEvent):
+                self.event_processors[EventType.CloseEvent].enqueue(incoming=incoming)
+            elif isinstance(incoming, RedeemEvent):
+                self.event_processors[EventType.RedeemEvent].enqueue(incoming=incoming)
             else:
                 self.event_processors[EventType.InterActorEvent].enqueue(incoming=incoming)
             self.logger.debug("Added event to event queue {}".format(incoming.__class__.__name__))

--- a/fabric_cf/actor/core/core/actor.py
+++ b/fabric_cf/actor/core/core/actor.py
@@ -855,6 +855,7 @@ class ActorMixin(ABCActorMixin):
             self.logger.debug("Added event to event queue {}".format(incoming.__class__.__name__))
         except Exception as e:
             self.logger.error(f"Failed to queue event: {incoming.__class__.__name__} e: {e}")
+            self.logger.error(traceback.format_exc())
 
     def queue_event_sync(self, *, incoming: ABCActorEvent):
         """

--- a/fabric_cf/actor/core/core/controller.py
+++ b/fabric_cf/actor/core/core/controller.py
@@ -193,7 +193,7 @@ class Controller(ActorMixin, ABCController):
         rset = self.policy.get_closing(cycle=self.current_cycle)
 
         if rset is not None and rset.size() > 0:
-            self.logger.debug("SlottedSM close expiring for cycle {} expiring {}".format(self.current_cycle, rset))
+            #self.logger.debug("SlottedSM close expiring for cycle {} expiring {}".format(self.current_cycle, rset))
             self.close_reservations(reservations=rset)
 
     def demand(self, *, rid: ID):
@@ -280,8 +280,7 @@ class Controller(ActorMixin, ABCController):
         rset = self.policy.get_redeeming(cycle=self.current_cycle)
 
         if rset is not None and rset.size() > 0:
-            self.logger.debug("SlottedController redeem for cycle {} redeeming {}".format(self.current_cycle, rset))
-
+            #self.logger.debug("SlottedController redeem for cycle {} redeeming {}".format(self.current_cycle, rset))
             self.redeem_reservations(rset=rset)
 
     def redeem(self, *, reservation: ABCControllerReservation):

--- a/fabric_cf/actor/core/core/controller.py
+++ b/fabric_cf/actor/core/core/controller.py
@@ -291,7 +291,7 @@ class Controller(ActorMixin, ABCController):
             self.wrapper.redeem(reservation=reservation)
 
     def redeem_reservations(self, *, rset: ReservationSet):
-        for reservation in rset.values():
+        for reservation in rset.reservations.values():
             try:
                 if isinstance(reservation, ABCControllerReservation):
                     self.redeem(reservation=reservation)

--- a/fabric_cf/actor/core/core/controller.py
+++ b/fabric_cf/actor/core/core/controller.py
@@ -195,9 +195,7 @@ class Controller(ActorMixin, ABCController):
 
         if rset is not None and rset.size() > 0:
             #self.logger.debug("SlottedSM close expiring for cycle {} expiring {}".format(self.current_cycle, rset))
-            #self.close_reservations(reservations=rset)
-            event = CloseEvent(actor=self, reservations=rset)
-            self.queue_event(incoming=event)
+            self.close_reservations(reservations=rset)
 
     def demand(self, *, rid: ID):
         if rid is None:
@@ -284,9 +282,7 @@ class Controller(ActorMixin, ABCController):
 
         if rset is not None and rset.size() > 0:
             #self.logger.debug("SlottedController redeem for cycle {} redeeming {}".format(self.current_cycle, rset))
-            #self.redeem_reservations(rset=rset)
-            event = RedeemEvent(actor=self, reservations=rset)
-            self.queue_event(incoming=event)
+            self.redeem_reservations(rset=rset)
 
     def redeem(self, *, reservation: ABCControllerReservation):
         if not self.recovered:
@@ -322,8 +318,8 @@ class Controller(ActorMixin, ABCController):
                 self.logger.error("Could not ticket for #{} e: {}".format(reservation.get_reservation_id(), e))
 
     def tick_handler(self):
-        self.close_expiring()
-        self.process_redeeming()
+        #self.close_expiring()
+        #self.process_redeeming()
         self.bid()
 
     def update_lease(self, *, reservation: ABCReservationMixin, update_data, caller: AuthToken):

--- a/fabric_cf/actor/core/core/controller.py
+++ b/fabric_cf/actor/core/core/controller.py
@@ -60,6 +60,8 @@ class Controller(ActorMixin, ABCController):
     Implements Controller
     """
     saved_extended_renewable = ReservationSet()
+    SUPPORTED_EVENTS = [EventType.TickEvent, EventType.InterActorEvent, EventType.SyncEvent,
+                        EventType.CloseEvent, EventType.RedeemEvent]
 
     def __init__(self, *, identity: AuthToken = None, clock: ActorClock = None):
         super().__init__(auth=identity, clock=clock)
@@ -78,8 +80,6 @@ class Controller(ActorMixin, ABCController):
         # initialization status
         self.initialized = False
         self.type = ActorType.Orchestrator
-        self.SUPPORTED_EVENTS = [EventType.TickEvent, EventType.InterActorEvent, EventType.SyncEvent,
-                                 EventType.CloseEvent, EventType.RedeemEvent]
         self.asm_update_thread = AsmUpdateThread(name=f"{self.get_name()}-asm-thread", logger=self.logger)
 
     def __getstate__(self):

--- a/fabric_cf/actor/core/core/controller.py
+++ b/fabric_cf/actor/core/core/controller.py
@@ -193,7 +193,7 @@ class Controller(ActorMixin, ABCController):
         rset = self.policy.get_closing(cycle=self.current_cycle)
 
         if rset is not None and rset.size() > 0:
-            self.logger.info("SlottedSM close expiring for cycle {} expiring {}".format(self.current_cycle, rset))
+            self.logger.debug("SlottedSM close expiring for cycle {} expiring {}".format(self.current_cycle, rset))
             self.close_reservations(reservations=rset)
 
     def demand(self, *, rid: ID):
@@ -280,7 +280,7 @@ class Controller(ActorMixin, ABCController):
         rset = self.policy.get_redeeming(cycle=self.current_cycle)
 
         if rset is not None and rset.size() > 0:
-            self.logger.info("SlottedController redeem for cycle {} redeeming {}".format(self.current_cycle, rset))
+            self.logger.debug("SlottedController redeem for cycle {} redeeming {}".format(self.current_cycle, rset))
 
             self.redeem_reservations(rset=rset)
 

--- a/fabric_cf/actor/core/core/controller.py
+++ b/fabric_cf/actor/core/core/controller.py
@@ -25,8 +25,6 @@
 # Author: Komal Thareja (kthare10@renci.org)
 from __future__ import annotations
 
-import queue
-import threading
 import traceback
 from typing import TYPE_CHECKING
 
@@ -37,6 +35,7 @@ from fabric_cf.actor.core.apis.abc_actor_mixin import ActorType
 from fabric_cf.actor.core.apis.abc_delegation import ABCDelegation
 from fabric_cf.actor.core.apis.abc_reservation_mixin import ABCReservationMixin
 from fabric_cf.actor.core.common.exceptions import ControllerException
+from fabric_cf.actor.core.core.event_processor import EventType
 from fabric_cf.actor.core.manage.controller_management_object import ControllerManagementObject
 from fabric_cf.actor.core.manage.kafka.services.kafka_controller_service import KafkaControllerService
 from fabric_cf.actor.core.proxies.kafka.services.controller_service import ControllerService
@@ -79,6 +78,8 @@ class Controller(ActorMixin, ABCController):
         # initialization status
         self.initialized = False
         self.type = ActorType.Orchestrator
+        self.SUPPORTED_EVENTS = [EventType.TickEvent, EventType.InterActorEvent, EventType.SyncEvent,
+                                 EventType.CloseEvent, EventType.RedeemEvent]
         self.asm_update_thread = AsmUpdateThread(name=f"{self.get_name()}-asm-thread", logger=self.logger)
 
     def __getstate__(self):

--- a/fabric_cf/actor/core/core/controller.py
+++ b/fabric_cf/actor/core/core/controller.py
@@ -294,7 +294,7 @@ class Controller(ActorMixin, ABCController):
             self.redeem_reservations(rset=rset)
         diff = int(time.time() - begin)
         if diff > 0:
-            self.logger.info(f"Event close_expiring TIME: {diff}")
+            self.logger.info(f"Event redeeming TIME: {diff}")
 
     def redeem(self, *, reservation: ABCControllerReservation):
         if not self.recovered:

--- a/fabric_cf/actor/core/core/controller.py
+++ b/fabric_cf/actor/core/core/controller.py
@@ -35,7 +35,7 @@ from fabric_cf.actor.core.apis.abc_actor_mixin import ActorType
 from fabric_cf.actor.core.apis.abc_delegation import ABCDelegation
 from fabric_cf.actor.core.apis.abc_reservation_mixin import ABCReservationMixin
 from fabric_cf.actor.core.common.exceptions import ControllerException
-from fabric_cf.actor.core.core.event_processor import EventType
+from fabric_cf.actor.core.core.event_processor import EventType, CloseEvent, RedeemEvent
 from fabric_cf.actor.core.manage.controller_management_object import ControllerManagementObject
 from fabric_cf.actor.core.manage.kafka.services.kafka_controller_service import KafkaControllerService
 from fabric_cf.actor.core.proxies.kafka.services.controller_service import ControllerService
@@ -195,7 +195,9 @@ class Controller(ActorMixin, ABCController):
 
         if rset is not None and rset.size() > 0:
             #self.logger.debug("SlottedSM close expiring for cycle {} expiring {}".format(self.current_cycle, rset))
-            self.close_reservations(reservations=rset)
+            #self.close_reservations(reservations=rset)
+            event = CloseEvent(actor=self, reservations=rset)
+            self.queue_event(incoming=event)
 
     def demand(self, *, rid: ID):
         if rid is None:
@@ -282,7 +284,9 @@ class Controller(ActorMixin, ABCController):
 
         if rset is not None and rset.size() > 0:
             #self.logger.debug("SlottedController redeem for cycle {} redeeming {}".format(self.current_cycle, rset))
-            self.redeem_reservations(rset=rset)
+            #self.redeem_reservations(rset=rset)
+            event = RedeemEvent(actor=self, reservations=rset)
+            self.queue_event(incoming=event)
 
     def redeem(self, *, reservation: ABCControllerReservation):
         if not self.recovered:

--- a/fabric_cf/actor/core/core/controller.py
+++ b/fabric_cf/actor/core/core/controller.py
@@ -26,6 +26,7 @@
 from __future__ import annotations
 
 import concurrent.futures
+import time
 import traceback
 from typing import TYPE_CHECKING
 
@@ -194,11 +195,15 @@ class Controller(ActorMixin, ABCController):
         Issues close requests on all reservations scheduled for closing on the
         current cycle
         """
+        begin = time.time()
         rset = self.policy.get_closing(cycle=self.current_cycle)
 
         if rset is not None and rset.size() > 0:
             #self.logger.debug("SlottedSM close expiring for cycle {} expiring {}".format(self.current_cycle, rset))
             self.close_reservations(reservations=rset)
+        diff = int(time.time() - begin)
+        if diff > 0:
+            self.logger.info(f"Event close_expiring TIME: {diff}")
 
     def demand(self, *, rid: ID):
         if rid is None:
@@ -281,11 +286,15 @@ class Controller(ActorMixin, ABCController):
         """
         Issue redeem requests on all reservations scheduled for redeeming on the current cycle
         """
+        begin = time.time()
         rset = self.policy.get_redeeming(cycle=self.current_cycle)
 
         if rset is not None and rset.size() > 0:
             #self.logger.debug("SlottedController redeem for cycle {} redeeming {}".format(self.current_cycle, rset))
             self.redeem_reservations(rset=rset)
+        diff = int(time.time() - begin)
+        if diff > 0:
+            self.logger.info(f"Event close_expiring TIME: {diff}")
 
     def redeem(self, *, reservation: ABCControllerReservation):
         if not self.recovered:

--- a/fabric_cf/actor/core/core/event_processor.py
+++ b/fabric_cf/actor/core/core/event_processor.py
@@ -34,12 +34,15 @@ from fabric_cf.actor.core.apis.abc_actor_event import ABCActorEvent
 from fabric_cf.actor.core.apis.abc_actor_runnable import ABCActorRunnable
 from fabric_cf.actor.core.apis.abc_timer_task import ABCTimerTask
 from fabric_cf.actor.core.util.iterable_queue import IterableQueue
+from fabric_cf.actor.core.util.reservation_set import ReservationSet
 
 
 class EventType(enum.Enum):
     TickEvent = enum.auto(),
     InterActorEvent = enum.auto(),
     SyncEvent = enum.auto()
+    CloseEvent = enum.auto
+    RedeemEvent = enum.auto
 
     def __str__(self):
         return self.name
@@ -64,6 +67,24 @@ class ExecutionStatus:
         Mark as done
         """
         self.done = True
+
+
+class RedeemEvent(ABCActorEvent):
+    def __init__(self, *, actor, reservations: ReservationSet):
+        self.actor = actor
+        self.reservations = reservations
+
+    def process(self):
+        self.actor.redeem_reservations(reservations=self.reservations)
+
+
+class CloseEvent(ABCActorEvent):
+    def __init__(self, *, actor, reservations: ReservationSet):
+        self.actor = actor
+        self.reservations = reservations
+
+    def process(self):
+        self.actor.close_reservations(reservations=self.reservations)
 
 
 class TickEvent(ABCActorEvent):

--- a/fabric_cf/actor/core/core/event_processor.py
+++ b/fabric_cf/actor/core/core/event_processor.py
@@ -34,15 +34,12 @@ from fabric_cf.actor.core.apis.abc_actor_event import ABCActorEvent
 from fabric_cf.actor.core.apis.abc_actor_runnable import ABCActorRunnable
 from fabric_cf.actor.core.apis.abc_timer_task import ABCTimerTask
 from fabric_cf.actor.core.util.iterable_queue import IterableQueue
-from fabric_cf.actor.core.util.reservation_set import ReservationSet
 
 
 class EventType(enum.Enum):
     TickEvent = enum.auto(),
     InterActorEvent = enum.auto(),
     SyncEvent = enum.auto()
-    CloseEvent = enum.auto()
-    RedeemEvent = enum.auto()
 
     def __str__(self):
         return self.name
@@ -67,22 +64,6 @@ class ExecutionStatus:
         Mark as done
         """
         self.done = True
-
-
-class RedeemEvent(ABCActorEvent):
-    def __init__(self, *, actor):
-        self.actor = actor
-
-    def process(self):
-        self.actor.process_redeeming()
-
-
-class CloseEvent(ABCActorEvent):
-    def __init__(self, *, actor):
-        self.actor = actor
-
-    def process(self):
-        self.actor.close_expiring()
 
 
 class TickEvent(ABCActorEvent):

--- a/fabric_cf/actor/core/core/event_processor.py
+++ b/fabric_cf/actor/core/core/event_processor.py
@@ -70,21 +70,19 @@ class ExecutionStatus:
 
 
 class RedeemEvent(ABCActorEvent):
-    def __init__(self, *, actor, reservations: ReservationSet):
+    def __init__(self, *, actor):
         self.actor = actor
-        self.reservations = reservations
 
     def process(self):
-        self.actor.redeem_reservations(rset=self.reservations)
+        self.actor.process_redeeming()
 
 
 class CloseEvent(ABCActorEvent):
-    def __init__(self, *, actor, reservations: ReservationSet):
+    def __init__(self, *, actor):
         self.actor = actor
-        self.reservations = reservations
 
     def process(self):
-        self.actor.close_reservations(reservations=self.reservations)
+        self.actor.close_expiring()
 
 
 class TickEvent(ABCActorEvent):

--- a/fabric_cf/actor/core/core/event_processor.py
+++ b/fabric_cf/actor/core/core/event_processor.py
@@ -41,8 +41,8 @@ class EventType(enum.Enum):
     TickEvent = enum.auto(),
     InterActorEvent = enum.auto(),
     SyncEvent = enum.auto()
-    CloseEvent = enum.auto
-    RedeemEvent = enum.auto
+    CloseEvent = enum.auto()
+    RedeemEvent = enum.auto()
 
     def __str__(self):
         return self.name

--- a/fabric_cf/actor/core/core/event_processor.py
+++ b/fabric_cf/actor/core/core/event_processor.py
@@ -226,7 +226,9 @@ class EventProcessor:
                     event.execute()
                 else:
                     event.process()
-                self.logger.info(f"Event {event.__class__.__name__} TIME: {time.time() - begin:.0f}")
+                diff = int(time.time() - begin)
+                if diff > 0:
+                    self.logger.info(f"Event {event.__class__.__name__} TIME: {diff}")
             except Exception as e:
                 self.logger.error(f"Error while processing event {type(event)}, {e}")
                 self.logger.error(traceback.format_exc())

--- a/fabric_cf/actor/core/core/event_processor.py
+++ b/fabric_cf/actor/core/core/event_processor.py
@@ -75,7 +75,7 @@ class RedeemEvent(ABCActorEvent):
         self.reservations = reservations
 
     def process(self):
-        self.actor.redeem_reservations(reservations=self.reservations)
+        self.actor.redeem_reservations(rset=self.reservations)
 
 
 class CloseEvent(ABCActorEvent):

--- a/fabric_cf/actor/core/kernel/incoming_rpc_event.py
+++ b/fabric_cf/actor/core/kernel/incoming_rpc_event.py
@@ -83,7 +83,7 @@ class IncomingRPCEvent(ABCActorEvent):
         if self.rpc.get_request_type() == RPCRequestType.UpdateLease:
             client.get_logger().info("processing update lease from <{}>".format(self.rpc.get_caller().get_name()))
             if self.rpc.get().get_resources().get_resources() is not None:
-                client.get_logger().info("inbound lease is {}".format(
+                client.get_logger().debug("inbound lease is {}".format(
                     self.rpc.get().get_resources().get_resources()))
 
             client.update_lease(reservation=self.rpc.get(), update_data=self.rpc.get_update_data(),
@@ -92,12 +92,12 @@ class IncomingRPCEvent(ABCActorEvent):
             client.get_logger().info("processing update ticket from <{}>".format(self.rpc.get_caller().get_name()))
             client.update_ticket(reservation=self.rpc.get(), update_data=self.rpc.get_update_data(),
                                  caller=self.rpc.get_caller())
-            client.get_logger().info("update ticket processed from <{}>".format(self.rpc.get_caller().get_name()))
+            client.get_logger().debug("update ticket processed from <{}>".format(self.rpc.get_caller().get_name()))
         elif self.rpc.get_request_type() == RPCRequestType.UpdateDelegation:
             client.get_logger().info("processing update delegation from <{}>".format(self.rpc.get_caller().get_name()))
             client.update_delegation(delegation=self.rpc.get(), update_data=self.rpc.get_update_data(),
                                      caller=self.rpc.get_caller())
-            client.get_logger().info("update delegation processed from <{}>".format(self.rpc.get_caller().get_name()))
+            client.get_logger().debug("update delegation processed from <{}>".format(self.rpc.get_caller().get_name()))
         else:
             processed = self.do_process_actor(actor=client)
         return processed
@@ -111,30 +111,30 @@ class IncomingRPCEvent(ABCActorEvent):
             server.get_logger().info("processing claim delegation from <{}>".format(self.rpc.get_caller().get_name()))
             server.claim_delegation(delegation=self.rpc.get(), callback=self.rpc.get_callback(),
                                     caller=self.rpc.get_caller())
-            server.get_logger().info("claim processed from <{}>".format(self.rpc.get_caller().get_name()))
+            server.get_logger().debug("claim processed from <{}>".format(self.rpc.get_caller().get_name()))
 
         elif self.rpc.get_request_type() == RPCRequestType.ReclaimDelegation:
             server.get_logger().info("processing reclaim delegation from <{}>".format(self.rpc.get_caller().get_name()))
             server.reclaim_delegation(delegation=self.rpc.get(), callback=self.rpc.get_callback(),
                                       caller=self.rpc.get_caller())
-            server.get_logger().info("reclaim processed from <{}>".format(self.rpc.get_caller().get_name()))
+            server.get_logger().debug("reclaim processed from <{}>".format(self.rpc.get_caller().get_name()))
 
         elif self.rpc.get_request_type() == RPCRequestType.Ticket:
             server.get_logger().info("processing ticket from <{}>".format(self.rpc.get_caller().get_name()))
             server.ticket(reservation=self.rpc.get(), callback=self.rpc.get_callback(),
                           caller=self.rpc.get_caller())
-            server.get_logger().info("ticket processed from <{}>".format(self.rpc.get_caller().get_name()))
+            server.get_logger().debug("ticket processed from <{}>".format(self.rpc.get_caller().get_name()))
 
         elif self.rpc.get_request_type() == RPCRequestType.ExtendTicket:
             server.get_logger().info("processing extend ticket from <{}>".format(self.rpc.get_caller().get_name()))
             server.extend_ticket(reservation=self.rpc.get(), caller=self.rpc.get_caller(),
                                  callback=self.rpc.get_callback())
-            server.get_logger().info("extend ticket processed from <{}>".format(self.rpc.get_caller().get_name()))
+            server.get_logger().debug("extend ticket processed from <{}>".format(self.rpc.get_caller().get_name()))
 
         elif self.rpc.get_request_type() == RPCRequestType.Relinquish:
             server.get_logger().info("processing relinquish from <{}>".format(self.rpc.get_caller().get_name()))
             server.relinquish(reservation=self.rpc.get(), caller=self.rpc.get_caller())
-            server.get_logger().info("relinquish processed from <{}>".format(self.rpc.get_caller().get_name()))
+            server.get_logger().debug("relinquish processed from <{}>".format(self.rpc.get_caller().get_name()))
 
         else:
             processed = self.do_process_actor(actor=server)

--- a/fabric_cf/actor/core/kernel/incoming_rpc_event.py
+++ b/fabric_cf/actor/core/kernel/incoming_rpc_event.py
@@ -55,7 +55,7 @@ class IncomingRPCEvent(ABCActorEvent):
         """
         processed = True
         if self.rpc.get_request_type() == RPCRequestType.Query:
-            actor.get_logger().info("processing query from <{}>".format(self.rpc.get_caller().get_name()))
+            actor.get_logger().debug("processing query from <{}>".format(self.rpc.get_caller().get_name()))
             result = actor.query(query=self.rpc.get(), caller=self.rpc.get_caller())
 
             from fabric_cf.actor.core.kernel.rpc_manager_singleton import RPCManagerSingleton
@@ -63,7 +63,7 @@ class IncomingRPCEvent(ABCActorEvent):
                                                    request_id=self.rpc.get_message_id(),
                                                    response=result, caller=actor.get_identity())
         elif self.rpc.get_request_type() == RPCRequestType.QueryResult:
-            actor.get_logger().info("processing query response from <{}>".format(self.rpc.get_caller().get_name()))
+            actor.get_logger().debug("processing query response from <{}>".format(self.rpc.get_caller().get_name()))
             result = self.rpc.get()
             if self.rpc.get_response_handler() is not None:
                 handler = self.rpc.get_response_handler()
@@ -81,7 +81,7 @@ class IncomingRPCEvent(ABCActorEvent):
         """
         processed = True
         if self.rpc.get_request_type() == RPCRequestType.UpdateLease:
-            client.get_logger().info("processing update lease from <{}>".format(self.rpc.get_caller().get_name()))
+            client.get_logger().debug("processing update lease from <{}>".format(self.rpc.get_caller().get_name()))
             if self.rpc.get().get_resources().get_resources() is not None:
                 client.get_logger().debug("inbound lease is {}".format(
                     self.rpc.get().get_resources().get_resources()))
@@ -89,12 +89,12 @@ class IncomingRPCEvent(ABCActorEvent):
             client.update_lease(reservation=self.rpc.get(), update_data=self.rpc.get_update_data(),
                                 caller=self.rpc.get_caller())
         elif self.rpc.get_request_type() == RPCRequestType.UpdateTicket:
-            client.get_logger().info("processing update ticket from <{}>".format(self.rpc.get_caller().get_name()))
+            client.get_logger().debug("processing update ticket from <{}>".format(self.rpc.get_caller().get_name()))
             client.update_ticket(reservation=self.rpc.get(), update_data=self.rpc.get_update_data(),
                                  caller=self.rpc.get_caller())
             client.get_logger().debug("update ticket processed from <{}>".format(self.rpc.get_caller().get_name()))
         elif self.rpc.get_request_type() == RPCRequestType.UpdateDelegation:
-            client.get_logger().info("processing update delegation from <{}>".format(self.rpc.get_caller().get_name()))
+            client.get_logger().debug("processing update delegation from <{}>".format(self.rpc.get_caller().get_name()))
             client.update_delegation(delegation=self.rpc.get(), update_data=self.rpc.get_update_data(),
                                      caller=self.rpc.get_caller())
             client.get_logger().debug("update delegation processed from <{}>".format(self.rpc.get_caller().get_name()))
@@ -108,31 +108,31 @@ class IncomingRPCEvent(ABCActorEvent):
         """
         processed = True
         if self.rpc.get_request_type() == RPCRequestType.ClaimDelegation:
-            server.get_logger().info("processing claim delegation from <{}>".format(self.rpc.get_caller().get_name()))
+            server.get_logger().debug("processing claim delegation from <{}>".format(self.rpc.get_caller().get_name()))
             server.claim_delegation(delegation=self.rpc.get(), callback=self.rpc.get_callback(),
                                     caller=self.rpc.get_caller())
             server.get_logger().debug("claim processed from <{}>".format(self.rpc.get_caller().get_name()))
 
         elif self.rpc.get_request_type() == RPCRequestType.ReclaimDelegation:
-            server.get_logger().info("processing reclaim delegation from <{}>".format(self.rpc.get_caller().get_name()))
+            server.get_logger().debug("processing reclaim delegation from <{}>".format(self.rpc.get_caller().get_name()))
             server.reclaim_delegation(delegation=self.rpc.get(), callback=self.rpc.get_callback(),
                                       caller=self.rpc.get_caller())
             server.get_logger().debug("reclaim processed from <{}>".format(self.rpc.get_caller().get_name()))
 
         elif self.rpc.get_request_type() == RPCRequestType.Ticket:
-            server.get_logger().info("processing ticket from <{}>".format(self.rpc.get_caller().get_name()))
+            server.get_logger().debug("processing ticket from <{}>".format(self.rpc.get_caller().get_name()))
             server.ticket(reservation=self.rpc.get(), callback=self.rpc.get_callback(),
                           caller=self.rpc.get_caller())
             server.get_logger().debug("ticket processed from <{}>".format(self.rpc.get_caller().get_name()))
 
         elif self.rpc.get_request_type() == RPCRequestType.ExtendTicket:
-            server.get_logger().info("processing extend ticket from <{}>".format(self.rpc.get_caller().get_name()))
+            server.get_logger().debug("processing extend ticket from <{}>".format(self.rpc.get_caller().get_name()))
             server.extend_ticket(reservation=self.rpc.get(), caller=self.rpc.get_caller(),
                                  callback=self.rpc.get_callback())
             server.get_logger().debug("extend ticket processed from <{}>".format(self.rpc.get_caller().get_name()))
 
         elif self.rpc.get_request_type() == RPCRequestType.Relinquish:
-            server.get_logger().info("processing relinquish from <{}>".format(self.rpc.get_caller().get_name()))
+            server.get_logger().debug("processing relinquish from <{}>".format(self.rpc.get_caller().get_name()))
             server.relinquish(reservation=self.rpc.get(), caller=self.rpc.get_caller())
             server.get_logger().debug("relinquish processed from <{}>".format(self.rpc.get_caller().get_name()))
 
@@ -155,22 +155,22 @@ class IncomingRPCEvent(ABCActorEvent):
         """
         processed = True
         if self.rpc.get_request_type() == RPCRequestType.Redeem:
-            authority.get_logger().info("processing redeem from <{}>".format(self.rpc.get_caller().get_name()))
+            authority.get_logger().debug("processing redeem from <{}>".format(self.rpc.get_caller().get_name()))
             authority.redeem(reservation=self.rpc.get(), callback=self.rpc.get_callback(),
                              caller=self.rpc.get_caller())
 
         elif self.rpc.get_request_type() == RPCRequestType.ExtendLease:
-            authority.get_logger().info("processing extend lease from <{}>".format(self.rpc.get_caller().get_name()))
+            authority.get_logger().debug("processing extend lease from <{}>".format(self.rpc.get_caller().get_name()))
             authority.extend_lease(reservation=self.rpc.get(), caller=self.rpc.get_caller(),
                                    callback=self.rpc.get_callback())
 
         elif self.rpc.get_request_type() == RPCRequestType.ModifyLease:
-            authority.get_logger().info("processing modify lease from <{}>".format(self.rpc.get_caller().get_name()))
+            authority.get_logger().debug("processing modify lease from <{}>".format(self.rpc.get_caller().get_name()))
             authority.modify_lease(reservation=self.rpc.get(), caller=self.rpc.get_caller(),
                                    callback=self.rpc.get_callback())
 
         elif self.rpc.get_request_type() == RPCRequestType.Close:
-            authority.get_logger().info("processing close from <{}>".format(self.rpc.get_caller().get_name()))
+            authority.get_logger().debug("processing close from <{}>".format(self.rpc.get_caller().get_name()))
             authority.close(reservation=self.rpc.get())
 
         else:

--- a/fabric_cf/actor/core/kernel/kernel.py
+++ b/fabric_cf/actor/core/kernel/kernel.py
@@ -703,15 +703,31 @@ class Kernel:
         @param reservation reservation
         """
         try:
+            begin = time.time()
             reservation.lock()
+            diff = int(time.time() - begin)
+            if diff > 0:
+                self.logger.info(f"REDEEM LOCK TIME: {diff}")
+            begin = time.time()
             if reservation.can_redeem():
                 reservation.reserve(policy=self.policy)
             else:
                 raise KernelException("The current reservation state prevent it from being redeemed")
+            diff = int(time.time() - begin)
+            if diff > 0:
+                self.logger.info(f"REDEEM TIME: {diff}")
+            begin = time.time()
 
             self.plugin.get_database().update_reservation(reservation=reservation)
+            diff = int(time.time() - begin)
+            if diff > 0:
+                self.logger.info(f"REDEEM DB TIME: {diff}")
+            begin = time.time()
             if not reservation.is_failed():
                 reservation.service_reserve()
+            diff = int(time.time() - begin)
+            if diff > 0:
+                self.logger.info(f"REDEEM SERVICE TIME: {diff}")
         except Exception as e:
             self.logger.error(f"An error occurred during redeem for reservation #{reservation.get_reservation_id()} "
                               f"e: {e}")

--- a/fabric_cf/actor/core/kernel/kernel.py
+++ b/fabric_cf/actor/core/kernel/kernel.py
@@ -1197,7 +1197,7 @@ class Kernel:
             begin = time.time()
             for reservation in self.reservations.values():
                 self.__probe_pending(reservation=reservation)
-            self.logger.info(f"KERNEL RES TICK TIME: {time.time() - begin:.0f}")
+            self.logger.info(f"KERNEL RES TICK TIME: {time.time() - begin:.0f} {self.reservations.size()}")
 
             begin = time.time()
             try:
@@ -1208,7 +1208,9 @@ class Kernel:
                 self.lock.release()
             self.logger.info(f"KERNEL SLC TICK TIME: {time.time() - begin:.0f}")
 
+            begin = time.time()
             self.__purge()
+            self.logger.info(f"KERNEL PURGE TICK TIME: {time.time() - begin:.0f}")
             self.check_nothing_pending()
         except Exception as e:
             self.logger.error(traceback.format_exc())

--- a/fabric_cf/actor/core/kernel/kernel.py
+++ b/fabric_cf/actor/core/kernel/kernel.py
@@ -598,11 +598,31 @@ class Kernel:
         @throws Exception rare
         """
         try:
+            begin = time.time()
             reservation.lock()
+            now = time.time()
+            diff = int(now - begin)
+            if diff > 10:
+                self.logger.info(f"RES LOCK TIME: {diff} - {reservation.get_reservation_id()}")
+            begin = time.time()
             reservation.prepare_probe()
             reservation.probe_pending()
+            now = time.time()
+            diff = int(now - begin)
+            if diff > 10:
+                self.logger.info(f"RES PROBE TIME: {diff} - {reservation.get_reservation_id()}")
+            begin = time.time()
             self.plugin.get_database().update_reservation(reservation=reservation)
+            now = time.time()
+            diff = int(now - begin)
+            if diff > 10:
+                self.logger.info(f"RES DB UPDATE TIME: {diff} - {reservation.get_reservation_id()}")
+            begin = time.time()
             reservation.service_probe()
+            now = time.time()
+            diff = int(now - begin)
+            if diff > 10:
+                self.logger.info(f"RES SERVICE PROBE TIME: {diff} - {reservation.get_reservation_id()}")
         except Exception as e:
             self.logger.error(traceback.format_exc())
             self.error(err=f"An error occurred during probe pending for reservation #{reservation.get_reservation_id()}",

--- a/fabric_cf/actor/core/kernel/kernel.py
+++ b/fabric_cf/actor/core/kernel/kernel.py
@@ -602,26 +602,26 @@ class Kernel:
             reservation.lock()
             now = time.time()
             diff = int(now - begin)
-            if diff > 10:
+            if diff > 0:
                 self.logger.info(f"RES LOCK TIME: {diff} - {reservation.get_reservation_id()}")
             begin = time.time()
             reservation.prepare_probe()
             reservation.probe_pending()
             now = time.time()
             diff = int(now - begin)
-            if diff > 10:
+            if diff > 0:
                 self.logger.info(f"RES PROBE TIME: {diff} - {reservation.get_reservation_id()}")
             begin = time.time()
             self.plugin.get_database().update_reservation(reservation=reservation)
             now = time.time()
             diff = int(now - begin)
-            if diff > 10:
+            if diff > 0:
                 self.logger.info(f"RES DB UPDATE TIME: {diff} - {reservation.get_reservation_id()}")
             begin = time.time()
             reservation.service_probe()
             now = time.time()
             diff = int(now - begin)
-            if diff > 10:
+            if diff > 0:
                 self.logger.info(f"RES SERVICE PROBE TIME: {diff} - {reservation.get_reservation_id()}")
         except Exception as e:
             self.logger.error(traceback.format_exc())

--- a/fabric_cf/actor/core/kernel/kernel_wrapper.py
+++ b/fabric_cf/actor/core/kernel/kernel_wrapper.py
@@ -23,6 +23,7 @@
 #
 #
 # Author: Komal Thareja (kthare10@renci.org)
+import time
 import traceback
 from datetime import datetime
 from typing import List, Dict
@@ -654,14 +655,26 @@ class KernelWrapper:
             self.logger.debug("redeem() Reservation {} is in state: {}".format(r.get_reservation_id(),
                                                                                ReservationStates(r.get_state()).name))
         '''
-
+        begin = time.time()
         target = self.kernel.validate(rid=reservation.get_reservation_id())
+        diff = int(time.time() - begin)
+        if diff > 0:
+            self.logger.info(f"REDEEM KERNEL VAL TIME: {diff}")
+        begin = time.time()
 
         if target is None:
             self.logger.error("Redeem on a reservation not registered with the kernel")
 
         target.validate_redeem()
+        diff = int(time.time() - begin)
+        if diff > 0:
+            self.logger.info(f"REDEEM VAL TIME: {diff}")
+        begin = time.time()
         self.kernel.redeem(reservation=target)
+        diff = int(time.time() - begin)
+        if diff > 0:
+            self.logger.info(f"REDEEM TIME: {diff}")
+        begin = time.time()
 
     def redeem_request(self, *, reservation: ABCAuthorityReservation, caller: AuthToken,
                        callback: ABCControllerCallbackProxy, compare_sequence_numbers: bool):

--- a/fabric_cf/actor/core/kernel/kernel_wrapper.py
+++ b/fabric_cf/actor/core/kernel/kernel_wrapper.py
@@ -650,9 +650,11 @@ class KernelWrapper:
 
         slice_object = reservation.get_slice()
 
+        '''
         for r in slice_object.get_reservations().values():
             self.logger.debug("redeem() Reservation {} is in state: {}".format(r.get_reservation_id(),
                                                                                ReservationStates(r.get_state()).name))
+        '''
 
         target = self.kernel.validate(rid=reservation.get_reservation_id())
 

--- a/fabric_cf/actor/core/kernel/kernel_wrapper.py
+++ b/fabric_cf/actor/core/kernel/kernel_wrapper.py
@@ -648,9 +648,8 @@ class KernelWrapper:
         if reservation is None:
             raise KernelException(Constants.INVALID_ARGUMENT)
 
-        slice_object = reservation.get_slice()
-
         '''
+        slice_object = reservation.get_slice()
         for r in slice_object.get_reservations().values():
             self.logger.debug("redeem() Reservation {} is in state: {}".format(r.get_reservation_id(),
                                                                                ReservationStates(r.get_state()).name))

--- a/fabric_cf/actor/core/kernel/reservation_client.py
+++ b/fabric_cf/actor/core/kernel/reservation_client.py
@@ -1082,12 +1082,12 @@ class ReservationClient(Reservation, ABCControllerReservation):
             # Check dependencies
             closed_preds = 0
             for pred_state in self.get_redeem_predecessors():
-                if pred_state.get_reservation().is_closed():
+                if pred_state.get_reservation().is_closed() or pred_state.get_reservation().is_closing():
                     closed_preds += 1
 
             #if closed_preds > len(self.get_redeem_predecessors()):
             if closed_preds:
-                self.logger.debug(f"Found dependencies# {closed_preds} in closed state")
+                self.logger.debug(f"Found dependencies# {closed_preds} in closed/closing state")
                 ret_val = True
         return ret_val
 

--- a/fabric_cf/actor/core/kernel/reservation_client.py
+++ b/fabric_cf/actor/core/kernel/reservation_client.py
@@ -203,6 +203,7 @@ class ReservationClient(Reservation, ABCControllerReservation):
         del state['service_pending']
         del state['suggested']
         del state['thread_lock']
+        del state['policy']
         return state
 
     def __setstate__(self, state):
@@ -218,6 +219,7 @@ class ReservationClient(Reservation, ABCControllerReservation):
         self.pending_recover = False
         self.state_transition = False
         self.service_pending = ReservationPendingStates.None_
+        self.policy = None
 
         self.suggested = True
         self.thread_lock = threading.Lock()

--- a/fabric_cf/actor/core/kernel/reservation_client.py
+++ b/fabric_cf/actor/core/kernel/reservation_client.py
@@ -34,8 +34,8 @@ from typing import TYPE_CHECKING, List, Tuple
 
 from fim.slivers.attached_components import ComponentType
 from fim.slivers.base_sliver import BaseSliver
-from fim.slivers.capacities_labels import Labels, ReservationInfo
-from fim.slivers.network_node import NodeSliver, NodeType
+from fim.slivers.capacities_labels import Labels
+from fim.slivers.network_node import NodeType
 from fim.slivers.network_service import NetworkServiceSliver
 
 from fabric_cf.actor.core.apis.abc_authority_policy import ABCAuthorityPolicy
@@ -919,6 +919,7 @@ class ReservationClient(Reservation, ABCControllerReservation):
         assert self.resources.sliver is not None
         sliver = self.resources.sliver
 
+        '''
         self.logger.info(f"Redeem prepared for Sliver: {sliver}")
         if isinstance(sliver, NetworkServiceSliver) and sliver.interface_info is not None:
             for ifs in sliver.interface_info.interfaces.values():
@@ -927,6 +928,7 @@ class ReservationClient(Reservation, ABCControllerReservation):
         if isinstance(sliver, NodeSliver) and sliver.attached_components_info is not None:
             for c in sliver.attached_components_info.devices.values():
                 self.logger.info(f"Component: {c}")
+        '''
 
     def probe_join_state(self):
         """

--- a/fabric_cf/actor/core/kernel/reservation_client.py
+++ b/fabric_cf/actor/core/kernel/reservation_client.py
@@ -1808,7 +1808,7 @@ class ReservationClient(Reservation, ABCControllerReservation):
         except Exception as e:
             self.logger.error(f"Failed to update the ASM Graph: {e}")
             self.logger.error(traceback.format_exc())
-        self.logger.info(f"ASM TIME: {time.time() - begin:.0f}")
+        #self.logger.info(f"ASM TIME: {time.time() - begin:.0f}")
 
     def mark_close_by_ticket_review(self, *, update_data: UpdateData):
         if self.last_ticket_update is not None:

--- a/fabric_cf/actor/core/kernel/reservation_client.py
+++ b/fabric_cf/actor/core/kernel/reservation_client.py
@@ -1131,20 +1131,25 @@ class ReservationClient(Reservation, ABCControllerReservation):
                     update_data.message = "Redeem/Ticket timeout"
                     self.mark_close_by_ticket_review(update_data=update_data)
 
+        if self.leased_resources is None:
+            return
+
         # Handling for close completion. Note that this reservation could
         # "stick" once we enter the CloseWait state, if we never hear back from
         # the authority. There is no harm to purging a CloseWait reservation,
         # but we just leave them for now.
-        close_by_deps = self.__are_dependencies_closed()
-        if (self.leased_resources is not None and self.pending_state == ReservationPendingStates.Closing and
-            self.leased_resources.is_closed()) or close_by_deps:
+        #close_by_deps = self.__are_dependencies_closed()
+        #if (self.leased_resources is not None and self.pending_state == ReservationPendingStates.Closing and
+        #    self.leased_resources.is_closed()) or close_by_deps:
 
-            if not close_by_deps:
-                self.logger.debug("LEASED RESOURCES are closed")
-                msg = "local close complete"
-            else:
-                msg = "close by dependencies"
+        #    if not close_by_deps:
+        #        self.logger.debug("LEASED RESOURCES are closed")
+        #        msg = "local close complete"
+        #    else:
+        #        msg = "close by dependencies"
 
+        if self.pending_state == ReservationPendingStates.Closing:
+            msg = "local close complete"
             self.transition(prefix=msg, state=ReservationStates.CloseWait, pending=ReservationPendingStates.None_)
 
             try:

--- a/fabric_cf/actor/core/kernel/reservation_client.py
+++ b/fabric_cf/actor/core/kernel/reservation_client.py
@@ -1131,16 +1131,13 @@ class ReservationClient(Reservation, ABCControllerReservation):
                     update_data.message = "Redeem/Ticket timeout"
                     self.mark_close_by_ticket_review(update_data=update_data)
 
-        if self.leased_resources is None:
-            return
-
         # Handling for close completion. Note that this reservation could
         # "stick" once we enter the CloseWait state, if we never hear back from
         # the authority. There is no harm to purging a CloseWait reservation,
         # but we just leave them for now.
         close_by_deps = self.__are_dependencies_closed()
-        if (self.pending_state == ReservationPendingStates.Closing and self.leased_resources.is_closed()) or \
-                close_by_deps:
+        if (self.leased_resources is not None and self.pending_state == ReservationPendingStates.Closing and
+            self.leased_resources.is_closed()) or close_by_deps:
 
             if not close_by_deps:
                 self.logger.debug("LEASED RESOURCES are closed")

--- a/fabric_cf/actor/core/kernel/reservation_client.py
+++ b/fabric_cf/actor/core/kernel/reservation_client.py
@@ -201,7 +201,6 @@ class ReservationClient(Reservation, ABCControllerReservation):
         del state['pending_recover']
         del state['state_transition']
         del state['service_pending']
-
         del state['suggested']
         del state['thread_lock']
         return state

--- a/fabric_cf/actor/core/kernel/rpc_manager.py
+++ b/fabric_cf/actor/core/kernel/rpc_manager.py
@@ -485,9 +485,9 @@ class RPCManager:
 
         else:
             actor.get_logger().debug("Added to actor queue to be processed")
-            start = time.time()
+            #start = time.time()
             actor.queue_event(incoming=IncomingRPCEvent(actor=actor, rpc=rpc))
-            actor.get_logger().info(f"Kafka Queue event: {time.time() - start:.0f}")
+            #actor.get_logger().info(f"Kafka Queue event: {time.time() - start:.0f}")
 
     def add_pending_request(self, *, guid: ID, request: RPCRequest):
         try:

--- a/fabric_cf/actor/core/kernel/rpc_manager.py
+++ b/fabric_cf/actor/core/kernel/rpc_manager.py
@@ -309,7 +309,7 @@ class RPCManager:
         # Schedule a timeout
         rpc.timer = KernelTimer.schedule(queue=actor, task=ClaimTimeout(req=rpc), delay=self.CLAIM_TIMEOUT_SECONDS)
         if proxy.get_logger() is not None:
-            proxy.get_logger().info(f"Timer started: {rpc.timer} for Claim")
+            proxy.get_logger().debug(f"Timer started: {rpc.timer} for Claim")
         self.enqueue(rpc=rpc)
 
     def do_reclaim_delegation(self, *, actor: ABCActorMixin, proxy: ABCBrokerProxy, delegation: ABCDelegation,
@@ -324,7 +324,7 @@ class RPCManager:
         # Schedule a timeout
         rpc.timer = KernelTimer.schedule(queue=actor, task=ReclaimTimeout(req=rpc), delay=self.CLAIM_TIMEOUT_SECONDS)
         if proxy.get_logger() is not None:
-            proxy.get_logger().info(f"Timer started: {rpc.timer} for Reclaim")
+            proxy.get_logger().debug(f"Timer started: {rpc.timer} for Reclaim")
         self.enqueue(rpc=rpc)
 
     def do_ticket(self, *, actor: ABCActorMixin, proxy: ABCBrokerProxy, reservation: ABCClientReservation,
@@ -429,7 +429,7 @@ class RPCManager:
         rpc = RPCRequest(request=state, actor=actor, proxy=remote_actor, handler=handler)
         # Timer
         rpc.timer = KernelTimer.schedule(queue=actor, task=QueryTimeout(req=rpc), delay=self.QUERY_TIMEOUT_SECONDS)
-        remote_actor.get_logger().info(f"Timer started: {rpc.timer} for Query")
+        remote_actor.get_logger().debug(f"Timer started: {rpc.timer} for Query")
         self.enqueue(rpc=rpc)
 
     def do_query_result(self, *, actor: ABCActorMixin, remote_actor: ABCCallbackProxy, request_id: str,
@@ -569,4 +569,4 @@ class RPCManager:
                     sliver = reservation.get_resources().get_sliver()
 
             if sliver is not None:
-                logger.info(f"Sliver: {sliver_to_str(sliver=sliver)}")
+                logger.debug(f"Sliver: {sliver_to_str(sliver=sliver)}")

--- a/fabric_cf/actor/core/kernel/rpc_manager.py
+++ b/fabric_cf/actor/core/kernel/rpc_manager.py
@@ -454,7 +454,7 @@ class RPCManager:
                 if request.handler is not None:
                     rpc.set_response_handler(response_handler=request.handler)
 
-        actor.get_logger().info(f"Inbound {rpc.get_request_type()} request from "
+        actor.get_logger().debug(f"Inbound {rpc.get_request_type()} request from "
                                 f"<{rpc.get_caller().get_name()}>:{rpc.get()}")
 
         self.__log_sliver(reservation=rpc.get(), logger=actor.get_logger())
@@ -530,7 +530,7 @@ class RPCManager:
     def enqueue(self, *, rpc: RPCRequest):
         from fabric_cf.actor.core.container.globals import GlobalsSingleton
         logger = GlobalsSingleton.get().get_logger()
-        logger.info(f"Outbound {rpc.get_request_type()} : {rpc.get()}")
+        logger.debug(f"Outbound {rpc.get_request_type()} : {rpc.get()}")
         self.__log_sliver(reservation=rpc.get(), logger=logger)
         if not self.started:
             logger.warning("Ignoring RPC request: container is shutting down")

--- a/fabric_cf/actor/core/manage/actor_management_object.py
+++ b/fabric_cf/actor/core/manage/actor_management_object.py
@@ -102,12 +102,36 @@ class ActorManagementObject(ManagementObject, ABCActorManagementObject):
 
         self.set_actor(actor=actor)
 
+    def make_local_db_object(self, *, actor: ABCActorMixin):
+        # Make a read only instance to return queries to avoid locking with Actor processing
+        from fabric_cf.actor.core.container.globals import GlobalsSingleton
+        config = GlobalsSingleton.get().get_config()
+
+        user = config.get_global_config().get_database()[Constants.PROPERTY_CONF_DB_USER]
+        password = config.get_global_config().get_database()[Constants.PROPERTY_CONF_DB_PASSWORD]
+        db_host = config.get_global_config().get_database()[Constants.PROPERTY_CONF_DB_HOST]
+        db_name = config.get_global_config().get_database()[Constants.PROPERTY_CONF_DB_NAME]
+
+        from fabric_cf.actor.core.apis.abc_actor_mixin import ActorType
+        if actor.get_type() in [ActorType.Orchestrator, ActorType.Authority]:
+            from fabric_cf.actor.core.plugins.substrate.db.substrate_actor_database import SubstrateActorDatabase
+            self.db = SubstrateActorDatabase(user=user, password=password, database=db_name, db_host=db_host,
+                                             logger=self.logger)
+        else:
+            from fabric_cf.actor.core.plugins.db.server_actor_database import ServerActorDatabase
+            self.db = ServerActorDatabase(user=user, password=password, database=db_name, db_host=db_host,
+                                          logger=self.logger)
+        self.db.set_actor_name(name=self.actor.get_name())
+        self.db.initialize()
+        self.db.actor_added(actor=actor)
+
     def set_actor(self, *, actor: ABCActorMixin):
         if self.actor is None:
             self.actor = actor
-            self.db = actor.get_plugin().get_database()
+            #self.db = actor.get_plugin().get_database()
             self.logger = actor.get_logger()
             self.id = actor.get_guid()
+            self.make_local_db_object(actor=actor)
 
     def get_slices(self, *, slice_id: ID, caller: AuthToken, slice_name: str = None, email: str = None,
                    states: List[int] = None, project: str = None, limit: int = None,

--- a/fabric_cf/actor/core/manage/actor_management_object.py
+++ b/fabric_cf/actor/core/manage/actor_management_object.py
@@ -345,7 +345,6 @@ class ActorManagementObject(ManagementObject, ABCActorManagementObject):
 
         return result
 
-
     def get_reservations(self, *, caller: AuthToken, states: List[int] = None,
                          slice_id: ID = None, rid: ID = None, oidc_claim_sub: str = None,
                          email: str = None, rid_list: List[str] = None, type: str = None,
@@ -359,14 +358,14 @@ class ActorManagementObject(ManagementObject, ABCActorManagementObject):
             return result
 
         try:
-
+            rsv_type = type.split(",")
             res_list = None
             try:
                 if rid_list is not None:
                     res_list = self.db.get_reservations_by_rids(rid=rid_list)
                 else:
                     res_list = self.db.get_reservations(slice_id=slice_id, rid=rid, email=email,
-                                                        states=states, rsv_type=type, site=site,
+                                                        states=states, rsv_type=rsv_type, site=site,
                                                         graph_node_id=node_id)
             except Exception as e:
                 self.logger.error("getReservations:db access {}".format(e))

--- a/fabric_cf/actor/core/manage/actor_management_object.py
+++ b/fabric_cf/actor/core/manage/actor_management_object.py
@@ -358,7 +358,9 @@ class ActorManagementObject(ManagementObject, ABCActorManagementObject):
             return result
 
         try:
-            rsv_type = type.split(",")
+            rsv_type = None
+            if type is not None:
+                rsv_type = type.split(",")
             res_list = None
             try:
                 if rid_list is not None:

--- a/fabric_cf/actor/core/manage/kafka/kafka_broker.py
+++ b/fabric_cf/actor/core/manage/kafka/kafka_broker.py
@@ -50,6 +50,7 @@ from fabric_cf.actor.core.common.constants import Constants
 from fabric_cf.actor.core.apis.abc_mgmt_broker_mixin import ABCMgmtBrokerMixin
 from fabric_cf.actor.core.common.exceptions import ManageException
 from fabric_cf.actor.core.manage.kafka.kafka_server_actor import KafkaServerActor
+from fabric_cf.actor.core.time.actor_clock import ActorClock
 from fabric_cf.actor.core.util.id import ID
 
 
@@ -136,6 +137,7 @@ class KafkaBroker(KafkaServerActor, ABCMgmtBrokerMixin):
         request.message_id = str(ID())
         request.callback_topic = self.callback_topic
         request.rid = str(reservation)
+        request.end_time = ActorClock.to_milliseconds(when=new_end_time)
         request.sliver = sliver
 
         status, response = self.send_request(request)

--- a/fabric_cf/actor/core/plugins/db/actor_database.py
+++ b/fabric_cf/actor/core/plugins/db/actor_database.py
@@ -25,6 +25,7 @@
 # Author: Komal Thareja (kthare10@renci.org)
 import pickle
 import threading
+import time
 import traceback
 from datetime import datetime
 from typing import List
@@ -276,8 +277,12 @@ class ActorDatabase(ABCDatabase):
             if reservation.get_resources() is not None and reservation.get_resources().get_sliver() is not None:
                 site = reservation.get_resources().get_sliver().get_site()
                 rsv_type = reservation.get_resources().get_sliver().get_type().name
-
+            begin = time.time()
             properties = pickle.dumps(reservation)
+            diff = int(time.time() - begin)
+            if diff > 0:
+                self.logger.info(f"PICKLE TIME: {diff}")
+            begin = time.time()
             self.db.update_reservation(slc_guid=str(reservation.get_slice_id()),
                                        rsv_resid=str(reservation.get_reservation_id()),
                                        rsv_category=reservation.get_category().value,
@@ -287,6 +292,9 @@ class ActorDatabase(ABCDatabase):
                                        properties=properties,
                                        rsv_graph_node_id=reservation.get_graph_node_id(),
                                        site=site, rsv_type=rsv_type)
+            diff = int(time.time() - begin)
+            if diff > 0:
+                self.logger.info(f"DB TIME: {diff}")
         finally:
             if self.lock.locked():
                 self.lock.release()

--- a/fabric_cf/actor/core/plugins/db/actor_database.py
+++ b/fabric_cf/actor/core/plugins/db/actor_database.py
@@ -286,7 +286,7 @@ class ActorDatabase(ABCDatabase):
                                        rsv_joining=reservation.get_join_state().value,
                                        properties=properties,
                                        rsv_graph_node_id=reservation.get_graph_node_id(),
-                                       site=site, rsv_type = rsv_type)
+                                       site=site, rsv_type=rsv_type)
         finally:
             if self.lock.locked():
                 self.lock.release()

--- a/fabric_cf/actor/core/plugins/db/actor_database.py
+++ b/fabric_cf/actor/core/plugins/db/actor_database.py
@@ -409,7 +409,8 @@ class ActorDatabase(ABCDatabase):
 
     def get_reservations(self, *, slice_id: ID = None, graph_node_id: str = None, project_id: str = None,
                          email: str = None, oidc_sub: str = None, rid: ID = None,
-                         states: list[int] = None, site: str = None, rsv_type: int = None) -> List[ABCReservationMixin]:
+                         states: list[int] = None, site: str = None,
+                         rsv_type: list[str] = None) -> List[ABCReservationMixin]:
         result = []
         try:
             self.lock.acquire()

--- a/fabric_cf/actor/core/plugins/db/actor_database.py
+++ b/fabric_cf/actor/core/plugins/db/actor_database.py
@@ -115,7 +115,7 @@ class ActorDatabase(ABCDatabase):
 
     def get_actor_id_from_name(self, *, actor_name: str) -> int or None:
         try:
-            self.lock.acquire()
+            #self.lock.acquire()
             actor = self.db.get_actor(name=actor_name)
             self.actor_id = actor['act_id']
             self.actor_type = ActorType(actor['act_type'])
@@ -129,7 +129,7 @@ class ActorDatabase(ABCDatabase):
 
     def get_slice_by_id(self, *, slc_id: int) -> ABCSlice or None:
         try:
-            self.lock.acquire()
+            #self.lock.acquire()
             slice_dict = self.db.get_slice_by_id(slc_id=slc_id)
             if slice_dict is not None:
                 pickled_slice = slice_dict.get(Constants.PROPERTY_PICKLE_PROPERTIES)
@@ -154,7 +154,7 @@ class ActorDatabase(ABCDatabase):
                 oidc_claim_sub = slice_object.get_owner().get_oidc_sub_claim()
                 email = slice_object.get_owner().get_email()
 
-            self.lock.acquire()
+            #self.lock.acquire()
             self.db.add_slice(slc_guid=str(slice_object.get_slice_id()),
                               slc_state=slice_object.get_state().value,
                               slc_name=slice_object.get_name(),
@@ -176,7 +176,7 @@ class ActorDatabase(ABCDatabase):
             return
         slice_object.clear_dirty()
         try:
-            self.lock.acquire()
+            #self.lock.acquire()
             properties = pickle.dumps(slice_object)
             self.db.update_slice(slc_guid=str(slice_object.get_slice_id()),
                                  slc_name=slice_object.get_name(),
@@ -192,7 +192,7 @@ class ActorDatabase(ABCDatabase):
 
     def remove_slice(self, *, slice_id: ID):
         try:
-            self.lock.acquire()
+            #self.lock.acquire()
             self.db.remove_slice(slc_guid=str(slice_id))
         finally:
             if self.lock.locked():
@@ -204,7 +204,7 @@ class ActorDatabase(ABCDatabase):
         result = []
         try:
             try:
-                self.lock.acquire()
+                #self.lock.acquire()
                 slice_type = None
                 if slc_type is not None:
                     slice_type = [x.value for x in slc_type]
@@ -230,7 +230,7 @@ class ActorDatabase(ABCDatabase):
 
     def add_reservation(self, *, reservation: ABCReservationMixin):
         try:
-            self.lock.acquire()
+            #self.lock.acquire()
             self.logger.debug("Adding reservation {} to slice {}".format(reservation.get_reservation_id(),
                                                                          reservation.get_slice()))
             properties = pickle.dumps(reservation)
@@ -267,7 +267,7 @@ class ActorDatabase(ABCDatabase):
             return
         reservation.clear_dirty()
         try:
-            self.lock.acquire()
+            #self.lock.acquire()
             self.logger.debug("Updating reservation {} in slice {}".format(reservation.get_reservation_id(),
                                                                            reservation.get_slice()))
 
@@ -293,7 +293,7 @@ class ActorDatabase(ABCDatabase):
 
     def remove_reservation(self, *, rid: ID):
         try:
-            self.lock.acquire()
+            #self.lock.acquire()
             self.logger.debug("Removing reservation {}".format(rid))
             try:
                 self.db.remove_unit(unt_uid=str(rid))
@@ -345,7 +345,7 @@ class ActorDatabase(ABCDatabase):
     def get_client_reservations(self, *, slice_id: ID = None) -> List[ABCReservationMixin]:
         result = []
         try:
-            self.lock.acquire()
+            #self.lock.acquire()
             sid = str(slice_id) if slice_id is not None else None
             res_dict_list = self.db.get_reservations(slice_id=sid,
                                                      category=[ReservationCategory.Broker.value,
@@ -363,7 +363,7 @@ class ActorDatabase(ABCDatabase):
     def get_holdings(self, *, slice_id: ID = None) -> List[ABCReservationMixin]:
         result = []
         try:
-            self.lock.acquire()
+            #self.lock.acquire()
             sid = str(slice_id) if slice_id is not None else None
             res_dict_list = self.db.get_reservations(slice_id=sid, category=[ReservationCategory.Client.value])
             if self.lock.locked():
@@ -379,7 +379,7 @@ class ActorDatabase(ABCDatabase):
     def get_broker_reservations(self) -> List[ABCReservationMixin]:
         result = []
         try:
-            self.lock.acquire()
+            #self.lock.acquire()
             res_dict_list = self.db.get_reservations(category=[ReservationCategory.Broker.value])
             if self.lock.locked():
                 self.lock.release()
@@ -394,7 +394,7 @@ class ActorDatabase(ABCDatabase):
     def get_authority_reservations(self) -> List[ABCReservationMixin]:
         result = []
         try:
-            self.lock.acquire()
+            #self.lock.acquire()
             result = []
             res_dict_list = self.db.get_reservations(category=[ReservationCategory.Authority.value])
             if self.lock.locked():
@@ -413,7 +413,7 @@ class ActorDatabase(ABCDatabase):
                          rsv_type: list[str] = None) -> List[ABCReservationMixin]:
         result = []
         try:
-            self.lock.acquire()
+            #self.lock.acquire()
             sid = str(slice_id) if slice_id is not None else None
             res_id = str(rid) if rid is not None else None
             res_dict_list = self.db.get_reservations(slice_id=sid, graph_node_id=graph_node_id,
@@ -432,7 +432,7 @@ class ActorDatabase(ABCDatabase):
     def get_reservations_by_rids(self, *, rid: List[str]) -> List[ABCReservationMixin]:
         result = []
         try:
-            self.lock.acquire()
+            #self.lock.acquire()
             res_dict_list = self.db.get_reservations_by_rids(rsv_resid_list=rid)
             if self.lock.locked():
                 self.lock.release()
@@ -446,7 +446,7 @@ class ActorDatabase(ABCDatabase):
 
     def add_broker(self, *, broker: ABCBrokerProxy):
         try:
-            self.lock.acquire()
+            #self.lock.acquire()
             self.logger.debug("Adding broker {}({})".format(broker.get_name(), broker.get_guid()))
             properties = pickle.dumps(broker)
             self.db.add_proxy(act_id=self.actor_id, prx_name=broker.get_name(), properties=properties)
@@ -456,7 +456,7 @@ class ActorDatabase(ABCDatabase):
 
     def update_broker(self, *, broker: ABCBrokerProxy):
         try:
-            self.lock.acquire()
+            #self.lock.acquire()
             self.logger.debug("Updating broker {}({})".format(broker.get_name(), broker.get_guid()))
             properties = pickle.dumps(broker)
             self.db.update_proxy(act_id=self.actor_id, prx_name=broker.get_name(), properties=properties)
@@ -466,7 +466,7 @@ class ActorDatabase(ABCDatabase):
 
     def remove_broker(self, *, broker: ABCBrokerProxy):
         try:
-            self.lock.acquire()
+            #self.lock.acquire()
             self.logger.debug("Removing broker {}({})".format(broker.get_name(), broker.get_guid()))
             self.db.remove_proxy(act_id=self.actor_id, prx_name=broker.get_name())
         finally:
@@ -478,7 +478,7 @@ class ActorDatabase(ABCDatabase):
 
     def get_brokers(self) -> List[ABCBrokerProxy] or None:
         try:
-            self.lock.acquire()
+            #self.lock.acquire()
             result = []
             broker_dict_list = self.db.get_proxies(act_id=self.actor_id)
             if broker_dict_list is not None:
@@ -499,7 +499,7 @@ class ActorDatabase(ABCDatabase):
         self.logger.debug("Adding delegation {} to slice {}".format(delegation.get_delegation_id(),
                                                                     delegation.get_slice_id()))
         try:
-            self.lock.acquire()
+            #self.lock.acquire()
             properties = pickle.dumps(delegation)
             self.db.add_delegation(slice_id=str(delegation.get_slice_id()),
                                    dlg_graph_id=str(delegation.get_delegation_id()),
@@ -518,7 +518,7 @@ class ActorDatabase(ABCDatabase):
             return
         delegation.clear_dirty()
         try:
-            self.lock.acquire()
+            #self.lock.acquire()
             self.logger.debug("Updating delegation {} in slice {}".format(delegation.get_delegation_id(),
                                                                           delegation.get_slice_id()))
             properties = pickle.dumps(delegation)
@@ -531,7 +531,7 @@ class ActorDatabase(ABCDatabase):
 
     def remove_delegation(self, *, dlg_graph_id: str):
         try:
-            self.lock.acquire()
+            #self.lock.acquire()
             self.logger.debug("Removing delegation {}".format(dlg_graph_id))
             self.db.remove_delegation(dlg_graph_id=str(dlg_graph_id))
         finally:
@@ -559,7 +559,7 @@ class ActorDatabase(ABCDatabase):
 
     def get_delegation(self, *, dlg_graph_id: str) -> ABCDelegation or None:
         try:
-            self.lock.acquire()
+            #self.lock.acquire()
             dlg_dict = self.db.get_delegation(dlg_graph_id=str(dlg_graph_id))
             if self.lock.locked():
                 self.lock.release()
@@ -574,10 +574,11 @@ class ActorDatabase(ABCDatabase):
     def get_delegations(self, *, slice_id: ID = None, states: List[int] = None) -> List[ABCDelegation]:
         result = []
         try:
-            self.lock.acquire()
+            #self.lock.acquire()
             sid = str(slice_id) if slice_id is not None else None
             dlg_dict_list = self.db.get_delegations(slc_guid=sid, states=states)
-            self.lock.release()
+            if self.lock.locked():
+                self.lock.release()
             result = self._load_delegation_from_db(dlg_dict_list=dlg_dict_list)
         except Exception as e:
             self.logger.error(e)
@@ -621,7 +622,7 @@ class ActorDatabase(ABCDatabase):
     def add_site(self, *, site: Site):
         self.logger.debug(f"Adding site {site.get_name()}")
         try:
-            self.lock.acquire()
+            #self.lock.acquire()
             properties = pickle.dumps(site)
             self.db.add_site(site_name=site.get_name(), state=site.get_state().value, properties=properties)
             self.logger.debug(f"Site {site.get_name()} added")
@@ -631,7 +632,7 @@ class ActorDatabase(ABCDatabase):
 
     def update_site(self, *, site: Site):
         try:
-            self.lock.acquire()
+            #self.lock.acquire()
             self.logger.debug(f"Updating site {site.get_name()}")
             properties = pickle.dumps(site)
             self.db.update_site(site_name=site.get_name(), state=site.get_state().value, properties=properties)
@@ -641,7 +642,7 @@ class ActorDatabase(ABCDatabase):
 
     def remove_site(self, *, site_name: str):
         try:
-            self.lock.acquire()
+            #self.lock.acquire()
             self.logger.debug(f"Removing site {site_name}")
             self.db.remove_site(site_name=site_name)
         finally:
@@ -662,7 +663,7 @@ class ActorDatabase(ABCDatabase):
 
     def get_site(self, *, site_name: str) -> Site or None:
         try:
-            self.lock.acquire()
+            #self.lock.acquire()
             site_list = self.db.get_site(site_name=site_name)
             if self.lock.locked():
                 self.lock.release()
@@ -679,9 +680,10 @@ class ActorDatabase(ABCDatabase):
     def get_sites(self) -> List[Site]:
         result = []
         try:
-            self.lock.acquire()
+            #self.lock.acquire()
             site_list = self.db.get_sites()
-            self.lock.release()
+            if self.lock.locked():
+                self.lock.release()
             result = self._load_site_from_db(site_list=site_list)
         except Exception as e:
             self.logger.error(e)
@@ -692,7 +694,7 @@ class ActorDatabase(ABCDatabase):
 
     def add_config_mapping(self, key: str, config_mapping: ConfigurationMapping):
         try:
-            self.lock.acquire()
+            #self.lock.acquire()
             properties = pickle.dumps(config_mapping)
             self.db.add_config_mapping(cfgm_type=key, act_id=self.actor_id, properties=properties)
         except Exception as e:
@@ -707,7 +709,7 @@ class ActorDatabase(ABCDatabase):
         cfg_map_list = None
         result = []
         try:
-            self.lock.acquire()
+            #self.lock.acquire()
             cfg_map_list = self.db.get_config_mappings(act_id=self.actor_id)
         except Exception as e:
             self.logger.error(e)

--- a/fabric_cf/actor/core/plugins/db/client_database.py
+++ b/fabric_cf/actor/core/plugins/db/client_database.py
@@ -60,7 +60,7 @@ class ClientDatabase:
         """
 
     @abstractmethod
-    def get_client(self, *, guid: ID) -> Client:
+    def get_client(self, *, guid: ID) -> Client or None:
         """
         Retrieves the specified client record
         @param guid client guid

--- a/fabric_cf/actor/core/plugins/db/server_actor_database.py
+++ b/fabric_cf/actor/core/plugins/db/server_actor_database.py
@@ -36,32 +36,35 @@ from fabric_cf.actor.core.util.id import ID
 class ServerActorDatabase(ActorDatabase, ClientDatabase):
     def add_client(self, *, client: Client):
         try:
-            self.lock.acquire()
+            #self.lock.acquire()
             properties = pickle.dumps(client)
             self.db.add_client(act_id=self.actor_id, clt_name=client.get_name(), clt_guid=str(client.get_guid()),
                                properties=properties)
         finally:
-            self.lock.release()
+            if self.lock.locked():
+                self.lock.release()
 
     def update_client(self, *, client: Client):
         try:
-            self.lock.acquire()
+            #self.lock.acquire()
             properties = pickle.dumps(client)
             self.db.update_client(act_id=self.actor_id, clt_name=client.get_name(), properties=properties)
         finally:
-            self.lock.release()
+            if self.lock.locked():
+                self.lock.release()
 
     def remove_client(self, *, guid: ID):
         try:
-            self.lock.acquire()
+            #self.lock.acquire()
             self.db.remove_client_by_guid(act_id=self.actor_id, clt_guid=str(guid))
         finally:
-            self.lock.release()
+            if self.lock.locked():
+                self.lock.release()
 
     def get_client(self, *, guid: ID) -> Client or None:
         result = None
         try:
-            self.lock.acquire()
+            #self.lock.acquire()
             client_dict = self.db.get_client_by_guid(clt_guid=str(guid))
             if client_dict is not None:
                 pickled_client = client_dict.get(Constants.PROPERTY_PICKLE_PROPERTIES)
@@ -69,13 +72,14 @@ class ServerActorDatabase(ActorDatabase, ClientDatabase):
         except Exception as e:
             self.logger.error(e)
         finally:
-            self.lock.release()
+            if self.lock.locked():
+                self.lock.release()
         return result
 
     def get_clients(self) -> List[Client]:
         result = None
         try:
-            self.lock.acquire()
+            #self.lock.acquire()
             result = []
             client_dict_list = self.db.get_clients()
             if client_dict_list is not None:
@@ -87,5 +91,6 @@ class ServerActorDatabase(ActorDatabase, ClientDatabase):
         except Exception as e:
             self.logger.error(e)
         finally:
-            self.lock.release()
+            if self.lock.locked():
+                self.lock.release()
         return result

--- a/fabric_cf/actor/core/plugins/db/server_actor_database.py
+++ b/fabric_cf/actor/core/plugins/db/server_actor_database.py
@@ -58,7 +58,7 @@ class ServerActorDatabase(ActorDatabase, ClientDatabase):
         finally:
             self.lock.release()
 
-    def get_client(self, *, guid: ID) -> Client:
+    def get_client(self, *, guid: ID) -> Client or None:
         result = None
         try:
             self.lock.acquire()

--- a/fabric_cf/actor/core/plugins/handlers/handler_processor.py
+++ b/fabric_cf/actor/core/plugins/handlers/handler_processor.py
@@ -103,34 +103,34 @@ class HandlerProcessor:
             self.lock.release()
 
     def create(self, unit: ConfigToken):
-        self.logger.info("Executing Create")
+        self.logger.debug("Executing Create")
 
         result = {Constants.PROPERTY_TARGET_NAME: Constants.TARGET_CREATE,
                   Constants.PROPERTY_TARGET_RESULT_CODE: Constants.RESULT_CODE_OK,
                   Constants.PROPERTY_ACTION_SEQUENCE_NUMBER: 0}
 
         self.plugin.configuration_complete(token=unit, properties=result)
-        self.logger.info("Executing Create completed")
+        self.logger.debug("Executing Create completed")
 
     def delete(self, unit: ConfigToken):
-        self.logger.info("Executing Delete")
+        self.logger.debug("Executing Delete")
 
         result = {Constants.PROPERTY_TARGET_NAME: Constants.TARGET_DELETE,
                   Constants.PROPERTY_TARGET_RESULT_CODE: Constants.RESULT_CODE_OK,
                   Constants.PROPERTY_ACTION_SEQUENCE_NUMBER: 0}
 
         self.plugin.configuration_complete(token=unit, properties=result)
-        self.logger.info("Executing Delete completed")
+        self.logger.debug("Executing Delete completed")
 
     def modify(self, unit: ConfigToken):
-        self.logger.info("Executing Modify")
+        self.logger.debug("Executing Modify")
 
         result = {Constants.PROPERTY_TARGET_NAME: Constants.TARGET_MODIFY,
                   Constants.PROPERTY_TARGET_RESULT_CODE: Constants.RESULT_CODE_OK,
                   Constants.PROPERTY_ACTION_SEQUENCE_NUMBER: 0}
 
         self.plugin.configuration_complete(token=unit, properties=result)
-        self.logger.info("Executing Modify completed")
+        self.logger.debug("Executing Modify completed")
 
     def set_logger(self, *, logger):
         self.logger = logger

--- a/fabric_cf/actor/core/plugins/substrate/db/substrate_actor_database.py
+++ b/fabric_cf/actor/core/plugins/substrate/db/substrate_actor_database.py
@@ -52,7 +52,7 @@ class SubstrateActorDatabase(ServerActorDatabase, ABCSubstrateDatabase):
         try:
             if u.get_resource_type() is None:
                 raise DatabaseException(Constants.INVALID_ARGUMENT)
-            self.lock.acquire()
+            #self.lock.acquire()
             if self.get_unit(uid=u.get_id()) is not None:
                 self.logger.info("unit {} is already present in database".format(u.get_id()))
                 return
@@ -77,7 +77,7 @@ class SubstrateActorDatabase(ServerActorDatabase, ABCSubstrateDatabase):
     def get_units(self, *, rid: ID):
         result = None
         try:
-            self.lock.acquire()
+            #self.lock.acquire()
             result = []
             unit_dict_list = self.db.get_units(rsv_resid=str(rid))
             if unit_dict_list is not None:
@@ -95,7 +95,7 @@ class SubstrateActorDatabase(ServerActorDatabase, ABCSubstrateDatabase):
 
     def remove_unit(self, *, uid: ID):
         try:
-            self.lock.acquire()
+            #self.lock.acquire()
             self.db.remove_unit(unt_uid=str(uid))
         finally:
             if self.lock.locked():
@@ -103,7 +103,7 @@ class SubstrateActorDatabase(ServerActorDatabase, ABCSubstrateDatabase):
 
     def update_unit(self, *, u: Unit):
         try:
-            self.lock.acquire()
+            #self.lock.acquire()
             properties = pickle.dumps(u)
             self.db.update_unit(unt_uid=str(u.get_id()), properties=properties)
         finally:

--- a/fabric_cf/actor/core/plugins/substrate/db/substrate_actor_database.py
+++ b/fabric_cf/actor/core/plugins/substrate/db/substrate_actor_database.py
@@ -58,7 +58,9 @@ class SubstrateActorDatabase(ServerActorDatabase, ABCSubstrateDatabase):
                 return
 
             slice_id = str(u.get_slice_id())
-            parent = self.get_unit(uid=u.get_parent_id())
+            parent = None
+            if u.get_parent_id() is not None:
+                parent = self.get_unit(uid=u.get_parent_id())
             parent_id = None
             if parent is not None:
                 parent_id = parent['unt_id']

--- a/fabric_cf/actor/core/policy/controller_calendar_policy.py
+++ b/fabric_cf/actor/core/policy/controller_calendar_policy.py
@@ -72,7 +72,7 @@ class ControllerCalendarPolicy(Policy, ABCControllerPolicy):
         if rvset is None:
             return
 
-        for reservation in rvset.values():
+        for reservation in rvset.reservations.values():
             if reservation.is_failed():
                 # This reservation has failed. Remove it from the list. This is
                 # a separate case, because we may fail but not satisfy the
@@ -215,7 +215,7 @@ class ControllerCalendarPolicy(Policy, ABCControllerPolicy):
     def get_closing(self, *, cycle: int) -> ReservationSet:
         closing = self.calendar.get_closing(cycle=cycle)
         result = ReservationSet()
-        for reservation in closing.values():
+        for reservation in closing.reservations.values():
             if not reservation.is_failed():
                 self.calendar.add_pending(reservation=reservation)
                 result.add(reservation=reservation)

--- a/fabric_cf/actor/core/policy/controller_simple_policy.py
+++ b/fabric_cf/actor/core/policy/controller_simple_policy.py
@@ -177,12 +177,12 @@ class ControllerSimplePolicy(ControllerCalendarPolicy):
         if renewing is None or renewing.size() == 0:
             return result
 
-        self.logger.debug("Renewing = {}".format(renewing.size()))
+        #self.logger.debug("Renewing = {}".format(renewing.size()))
         for reservation in renewing.values():
-            self.logger.debug("Renewing res: {}".format(reservation))
+            #self.logger.debug("Renewing res: {}".format(reservation))
 
             if reservation.is_renewable():
-                self.logger.debug("Found a renewable reservation that needs an extension.")
+                #self.logger.debug("Found a renewable reservation that needs an extension.")
                 if reservation.is_closed() or reservation.is_closing() or reservation.is_failed():
                     self.logger.debug("Found a renewable reservation that is closing/closed/or failed")
                 else:

--- a/fabric_cf/actor/core/policy/controller_ticket_review_policy.py
+++ b/fabric_cf/actor/core/policy/controller_ticket_review_policy.py
@@ -111,7 +111,7 @@ class ControllerTicketReviewPolicy(ControllerSimplePolicy):
                     # examine every reservation contained within the slice,
                     # looking for either a Failed or Nascent reservation
                     # we have to look at everything in a slice once, to determine all/any Sites with failures
-                    for slice_reservation in slice_obj.get_reservations().values():
+                    for slice_reservation in slice_obj.get_reservations_list():
 
                         # If any Reservations that are being redeemed, that means the
                         # slice has already cleared TicketReview.

--- a/fabric_cf/actor/core/policy/controller_ticket_review_policy.py
+++ b/fabric_cf/actor/core/policy/controller_ticket_review_policy.py
@@ -84,7 +84,7 @@ class ControllerTicketReviewPolicy(ControllerSimplePolicy):
         @throws Exception in case of error
         """
         # add all of our pendingRedeem, so they can be checked
-        for reservation in self.pending_redeem.values():
+        for reservation in self.pending_redeem.reservations.values():
             self.calendar.add_pending(reservation=reservation)
 
         # get set of reservations that need to be redeemed
@@ -98,7 +98,7 @@ class ControllerTicketReviewPolicy(ControllerSimplePolicy):
             return
 
         # check the status of the Slice of each reservation
-        for reservation in my_pending.values():
+        for reservation in my_pending.reservations.values():
             slice_obj = reservation.get_slice()
             slice_id = slice_obj.get_slice_id()
 

--- a/fabric_cf/actor/core/util/reservation_set.py
+++ b/fabric_cf/actor/core/util/reservation_set.py
@@ -23,7 +23,6 @@
 #
 #
 # Author: Komal Thareja (kthare10@renci.org)
-import datetime
 import threading
 
 from fabric_cf.actor.core.apis.abc_reservation_mixin import ABCReservationMixin

--- a/fabric_cf/actor/core/util/reservation_set.py
+++ b/fabric_cf/actor/core/util/reservation_set.py
@@ -216,9 +216,6 @@ class ReservationSet:
     def values(self) -> list:
         try:
             self.lock.acquire()
-            result = []
-            for r in self.reservations.values():
-                result.append(r)
-            return result
+            return list(self.reservations.values())
         finally:
             self.lock.release()

--- a/fabric_cf/actor/db/__init__.py
+++ b/fabric_cf/actor/db/__init__.py
@@ -129,6 +129,7 @@ class Reservations(Base):
     Index('idx_resid_state', rsv_resid, rsv_state)
     Index('idx_slcid_state', rsv_slc_id, rsv_state)
     Index('idx_graph_id_res_id', rsv_graph_node_id, rsv_resid)
+    Index('idx_res_id', rsv_resid)
 
 
 class Slices(Base):

--- a/fabric_cf/actor/db/__init__.py
+++ b/fabric_cf/actor/db/__init__.py
@@ -129,7 +129,6 @@ class Reservations(Base):
     Index('idx_resid_state', rsv_resid, rsv_state)
     Index('idx_slcid_state', rsv_slc_id, rsv_state)
     Index('idx_graph_id_res_id', rsv_graph_node_id, rsv_resid)
-    Index('idx_res_id', rsv_resid)
 
 
 class Slices(Base):

--- a/fabric_cf/actor/db/psql_database.py
+++ b/fabric_cf/actor/db/psql_database.py
@@ -154,9 +154,8 @@ class PsqlDatabase:
         session = self.get_session()
         try:
             # Delete the actor in the database
-            
-                session.query(Actors).filter_by(act_name=name).delete()
-
+            session.query(Actors).filter_by(act_name=name).delete()
+            session.commit()
         except Exception as e:
             session.rollback()
             self.logger.error(Constants.EXCEPTION_OCCURRED.format(e))
@@ -170,11 +169,9 @@ class PsqlDatabase:
         result = []
         session = self.get_session()
         try:
-            
-                for row in session.query(Actors).all():
-                    result.append(self.generate_dict_from_row(row=row))
+            for row in session.query(Actors).all():
+                result.append(self.generate_dict_from_row(row=row))
         except Exception as e:
-            session.rollback()
             self.logger.error(Constants.EXCEPTION_OCCURRED.format(e))
             raise e
         return result
@@ -189,12 +186,10 @@ class PsqlDatabase:
         result = []
         session = self.get_session()
         try:
-            
-                for row in session.query(Actors).filter(Actors.act_type == act_type).filter(
-                        Actors.act_name.like(actor_name)).all():
-                    result.append(self.generate_dict_from_row(row=row))
+            for row in session.query(Actors).filter(Actors.act_type == act_type).filter(
+                    Actors.act_name.like(actor_name)).all():
+                result.append(self.generate_dict_from_row(row=row))
         except Exception as e:
-            session.rollback()
             self.logger.error(Constants.EXCEPTION_OCCURRED.format(e))
             raise e
         return result
@@ -208,11 +203,9 @@ class PsqlDatabase:
         result = []
         session = self.get_session()
         try:
-            
-                for row in session.query(Actors).filter(Actors.act_name.like(act_name)).all():
-                    result.append(self.generate_dict_from_row(row=row))
+            for row in session.query(Actors).filter(Actors.act_name.like(act_name)).all():
+                result.append(self.generate_dict_from_row(row=row))
         except Exception as e:
-            session.rollback()
             self.logger.error(Constants.EXCEPTION_OCCURRED.format(e))
             raise e
         return result
@@ -225,19 +218,17 @@ class PsqlDatabase:
         result = {}
         session = self.get_session()
         try:
-            
-                actor = session.query(Actors).filter_by(act_name=name).one_or_none()
-                if actor is not None:
-                    result['act_guid'] = actor.act_guid
-                    result['act_name'] = actor.act_name
-                    result['act_type'] = actor.act_type
-                    result['properties'] = actor.properties
-                    result['act_id'] = actor.act_id
-                else:
-                    result = None
-                    self.logger.error("Actor: {} not found!".format(name))
+            actor = session.query(Actors).filter_by(act_name=name).one_or_none()
+            if actor is not None:
+                result['act_guid'] = actor.act_guid
+                result['act_name'] = actor.act_name
+                result['act_type'] = actor.act_type
+                result['properties'] = actor.properties
+                result['act_id'] = actor.act_id
+            else:
+                result = None
+                self.logger.error("Actor: {} not found!".format(name))
         except Exception as e:
-            session.rollback()
             self.logger.error(Constants.EXCEPTION_OCCURRED.format(e))
             raise e
         return result
@@ -253,6 +244,7 @@ class PsqlDatabase:
         try:
             msc_obj = Miscellaneous(msc_path=name, properties=properties)
             session.add(msc_obj)
+            session.commit()
         except Exception as e:
             session.rollback()
             self.logger.error(Constants.EXCEPTION_OCCURRED.format(e))
@@ -270,6 +262,7 @@ class PsqlDatabase:
             msc_obj = session.query(Miscellaneous).filter_by(msc_path=name).one_or_none()
             if msc_obj is not None:
                 msc_obj.properties = properties
+            session.commit()
         except Exception as e:
             session.rollback()
             self.logger.error(Constants.EXCEPTION_OCCURRED.format(e))
@@ -283,6 +276,7 @@ class PsqlDatabase:
         session = self.get_session()
         try:
             session.query(Miscellaneous).filter_by(msc_path=name).delete()
+            session.commit()
         except Exception as e:
             session.rollback()
             self.logger.error(Constants.EXCEPTION_OCCURRED.format(e))
@@ -303,7 +297,6 @@ class PsqlDatabase:
             else:
                 return None
         except Exception as e:
-            session.rollback()
             self.logger.error(Constants.EXCEPTION_OCCURRED.format(e))
             raise e
         return result
@@ -322,6 +315,7 @@ class PsqlDatabase:
             else:
                 mng_obj = ManagerObjects(mo_key=manager_key, properties=properties)
             session.add(mng_obj)
+            session.commit()
         except Exception as e:
             session.rollback()
             self.logger.error(Constants.EXCEPTION_OCCURRED.format(e))
@@ -335,6 +329,7 @@ class PsqlDatabase:
         session = self.get_session()
         try:
             session.query(ManagerObjects).filter_by(mo_key=manager_key).delete()
+            session.commit()
         except Exception as e:
             session.rollback()
             self.logger.error(Constants.EXCEPTION_OCCURRED.format(e))
@@ -348,6 +343,7 @@ class PsqlDatabase:
         session = self.get_session()
         try:
             session.query(ManagerObjects).filter_by(mo_act_id=act_id).delete()
+            session.commit()
         except Exception as e:
             session.rollback()
             self.logger.error(Constants.EXCEPTION_OCCURRED.format(e))
@@ -369,9 +365,7 @@ class PsqlDatabase:
 
             for row in rows:
                 result.append(self.generate_dict_from_row(row=row))
-
         except Exception as e:
-            session.rollback()
             self.logger.error(Constants.EXCEPTION_OCCURRED.format(e))
             raise e
         return result
@@ -407,7 +401,6 @@ class PsqlDatabase:
             else:
                 raise DatabaseException(self.OBJECT_NOT_FOUND.format("Manager Object", mo_key))
         except Exception as e:
-            session.rollback()
             self.logger.error(Constants.EXCEPTION_OCCURRED.format(e))
             raise e
         return result
@@ -420,11 +413,9 @@ class PsqlDatabase:
         result = []
         session = self.get_session()
         try:
-            
-                for mo_obj in session.query(ManagerObjects).filter(ManagerObjects.mo_act_id.is_(None)).all():
-                    result.append(self.generate_dict_from_row(mo_obj))
+            for mo_obj in session.query(ManagerObjects).filter(ManagerObjects.mo_act_id.is_(None)).all():
+                result.append(self.generate_dict_from_row(mo_obj))
         except Exception as e:
-            session.rollback()
             self.logger.error(Constants.EXCEPTION_OCCURRED.format(e))
             raise e
         return result
@@ -456,7 +447,8 @@ class PsqlDatabase:
             if slc_graph_id is not None:
                 slc_obj.slc_graph_id = slc_graph_id
             
-                session.add(slc_obj)
+            session.add(slc_obj)
+            session.commit()
         except Exception as e:
             session.rollback()
             self.logger.error(Constants.EXCEPTION_OCCURRED.format(e))
@@ -478,20 +470,20 @@ class PsqlDatabase:
         """
         session = self.get_session()
         try:
-            
-                slc_obj = session.query(Slices).filter_by(slc_guid=slc_guid).one_or_none()
-                if slc_obj is not None:
-                    slc_obj.properties = properties
-                    slc_obj.slc_name = slc_name
-                    slc_obj.slc_type = slc_type
-                    slc_obj.slc_resource_type = slc_resource_type
-                    slc_obj.slc_state = slc_state
-                    slc_obj.lease_start = lease_start
-                    slc_obj.lease_end = lease_end
-                    if slc_graph_id is not None:
-                        slc_obj.slc_graph_id = slc_graph_id
-                else:
-                    raise DatabaseException(self.OBJECT_NOT_FOUND.format("Slice", slc_guid))
+            slc_obj = session.query(Slices).filter_by(slc_guid=slc_guid).one_or_none()
+            if slc_obj is not None:
+                slc_obj.properties = properties
+                slc_obj.slc_name = slc_name
+                slc_obj.slc_type = slc_type
+                slc_obj.slc_resource_type = slc_resource_type
+                slc_obj.slc_state = slc_state
+                slc_obj.lease_start = lease_start
+                slc_obj.lease_end = lease_end
+                if slc_graph_id is not None:
+                    slc_obj.slc_graph_id = slc_graph_id
+            else:
+                raise DatabaseException(self.OBJECT_NOT_FOUND.format("Slice", slc_guid))
+            session.commit()
         except Exception as e:
             session.rollback()
             self.logger.error(Constants.EXCEPTION_OCCURRED.format(e))
@@ -504,8 +496,8 @@ class PsqlDatabase:
         """
         session = self.get_session()
         try:
-            
-                session.query(Slices).filter_by(slc_guid=slc_guid).delete()
+            session.query(Slices).filter_by(slc_guid=slc_guid).delete()
+            session.commit()
         except Exception as e:
             session.rollback()
             self.logger.error(Constants.EXCEPTION_OCCURRED.format(e))
@@ -520,11 +512,9 @@ class PsqlDatabase:
         result = []
         session = self.get_session()
         try:
-            
-                for row in session.query(Slices).all():
-                    result.append(row.slc_id)
+            for row in session.query(Slices).all():
+                result.append(row.slc_id)
         except Exception as e:
-            session.rollback()
             self.logger.error(Constants.EXCEPTION_OCCURRED.format(e))
             raise e
         return result
@@ -588,7 +578,6 @@ class PsqlDatabase:
             for row in rows.all():
                 result.append(self.generate_dict_from_row(row=row))
         except Exception as e:
-            session.rollback()
             self.logger.error(Constants.EXCEPTION_OCCURRED.format(e))
             raise e
         return result
@@ -608,7 +597,6 @@ class PsqlDatabase:
             else:
                 raise DatabaseException(self.OBJECT_NOT_FOUND.format("Slice", slc_id))
         except Exception as e:
-            session.rollback()
             self.logger.error(Constants.EXCEPTION_OCCURRED.format(e))
             raise e
         return result
@@ -647,6 +635,7 @@ class PsqlDatabase:
                 rsv_obj.rsv_graph_node_id = rsv_graph_node_id
             
             session.add(rsv_obj)
+            session.commit()
         except Exception as e:
             session.rollback()
             self.logger.error(Constants.EXCEPTION_OCCURRED.format(e))
@@ -690,6 +679,7 @@ class PsqlDatabase:
                     rsv_obj.rsv_type = rsv_type
             else:
                 raise DatabaseException(self.OBJECT_NOT_FOUND.format("Reservation", rsv_resid))
+            session.commit()
         except Exception as e:
             session.rollback()
             self.logger.error(Constants.EXCEPTION_OCCURRED.format(e))
@@ -703,6 +693,7 @@ class PsqlDatabase:
         session = self.get_session()
         try:
             session.query(Reservations).filter_by(rsv_resid=rsv_resid).delete()
+            session.commit()
         except Exception as e:
             session.rollback()
             self.logger.error(Constants.EXCEPTION_OCCURRED.format(e))
@@ -767,7 +758,6 @@ class PsqlDatabase:
             for row in rows.all():
                 result.append(self.generate_dict_from_row(row=row))
         except Exception as e:
-            session.rollback()
             self.logger.error(Constants.EXCEPTION_OCCURRED.format(e))
             raise e
         return result
@@ -785,7 +775,6 @@ class PsqlDatabase:
             for row in session.query(Reservations).filter(Reservations.rsv_resid.in_(rsv_resid_list)).all():
                 result.append(self.generate_dict_from_row(row=row))
         except Exception as e:
-            session.rollback()
             self.logger.error(Constants.EXCEPTION_OCCURRED.format(e))
             raise e
         return result
@@ -801,6 +790,7 @@ class PsqlDatabase:
         try:
             prx_obj = Proxies(prx_act_id=act_id, prx_name=prx_name, properties=properties)
             session.add(prx_obj)
+            session.commit()
         except Exception as e:
             session.rollback()
             self.logger.error(Constants.EXCEPTION_OCCURRED.format(e))
@@ -821,6 +811,7 @@ class PsqlDatabase:
                 prx_obj.properties = properties
             else:
                 raise DatabaseException(self.OBJECT_NOT_FOUND.format("Proxy", prx_name))
+            session.commit()
         except Exception as e:
             session.rollback()
             self.logger.error(Constants.EXCEPTION_OCCURRED.format(e))
@@ -834,8 +825,8 @@ class PsqlDatabase:
         """
         session = self.get_session()
         try:
-            session.query(Proxies).filter(Proxies.prx_act_id == act_id).filter(
-                Proxies.prx_name == prx_name).delete()
+            session.query(Proxies).filter(Proxies.prx_act_id == act_id).filter(Proxies.prx_name == prx_name).delete()
+            session.commit()
         except Exception as e:
             session.rollback()
             self.logger.error(Constants.EXCEPTION_OCCURRED.format(e))
@@ -852,7 +843,6 @@ class PsqlDatabase:
             for row in session.query(Proxies).filter_by(prx_act_id=act_id).all():
                 result.append(self.generate_dict_from_row(row=row))
         except Exception as e:
-            session.rollback()
             self.logger.error(Constants.EXCEPTION_OCCURRED.format(e))
             raise e
         return result
@@ -868,6 +858,7 @@ class PsqlDatabase:
         try:
             cfg_obj = ConfigMappings(cfgm_act_id=act_id, cfgm_type=cfgm_type, properties=properties)
             session.add(cfg_obj)
+            session.commit()
         except Exception as e:
             session.rollback()
             self.logger.error(Constants.EXCEPTION_OCCURRED.format(e))
@@ -888,6 +879,7 @@ class PsqlDatabase:
                 cfg_obj.properties = properties
             else:
                 raise DatabaseException(self.OBJECT_NOT_FOUND.format("Config Mapping", cfgm_type))
+            session.commit()
         except Exception as e:
             session.rollback()
             self.logger.error(Constants.EXCEPTION_OCCURRED.format(e))
@@ -901,6 +893,7 @@ class PsqlDatabase:
         session = self.get_session()
         try:
             session.query(ConfigMappings).filter_by(cfgm_type=cfgm_type).delete()
+            session.commit()
         except Exception as e:
             session.rollback()
             self.logger.error(Constants.EXCEPTION_OCCURRED.format(e))
@@ -918,7 +911,6 @@ class PsqlDatabase:
             for row in session.query(ConfigMappings).filter_by(cfgm_act_id=act_id).all():
                 result.append(self.generate_dict_from_row(row=row))
         except Exception as e:
-            session.rollback()
             self.logger.error(Constants.EXCEPTION_OCCURRED.format(e))
             raise e
         return result
@@ -935,6 +927,7 @@ class PsqlDatabase:
         try:
             clt_obj = Clients(clt_act_id=act_id, clt_name=clt_name, clt_guid=clt_guid, properties=properties)
             session.add(clt_obj)
+            session.commit()
         except Exception as e:
             session.rollback()
             self.logger.error(Constants.EXCEPTION_OCCURRED.format(e))
@@ -955,6 +948,7 @@ class PsqlDatabase:
                 clt_obj.properties = properties
             else:
                 raise DatabaseException(self.OBJECT_NOT_FOUND.format("Client", clt_name))
+            session.commit()
         except Exception as e:
             session.rollback()
             self.logger.error(Constants.EXCEPTION_OCCURRED.format(e))
@@ -968,8 +962,8 @@ class PsqlDatabase:
         """
         session = self.get_session()
         try:
-            session.query(Clients).filter(Clients.clt_act_id == act_id).filter(
-                Clients.clt_name == clt_name).delete()
+            session.query(Clients).filter(Clients.clt_act_id == act_id).filter(Clients.clt_name == clt_name).delete()
+            session.commit()
         except Exception as e:
             session.rollback()
             self.logger.error(Constants.EXCEPTION_OCCURRED.format(e))
@@ -983,8 +977,8 @@ class PsqlDatabase:
         """
         session = self.get_session()
         try:
-            session.query(Clients).filter(Clients.clt_act_id == act_id).filter(
-                Clients.clt_guid == clt_guid).delete()
+            session.query(Clients).filter(Clients.clt_act_id == act_id).filter(Clients.clt_guid == clt_guid).delete()
+            session.commit()
         except Exception as e:
             session.rollback()
             self.logger.error(Constants.EXCEPTION_OCCURRED.format(e))
@@ -1005,7 +999,6 @@ class PsqlDatabase:
                 raise DatabaseException(self.OBJECT_NOT_FOUND.format("Client", clt_guid))
             result = self.generate_dict_from_row(clt_obj)
         except Exception as e:
-            session.rollback()
             self.logger.error(Constants.EXCEPTION_OCCURRED.format(e))
             raise e
         return result
@@ -1022,7 +1015,6 @@ class PsqlDatabase:
             for row in session.query(Clients).all():
                 result.append(self.generate_dict_from_row(row=row))
         except Exception as e:
-            session.rollback()
             self.logger.error(Constants.EXCEPTION_OCCURRED.format(e))
             raise e
         return result
@@ -1051,6 +1043,7 @@ class PsqlDatabase:
             if unt_unt_id is not None:
                 unt_obj.unt_unt_id = unt_unt_id
             session.add(unt_obj)
+            session.commit()
         except Exception as e:
             session.rollback()
             self.logger.error(Constants.EXCEPTION_OCCURRED.format(e))
@@ -1072,7 +1065,6 @@ class PsqlDatabase:
                 return result
             result = self.generate_dict_from_row(unt_obj)
         except Exception as e:
-            session.rollback()
             self.logger.error(Constants.EXCEPTION_OCCURRED.format(e))
             raise e
         return result
@@ -1094,7 +1086,6 @@ class PsqlDatabase:
             for row in session.query(Units).filter_by(unt_rsv_id=rsv_obj['rsv_id']).all():
                 result.append(self.generate_dict_from_row(row=row))
         except Exception as e:
-            session.rollback()
             self.logger.error(Constants.EXCEPTION_OCCURRED.format(e))
             raise e
         return result
@@ -1107,6 +1098,7 @@ class PsqlDatabase:
         session = self.get_session()
         try:
             session.query(Units).filter_by(unt_uid=unt_uid).delete()
+            session.commit()
         except Exception as e:
             session.rollback()
             self.logger.error(Constants.EXCEPTION_OCCURRED.format(e))
@@ -1125,6 +1117,7 @@ class PsqlDatabase:
             if unt_obj is None:
                 raise DatabaseException(self.OBJECT_NOT_FOUND.format("Unit", unt_uid))
             unt_obj.properties = properties
+            session.commit()
         except Exception as e:
             session.rollback()
             self.logger.error(Constants.EXCEPTION_OCCURRED.format(e))
@@ -1146,6 +1139,7 @@ class PsqlDatabase:
             dlg_obj = Delegations(dlg_slc_id=slc_id, dlg_graph_id=dlg_graph_id,
                                   dlg_state=dlg_state, properties=properties, site=site)
             session.add(dlg_obj)
+            session.commit()
         except Exception as e:
             session.rollback()
             self.logger.error(Constants.EXCEPTION_OCCURRED.format(e))
@@ -1168,6 +1162,7 @@ class PsqlDatabase:
                     dlg_obj.site = site
             else:
                 raise DatabaseException(self.OBJECT_NOT_FOUND.format("Delegation", dlg_graph_id))
+            session.commit()
         except Exception as e:
             session.rollback()
             self.logger.error(Constants.EXCEPTION_OCCURRED.format(e))
@@ -1181,6 +1176,7 @@ class PsqlDatabase:
         session = self.get_session()
         try:
             session.query(Delegations).filter_by(dlg_graph_id=dlg_graph_id).delete()
+            session.commit()
         except Exception as e:
             session.rollback()
             self.logger.error(Constants.EXCEPTION_OCCURRED.format(e))
@@ -1217,7 +1213,6 @@ class PsqlDatabase:
             for row in rows.all():
                 result.append(self.generate_dict_from_row(row=row))
         except Exception as e:
-            session.rollback()
             self.logger.error(Constants.EXCEPTION_OCCURRED.format(e))
             raise e
         return result
@@ -1237,7 +1232,6 @@ class PsqlDatabase:
             else:
                 raise DatabaseException(self.OBJECT_NOT_FOUND.format("Delegation", dlg_graph_id))
         except Exception as e:
-            session.rollback()
             self.logger.error(Constants.EXCEPTION_OCCURRED.format(e))
             raise e
         return result
@@ -1253,6 +1247,7 @@ class PsqlDatabase:
         try:
             site_obj = Sites(name=site_name, state=state, properties=properties)
             session.add(site_obj)
+            session.commit()
         except Exception as e:
             session.rollback()
             self.logger.error(Constants.EXCEPTION_OCCURRED.format(e))
@@ -1273,6 +1268,7 @@ class PsqlDatabase:
                 site_obj.state = state
             else:
                 raise DatabaseException(self.OBJECT_NOT_FOUND.format("Sites", site_name))
+            session.commit()
         except Exception as e:
             session.rollback()
             self.logger.error(Constants.EXCEPTION_OCCURRED.format(e))
@@ -1286,6 +1282,7 @@ class PsqlDatabase:
         session = self.get_session()
         try:
             session.query(Sites).filter_by(name=site_name).delete()
+            session.commit()
         except Exception as e:
             session.rollback()
             self.logger.error(Constants.EXCEPTION_OCCURRED.format(e))
@@ -1301,7 +1298,6 @@ class PsqlDatabase:
             for row in session.query(Sites).all():
                 result.append(self.generate_dict_from_row(row=row))
         except Exception as e:
-            session.rollback()
             self.logger.error(Constants.EXCEPTION_OCCURRED.format(e))
             raise e
         return result
@@ -1316,7 +1312,6 @@ class PsqlDatabase:
             for row in session.query(Sites).filter_by(name=site_name).all():
                 result.append(self.generate_dict_from_row(row=row))
         except Exception as e:
-            session.rollback()
             self.logger.error(Constants.EXCEPTION_OCCURRED.format(e))
             raise e
         return result

--- a/fabric_cf/actor/db/psql_database.py
+++ b/fabric_cf/actor/db/psql_database.py
@@ -663,11 +663,8 @@ class PsqlDatabase:
         @param rsv_type reservation type
         """
         try:
-            filter_dict = self.create_reservation_filter(slice_id=slc_guid, graph_node_id=rsv_graph_node_id,
-                                                         rid=rsv_resid, site=site)
             with session_scope(self.db_engine) as session:
-                rows = session.query(Reservations).filter_by(**filter_dict)
-                rsv_obj = rows.first()
+                rsv_obj = session.query(Reservations).filter(Reservations.rsv_resid == rsv_resid).one()
                 if rsv_obj is not None:
                     rsv_obj.rsv_category = rsv_category
                     rsv_obj.rsv_state = rsv_state

--- a/fabric_cf/actor/db/psql_database.py
+++ b/fabric_cf/actor/db/psql_database.py
@@ -663,10 +663,11 @@ class PsqlDatabase:
         @param rsv_type reservation type
         """
         try:
-            slc_id = self.get_slc_id_by_slice_id(slice_id=slc_guid)
+            filter_dict = self.create_reservation_filter(slice_id=slc_guid, graph_node_id=rsv_graph_node_id,
+                                                         rid=rsv_resid, site=site)
             with session_scope(self.db_engine) as session:
-                rsv_obj = session.query(Reservations).filter(Reservations.rsv_slc_id == slc_id).filter(
-                    Reservations.rsv_resid == rsv_resid).first()
+                rows = session.query(Reservations).filter_by(**filter_dict)
+                rsv_obj = rows.first()
                 if rsv_obj is not None:
                     rsv_obj.rsv_category = rsv_category
                     rsv_obj.rsv_state = rsv_state
@@ -1120,7 +1121,7 @@ class PsqlDatabase:
             with session_scope(self.db_engine) as session:
                 unt_obj = session.query(Units).filter(Units.unt_uid == unt_uid).first()
                 if unt_obj is None:
-                    self.logger.error("Unit with guid {} not found".format(unt_uid))
+                    self.logger.debug("Unit with guid {} not found".format(unt_uid))
                     return result
                 result = self.generate_unit_dict_from_row(unt_obj)
         except Exception as e:

--- a/fabric_cf/actor/db/psql_database.py
+++ b/fabric_cf/actor/db/psql_database.py
@@ -715,8 +715,7 @@ class PsqlDatabase:
         return rsv_obj
 
     def create_reservation_filter(self, *, slice_id: str = None, graph_node_id: str = None, project_id: str = None,
-                                  email: str = None, oidc_sub: str = None, rid: str = None, site: str = None,
-                                  rsv_type: str = None) -> dict:
+                                  email: str = None, oidc_sub: str = None, rid: str = None, site: str = None) -> dict:
 
         filter_dict = {}
         if slice_id is not None:
@@ -734,13 +733,11 @@ class PsqlDatabase:
             filter_dict['rsv_resid'] = rid
         if site is not None:
             filter_dict['site'] = site
-        if rsv_type is not None:
-            filter_dict['rsv_type'] = rsv_type
         return filter_dict
 
     def get_reservations(self, *, slice_id: str = None, graph_node_id: str = None, project_id: str = None,
                          email: str = None, oidc_sub: str = None, rid: str = None, states: list[int] = None,
-                         category: list[int] = None, site: str = None, rsv_type: str = None) -> list:
+                         category: list[int] = None, site: str = None, rsv_type: list[str] = None) -> list:
         """
         Get Reservations for an actor
         @param slice_id slice id
@@ -760,9 +757,12 @@ class PsqlDatabase:
         try:
             filter_dict = self.create_reservation_filter(slice_id=slice_id, graph_node_id=graph_node_id,
                                                          project_id=project_id, email=email, oidc_sub=oidc_sub,
-                                                         rid=rid, site=site, rsv_type=rsv_type)
+                                                         rid=rid, site=site)
             with session_scope(self.db_engine) as session:
                 rows = session.query(Reservations).filter_by(**filter_dict)
+
+                if rsv_type is not None:
+                    rows = rows.filter(Reservations.rsv_type.in_(rsv_type))
 
                 if states is not None:
                     rows = rows.filter(Reservations.rsv_state.in_(states))

--- a/fabric_cf/actor/db/psql_database.py
+++ b/fabric_cf/actor/db/psql_database.py
@@ -122,7 +122,7 @@ class PsqlDatabase:
         """
         try:
             with session_scope(self.db_engine) as session:
-                actor = session.query(Actors).filter_by(act_name=name).first()
+                actor = session.query(Actors).filter_by(act_name=name).one_or_none()
                 if actor is not None:
                     actor.properties = properties
 
@@ -138,7 +138,7 @@ class PsqlDatabase:
         try:
             # Delete the actor in the database
             with session_scope(self.db_engine) as session:
-                session.query(Actors).filter(Actors.act_name == name).delete()
+                session.query(Actors).filter_by(Actors.act_name == name).delete()
 
         except Exception as e:
             self.logger.error(Constants.EXCEPTION_OCCURRED.format(e))
@@ -153,10 +153,7 @@ class PsqlDatabase:
         try:
             with session_scope(self.db_engine) as session:
                 for row in session.query(Actors).all():
-                    actor = {'act_guid': row.act_guid, 'act_name': row.act_name, 'act_type': row.act_type,
-                             'properties': row.properties, 'act_id': row.act_id}
-                    result.append(actor.copy())
-                    actor.clear()
+                    result.append(dict(row.items()))
         except Exception as e:
             self.logger.error(Constants.EXCEPTION_OCCURRED.format(e))
             raise e
@@ -174,10 +171,7 @@ class PsqlDatabase:
             with session_scope(self.db_engine) as session:
                 for row in session.query(Actors).filter(Actors.act_type == act_type).filter(
                         Actors.act_name.like(actor_name)).all():
-                    actor = {'act_guid': row.act_guid, 'act_name': row.act_name, 'act_type': row.act_type,
-                             'properties': row.properties, 'act_id': row.act_id}
-                    result.append(actor.copy())
-                    actor.clear()
+                    result.append(dict(row.items()))
         except Exception as e:
             self.logger.error(Constants.EXCEPTION_OCCURRED.format(e))
             raise e
@@ -193,10 +187,7 @@ class PsqlDatabase:
         try:
             with session_scope(self.db_engine) as session:
                 for row in session.query(Actors).filter(Actors.act_name.like(act_name)).all():
-                    actor = {'act_guid': row.act_guid, 'act_name': row.act_name, 'act_type': row.act_type,
-                             'properties': row.properties, 'act_id': row.act_id}
-                    result.append(actor.copy())
-                    actor.clear()
+                    result.append(dict(row.items()))
         except Exception as e:
             self.logger.error(Constants.EXCEPTION_OCCURRED.format(e))
             raise e
@@ -210,7 +201,7 @@ class PsqlDatabase:
         result = {}
         try:
             with session_scope(self.db_engine) as session:
-                actor = session.query(Actors).filter_by(act_name=name).first()
+                actor = session.query(Actors).filter_by(act_name=name).one_or_none()
                 if actor is not None:
                     result['act_guid'] = actor.act_guid
                     result['act_name'] = actor.act_name
@@ -250,7 +241,7 @@ class PsqlDatabase:
         """
         try:
             with session_scope(self.db_engine) as session:
-                msc_obj = session.query(Miscellaneous).filter(Miscellaneous.msc_path == name).first()
+                msc_obj = session.query(Miscellaneous).filter_by(Miscellaneous.msc_path == name).one_or_none()
                 if msc_obj is not None:
                     msc_obj.properties = properties
         except Exception as e:
@@ -264,7 +255,7 @@ class PsqlDatabase:
         """
         try:
             with session_scope(self.db_engine) as session:
-                session.query(Miscellaneous).filter(Miscellaneous.msc_path == name).delete()
+                session.query(Miscellaneous).filter_by(Miscellaneous.msc_path == name).delete()
         except Exception as e:
             self.logger.error(Constants.EXCEPTION_OCCURRED.format(e))
             raise e
@@ -278,7 +269,7 @@ class PsqlDatabase:
         result = {}
         try:
             with session_scope(self.db_engine) as session:
-                msc_obj = session.query(Miscellaneous).filter_by(msc_path=name).first()
+                msc_obj = session.query(Miscellaneous).filter_by(msc_path=name).one_or_none()
                 if msc_obj is not None:
                     result = msc_obj.properties
                 else:
@@ -314,7 +305,7 @@ class PsqlDatabase:
         """
         try:
             with session_scope(self.db_engine) as session:
-                session.query(ManagerObjects).filter(ManagerObjects.mo_key == manager_key).delete()
+                session.query(ManagerObjects).filter_by(ManagerObjects.mo_key == manager_key).delete()
         except Exception as e:
             self.logger.error(Constants.EXCEPTION_OCCURRED.format(e))
             raise e
@@ -326,7 +317,7 @@ class PsqlDatabase:
         """
         try:
             with session_scope(self.db_engine) as session:
-                session.query(ManagerObjects).filter(ManagerObjects.mo_act_id == act_id).delete()
+                session.query(ManagerObjects).filter_by(ManagerObjects.mo_act_id == act_id).delete()
         except Exception as e:
             self.logger.error(Constants.EXCEPTION_OCCURRED.format(e))
             raise e
@@ -341,17 +332,12 @@ class PsqlDatabase:
         try:
             with session_scope(self.db_engine) as session:
                 if act_id is None:
-                    for row in session.query(ManagerObjects).all():
-                        mo = {'mo_act_id': row.mo_act_id, 'mo_key': row.mo_key, 'properties': row.properties,
-                              'mo_id': row.mo_id}
-                        result.append(mo.copy())
-                        mo.clear()
+                    rows = session.query(ManagerObjects).all()
                 else:
-                    for row in session.query(ManagerObjects).filter(ManagerObjects.mo_act_id == act_id).all():
-                        mo = {'mo_act_id': row.mo_act_id, 'mo_key': row.mo_key, 'properties': row.properties,
-                              'mo_id': row.mo_id}
-                        result.append(mo.copy())
-                        mo.clear()
+                    rows = session.query(ManagerObjects).filter_by(ManagerObjects.mo_act_id == act_id).all()
+
+                for row in rows:
+                    result.append(dict(row.items()))
 
         except Exception as e:
             self.logger.error(Constants.EXCEPTION_OCCURRED.format(e))
@@ -383,13 +369,9 @@ class PsqlDatabase:
         result = {}
         try:
             with session_scope(self.db_engine) as session:
-                mo_obj = session.query(ManagerObjects).filter_by(mo_key=mo_key).first()
+                mo_obj = session.query(ManagerObjects).filter_by(mo_key=mo_key).one_or_none()
                 if mo_obj is not None:
-                    result['mo_id'] = mo_obj.mo_id
-                    result['mo_key'] = mo_obj.mo_key
-                    if mo_obj.mo_act_id is not None:
-                        result['mo_act_id'] = mo_obj.mo_act_id
-                    result['properties'] = mo_obj.properties
+                    result = dict(mo_obj.items())
                 else:
                     raise DatabaseException(self.OBJECT_NOT_FOUND.format("Manager Object", mo_key))
         except Exception as e:
@@ -406,9 +388,7 @@ class PsqlDatabase:
         try:
             with session_scope(self.db_engine) as session:
                 for mo_obj in session.query(ManagerObjects).filter(ManagerObjects.mo_act_id.is_(None)).all():
-                    mo = {'mo_id': mo_obj.mo_id, 'mo_key': mo_obj.mo_key, 'properties': mo_obj.properties}
-                    result.append(mo.copy())
-                    mo.clear()
+                    result.append(dict(mo_obj.items()))
         except Exception as e:
             self.logger.error(Constants.EXCEPTION_OCCURRED.format(e))
             raise e
@@ -461,7 +441,7 @@ class PsqlDatabase:
         """
         try:
             with session_scope(self.db_engine) as session:
-                slc_obj = session.query(Slices).filter(Slices.slc_guid == slc_guid).first()
+                slc_obj = session.query(Slices).filter_by(Slices.slc_guid == slc_guid).one_or_none()
                 if slc_obj is not None:
                     slc_obj.properties = properties
                     slc_obj.slc_name = slc_name
@@ -485,7 +465,7 @@ class PsqlDatabase:
         """
         try:
             with session_scope(self.db_engine) as session:
-                session.query(Slices).filter(Slices.slc_guid == slc_guid).delete()
+                session.query(Slices).filter_by(Slices.slc_guid == slc_guid).delete()
         except Exception as e:
             self.logger.error(Constants.EXCEPTION_OCCURRED.format(e))
             raise e
@@ -498,6 +478,7 @@ class PsqlDatabase:
         if row is None:
             return None
 
+        '''
         slice_obj = {'slc_id': row.slc_id, 'slc_guid': row.slc_guid, 'slc_name': row.slc_name,
                      'slc_type': row.slc_type, 'slc_resource_type': row.slc_resource_type, 'slc_state': row.slc_state,
                      'project_id': row.project_id, 'lease_start': row.lease_start, 'lease_end': row.lease_end,
@@ -506,6 +487,8 @@ class PsqlDatabase:
             slice_obj['slc_graph_id'] = row.slc_graph_id
 
         return slice_obj
+        '''
+        return dict(row.items())
 
     def get_slice_ids(self) -> list:
         """
@@ -579,9 +562,7 @@ class PsqlDatabase:
                     rows = rows.offset(offset).limit(limit)
 
                 for row in rows.all():
-                    slice_obj = self.generate_slice_dict_from_row(row)
-                    result.append(slice_obj.copy())
-                    slice_obj.clear()
+                    result.append(dict(row.items()))
         except Exception as e:
             self.logger.error(Constants.EXCEPTION_OCCURRED.format(e))
             raise e
@@ -596,7 +577,7 @@ class PsqlDatabase:
         result = {}
         try:
             with session_scope(self.db_engine) as session:
-                slc_obj = session.query(Slices).filter(Slices.slc_id == slc_id).first()
+                slc_obj = session.query(Slices).filter_by(Slices.slc_id == slc_id).one_or_none()
                 if slc_obj is not None:
                     result = self.generate_slice_dict_from_row(slc_obj)
                 else:
@@ -664,7 +645,7 @@ class PsqlDatabase:
         """
         try:
             with session_scope(self.db_engine) as session:
-                rsv_obj = session.query(Reservations).filter(Reservations.rsv_resid == rsv_resid).one()
+                rsv_obj = session.query(Reservations).filter_by(Reservations.rsv_resid == rsv_resid).one()
                 if rsv_obj is not None:
                     rsv_obj.rsv_category = rsv_category
                     rsv_obj.rsv_state = rsv_state
@@ -692,7 +673,7 @@ class PsqlDatabase:
         """
         try:
             with session_scope(self.db_engine) as session:
-                session.query(Reservations).filter(Reservations.rsv_resid == rsv_resid).delete()
+                session.query(Reservations).filter_by(Reservations.rsv_resid == rsv_resid).delete()
         except Exception as e:
             self.logger.error(Constants.EXCEPTION_OCCURRED.format(e))
             raise e
@@ -705,12 +686,15 @@ class PsqlDatabase:
         """
         if row is None:
             return None
+        '''
         rsv_obj = {'rsv_id': row.rsv_id, 'rsv_slc_id': row.rsv_slc_id, 'rsv_resid': row.rsv_resid,
                    'rsv_category': row.rsv_category, 'rsv_state': row.rsv_state,
                    'rsv_pending': row.rsv_pending, 'rsv_joining': row.rsv_joining,
                    'properties': row.properties, 'rsv_graph_node_id': row.rsv_graph_node_id}
 
         return rsv_obj
+        '''
+        return dict(row.items())
 
     def create_reservation_filter(self, *, slice_id: str = None, graph_node_id: str = None, project_id: str = None,
                                   email: str = None, oidc_sub: str = None, rid: str = None, site: str = None) -> dict:
@@ -769,9 +753,7 @@ class PsqlDatabase:
                     rows = rows.filter(Reservations.rsv_category.in_(category))
 
                 for row in rows.all():
-                    rsv_obj = self.generate_reservation_dict_from_row(row)
-                    result.append(rsv_obj.copy())
-                    rsv_obj.clear()
+                    result.append(dict(row.items()))
         except Exception as e:
             self.logger.error(Constants.EXCEPTION_OCCURRED.format(e))
             raise e
@@ -788,9 +770,7 @@ class PsqlDatabase:
         try:
             with session_scope(self.db_engine) as session:
                 for row in session.query(Reservations).filter(Reservations.rsv_resid.in_(rsv_resid_list)).all():
-                    rsv_obj = self.generate_reservation_dict_from_row(row)
-                    result.append(rsv_obj.copy())
-                    rsv_obj.clear()
+                    result.append(dict(row.items()))
         except Exception as e:
             self.logger.error(Constants.EXCEPTION_OCCURRED.format(e))
             raise e
@@ -820,8 +800,8 @@ class PsqlDatabase:
         """
         try:
             with session_scope(self.db_engine) as session:
-                prx_obj = session.query(Proxies).filter(Proxies.prx_act_id == act_id).filter(
-                    Proxies.prx_name == prx_name).first()
+                prx_obj = session.query(Proxies).filter_by(Proxies.prx_act_id == act_id).filter(
+                    Proxies.prx_name == prx_name).one_or_none()
                 if prx_obj is not None:
                     prx_obj.properties = properties
                 else:
@@ -852,10 +832,13 @@ class PsqlDatabase:
         if row is None:
             return None
 
+        '''
         prx_obj = {'prx_id': row.prx_id, 'prx_act_id': row.prx_act_id, 'prx_name': row.prx_name,
                    'properties': row.properties}
 
         return prx_obj
+        '''
+        return dict(row.items())
 
     def get_proxies(self, *, act_id: int) -> list:
         """
@@ -865,10 +848,8 @@ class PsqlDatabase:
         result = []
         try:
             with session_scope(self.db_engine) as session:
-                for row in session.query(Proxies).filter(Proxies.prx_act_id == act_id).all():
-                    prx_obj = self.generate_proxy_dict_from_row(row)
-                    result.append(prx_obj.copy())
-                    prx_obj.clear()
+                for row in session.query(Proxies).filter_by(Proxies.prx_act_id == act_id).all():
+                    result.append(dict(row.items()))
         except Exception as e:
             self.logger.error(Constants.EXCEPTION_OCCURRED.format(e))
             raise e
@@ -899,7 +880,7 @@ class PsqlDatabase:
         try:
             with session_scope(self.db_engine) as session:
                 cfg_obj = session.query(ConfigMappings).filter(ConfigMappings.cfgm_act_id == act_id).filter(
-                    ConfigMappings.cfgm_type == cfgm_type).first()
+                    ConfigMappings.cfgm_type == cfgm_type).one_or_none()
                 if cfg_obj is not None:
                     cfg_obj.properties = properties
                 else:
@@ -915,7 +896,7 @@ class PsqlDatabase:
         """
         try:
             with session_scope(self.db_engine) as session:
-                session.query(ConfigMappings).filter(ConfigMappings.cfgm_type == cfgm_type).delete()
+                session.query(ConfigMappings).filter_by(ConfigMappings.cfgm_type == cfgm_type).delete()
         except Exception as e:
             self.logger.error(Constants.EXCEPTION_OCCURRED.format(e))
             raise e
@@ -928,10 +909,13 @@ class PsqlDatabase:
         if row is None:
             return None
 
+        '''
         cfg_obj = {'cfgm_id': row.cfgm_id, 'cfgm_act_id': row.cfgm_act_id, 'cfgm_type': row.cfgm_type,
                    'properties': row.properties}
 
         return cfg_obj
+        '''
+        return dict(row.items())
 
     def get_config_mappings(self, *, act_id: int) -> list:
         """
@@ -942,10 +926,8 @@ class PsqlDatabase:
         result = []
         try:
             with session_scope(self.db_engine) as session:
-                for row in session.query(ConfigMappings).filter(ConfigMappings.cfgm_act_id == act_id).all():
-                    cfg_obj = self.generate_config_mapping_dict_from_row(row)
-                    result.append(cfg_obj.copy())
-                    cfg_obj.clear()
+                for row in session.query(ConfigMappings).filter_by(ConfigMappings.cfgm_act_id == act_id).all():
+                    result.append(dict(row.items()))
         except Exception as e:
             self.logger.error(Constants.EXCEPTION_OCCURRED.format(e))
             raise e
@@ -977,7 +959,7 @@ class PsqlDatabase:
         try:
             with session_scope(self.db_engine) as session:
                 clt_obj = session.query(Clients).filter(Clients.clt_act_id == act_id).filter(
-                    Clients.clt_name == clt_name).first()
+                    Clients.clt_name == clt_name).one_or_none()
                 if clt_obj is not None:
                     clt_obj.properties = properties
                 else:
@@ -1037,7 +1019,7 @@ class PsqlDatabase:
         result = None
         try:
             with session_scope(self.db_engine) as session:
-                clt_obj = session.query(Clients).filter(Clients.clt_guid == clt_guid).first()
+                clt_obj = session.query(Clients).filter_by(Clients.clt_guid == clt_guid).one_or_none()
                 if clt_obj is None:
                     raise DatabaseException(self.OBJECT_NOT_FOUND.format("Client", clt_guid))
                 result = self.generate_client_dict_from_row(clt_obj)
@@ -1056,9 +1038,7 @@ class PsqlDatabase:
         try:
             with session_scope(self.db_engine) as session:
                 for row in session.query(Clients).all():
-                    clt_obj = self.generate_client_dict_from_row(row)
-                    result.append(clt_obj.copy())
-                    clt_obj.clear()
+                    result.append(dict(row.items()))
         except Exception as e:
             self.logger.error(Constants.EXCEPTION_OCCURRED.format(e))
             raise e
@@ -1100,11 +1080,14 @@ class PsqlDatabase:
         if row is None:
             return None
 
+        '''
         result = {'unt_id': row.unt_id, 'unt_uid': row.unt_uid, 'unt_unt_id': row.unt_unt_id,
                   'unt_slc_id': row.unt_slc_id, 'unt_rsv_id': row.unt_rsv_id, 'unt_state': row.unt_state,
                   'properties': row.properties}
 
         return result
+        '''
+        return dict(row.items())
 
     def get_unit(self, *, unt_uid: str) -> dict or None:
         """
@@ -1116,7 +1099,7 @@ class PsqlDatabase:
         result = None
         try:
             with session_scope(self.db_engine) as session:
-                unt_obj = session.query(Units).filter(Units.unt_uid == unt_uid).first()
+                unt_obj = session.query(Units).filter_by(Units.unt_uid == unt_uid).one_or_none()
                 if unt_obj is None:
                     self.logger.debug("Unit with guid {} not found".format(unt_uid))
                     return result
@@ -1140,10 +1123,8 @@ class PsqlDatabase:
                 raise DatabaseException(self.OBJECT_NOT_FOUND.format("Reservation", rsv_resid))
 
             with session_scope(self.db_engine) as session:
-                for row in session.query(Units).filter(Units.unt_rsv_id == rsv_obj['rsv_id']).all():
-                    unt_obj = self.generate_unit_dict_from_row(row)
-                    result.append(unt_obj.copy())
-                    unt_obj.clear()
+                for row in session.query(Units).filter_by(Units.unt_rsv_id == rsv_obj['rsv_id']).all():
+                    result.append(dict(row.items()))
         except Exception as e:
             self.logger.error(Constants.EXCEPTION_OCCURRED.format(e))
             raise e
@@ -1156,7 +1137,7 @@ class PsqlDatabase:
         """
         try:
             with session_scope(self.db_engine) as session:
-                session.query(Units).filter(Units.unt_uid == unt_uid).delete()
+                session.query(Units).filter_by(Units.unt_uid == unt_uid).delete()
         except Exception as e:
             self.logger.error(Constants.EXCEPTION_OCCURRED.format(e))
             raise e
@@ -1170,7 +1151,7 @@ class PsqlDatabase:
         result = None
         try:
             with session_scope(self.db_engine) as session:
-                unt_obj = session.query(Units).filter(Units.unt_uid == unt_uid).first()
+                unt_obj = session.query(Units).filter_by(Units.unt_uid == unt_uid).one_or_none()
                 if unt_obj is None:
                     raise DatabaseException(self.OBJECT_NOT_FOUND.format("Unit", unt_uid))
                 unt_obj.properties = properties
@@ -1207,7 +1188,7 @@ class PsqlDatabase:
         """
         try:
             with session_scope(self.db_engine) as session:
-                dlg_obj = session.query(Delegations).filter(Delegations.dlg_graph_id == dlg_graph_id).first()
+                dlg_obj = session.query(Delegations).filter_by(Delegations.dlg_graph_id == dlg_graph_id).one_or_none()
                 if dlg_obj is not None:
                     dlg_obj.dlg_state = dlg_state
                     dlg_obj.properties = properties
@@ -1226,7 +1207,7 @@ class PsqlDatabase:
         """
         try:
             with session_scope(self.db_engine) as session:
-                session.query(Delegations).filter(Delegations.dlg_graph_id == dlg_graph_id).delete()
+                session.query(Delegations).filter_by(Delegations.dlg_graph_id == dlg_graph_id).delete()
         except Exception as e:
             self.logger.error(Constants.EXCEPTION_OCCURRED.format(e))
             raise e
@@ -1239,10 +1220,12 @@ class PsqlDatabase:
         if row is None:
             return None
 
+        '''
         dlg_obj = {'dlg_id': row.dlg_id, 'dlg_slc_id': row.dlg_slc_id,
                    'dlg_graph_id':row.dlg_graph_id, 'dlg_state': row.dlg_state, 'properties': row.properties}
-
         return dlg_obj
+        '''
+        return dict(row.items())
 
     def get_slc_id_by_slice_id(self, *, slice_id: str) -> int:
         slices = self.get_slices(slice_id=slice_id)
@@ -1273,9 +1256,7 @@ class PsqlDatabase:
                 if states is not None:
                     rows = rows.filter(Delegations.dlg_state.in_(states))
                 for row in rows.all():
-                    dlg_obj = self.generate_delegation_dict_from_row(row)
-                    result.append(dlg_obj.copy())
-                    dlg_obj.clear()
+                    result.append(dict(row.items()))
         except Exception as e:
             self.logger.error(Constants.EXCEPTION_OCCURRED.format(e))
             raise e
@@ -1290,7 +1271,7 @@ class PsqlDatabase:
         result = {}
         try:
             with session_scope(self.db_engine) as session:
-                dlg_obj = session.query(Delegations).filter(Delegations.dlg_graph_id == dlg_graph_id).first()
+                dlg_obj = session.query(Delegations).filter_by(Delegations.dlg_graph_id == dlg_graph_id).one_or_none()
                 if dlg_obj is not None:
                     result = self.generate_delegation_dict_from_row(dlg_obj)
                 else:
@@ -1324,7 +1305,7 @@ class PsqlDatabase:
         """
         try:
             with session_scope(self.db_engine) as session:
-                site_obj = session.query(Sites).filter(Sites.name == site_name).first()
+                site_obj = session.query(Sites).filter_by(Sites.name == site_name).one_or_none()
                 if site_obj is not None:
                     site_obj.properties = properties
                     site_obj.state = state
@@ -1341,7 +1322,7 @@ class PsqlDatabase:
         """
         try:
             with session_scope(self.db_engine) as session:
-                session.query(Sites).filter(Sites.name == site_name).delete()
+                session.query(Sites).filter_by(Sites.name == site_name).delete()
         except Exception as e:
             self.logger.error(Constants.EXCEPTION_OCCURRED.format(e))
             raise e
@@ -1353,10 +1334,12 @@ class PsqlDatabase:
         """
         if row is None:
             return None
-
+        '''
         site_obj = {'name': row.name, 'properties': row.properties}
 
         return site_obj
+        '''
+        return dict(row.items())
 
     def get_sites(self) -> list:
         """
@@ -1366,9 +1349,7 @@ class PsqlDatabase:
         try:
             with session_scope(self.db_engine) as session:
                 for row in session.query(Sites).all():
-                    site_obj = self.generate_site_dict_from_row(row)
-                    result.append(site_obj.copy())
-                    site_obj.clear()
+                    result.append(dict(row.items()))
         except Exception as e:
             self.logger.error(Constants.EXCEPTION_OCCURRED.format(e))
             raise e
@@ -1381,10 +1362,8 @@ class PsqlDatabase:
         result = []
         try:
             with session_scope(self.db_engine) as session:
-                for row in session.query(Sites).filter(Sites.name == site_name).all():
-                    site_obj = self.generate_site_dict_from_row(row)
-                    result.append(site_obj.copy())
-                    site_obj.clear()
+                for row in session.query(Sites).filter_by(Sites.name == site_name).all():
+                    result.append(dict(row.items()))
         except Exception as e:
             self.logger.error(Constants.EXCEPTION_OCCURRED.format(e))
             raise e
@@ -1458,7 +1437,7 @@ def test():
     db.update_reservation(slc_guid="1234", rsv_resid="rsv_567", rsv_category=1, rsv_state=2,
                           rsv_pending=3, rsv_joining=5, properties=pickle.dumps(prop))
     print("Reservations after update {}".format(db.get_reservations()))
-    print("Reservations after by state {}".format(db.get_reservations(slice_id="1234", state=[2])))
+    print("Reservations after by state {}".format(db.get_reservations(slice_id="1234", states=[2])))
 
     print("Reservations after by rid {}".format(db.get_reservations(rid="rsv_567")))
     print("Reservations after by rid list {}".format(db.get_reservations_by_rids(rsv_resid_list=["rsv_567"])))
@@ -1518,7 +1497,7 @@ def test2():
               ReservationStates.ActiveTicketed.value,
               ReservationStates.Ticketed.value,
               ReservationStates.Nascent.value]
-    res = db.get_reservations(graph_node_id='node+renc-data-sw:ip+192.168.11.3-ns', state=states)
+    res = db.get_reservations(graph_node_id='node+renc-data-sw:ip+192.168.11.3-ns', states=states)
     print(f"All {len(res)}")
     for r in res:
         print(r['rsv_state'])
@@ -1555,17 +1534,17 @@ def test3():
                  properties=pickle.dumps(prop), lease_start=datetime.now(timezone.utc), lease_end=datetime.now(timezone.utc),
                  slc_state=SliceState.Configuring.value, email="kthare10@email.unc.edu")
 
-    ss = db.get_slices(state=[SliceState.Dead.value, SliceState.Closing.value],
+    ss = db.get_slices(states=[SliceState.Dead.value, SliceState.Closing.value],
                        email="kthare10@email.unc.edu")
 
     assert len(ss) == 2
 
-    ss = db.get_slices(state=[SliceState.StableOK.value, SliceState.StableError.value],
+    ss = db.get_slices(states=[SliceState.StableOK.value, SliceState.StableError.value],
                        email="kthare10@email.unc.edu")
 
     assert len(ss) == 2
 
-    ss = db.get_slices(state=[SliceState.Configuring.value],
+    ss = db.get_slices(states=[SliceState.Configuring.value],
                        email="kthare10@email.unc.edu")
 
     assert len(ss) == 1

--- a/fabric_cf/actor/fim/asm_update_thread.py
+++ b/fabric_cf/actor/fim/asm_update_thread.py
@@ -148,8 +148,10 @@ class AsmUpdateThread:
             try:
                 begin = time.time()
                 event.process()
-                self.logger.info(f"Event {event.__class__.__name__} "
-                                 f"TIME: {time.time() - begin:.0f}")
+                diff = int(time.time() - begin)
+                if diff > 0:
+                    self.logger.info(f"Event {event.__class__.__name__} "
+                                     f"TIME: {time.time() - begin:.0f}")
             except Exception as e:
                 self.logger.error(f"Error while processing event {type(event)}, {e}")
                 self.logger.error(traceback.format_exc())

--- a/fabric_cf/actor/fim/fim_helper.py
+++ b/fabric_cf/actor/fim/fim_helper.py
@@ -25,6 +25,7 @@
 # Author: Komal Thareja (kthare10@renci.org)
 import logging
 import random
+import traceback
 from typing import Tuple, List, Union
 
 from fim.graph.abc_property_graph import ABCPropertyGraph, ABCGraphImporter

--- a/fabric_cf/actor/fim/fim_helper.py
+++ b/fabric_cf/actor/fim/fim_helper.py
@@ -335,23 +335,22 @@ class FimHelper:
                         reservation_info.reservation_state = ReservationStates.Failed.name
                         node.components[cname].set_properties(reservation_info=reservation_info)
 
+                topo_component_dict = node.components
                 for component in sliver.attached_components_info.devices.values():
-                    cname = component.get_name()
-                    node.components[cname].set_properties(
-                                                          labels=component.labels,
-                                                          label_allocations=component.label_allocations,
-                                                          capacity_allocations=component.capacity_allocations,
-                                                          node_map=component.node_map)
+                    topo_component = topo_component_dict[component.get_name()]
+                    topo_component.set_properties(labels=component.labels,
+                                                  label_allocations=component.label_allocations,
+                                                  capacity_allocations=component.capacity_allocations,
+                                                  node_map=component.node_map)
                     # Update Mac address
                     if component.network_service_info is not None and \
                             component.network_service_info.network_services is not None:
+                        topo_ifs_dict = topo_component.interfaces
                         for ns in component.network_service_info.network_services.values():
                             if ns.interface_info is None or ns.interface_info.interfaces is None:
                                 continue
-
                             for ifs in ns.interface_info.interfaces.values():
-                                topo_component = node.components[cname]
-                                topo_ifs = topo_component.interfaces[ifs.get_name()]
+                                topo_ifs = topo_ifs_dict[ifs.get_name()]
                                 topo_ifs.set_properties(labels=ifs.labels,
                                                         label_allocations=ifs.label_allocations,
                                                         node_map=ifs.node_map)
@@ -370,10 +369,11 @@ class FimHelper:
                                 node_map=sliver.node_map,
                                 gateway=sliver.gateway)
             if sliver.interface_info is not None:
+                topo_ifs_dict = node.interfaces
                 for ifs in sliver.interface_info.interfaces.values():
                     if ifs.get_name() not in node.interfaces:
                         continue
-                    topo_ifs = node.interfaces[ifs.get_name()]
+                    topo_ifs = topo_ifs_dict[ifs.get_name()]
                     topo_ifs.set_properties(labels=ifs.labels,
                                             label_allocations=ifs.label_allocations,
                                             node_map=ifs.node_map)

--- a/fabric_cf/actor/security/fabric_token.py
+++ b/fabric_cf/actor/security/fabric_token.py
@@ -55,7 +55,7 @@ class FabricToken:
             verify_exp = self.oauth_config.get(Constants.PROPERTY_CONF_O_AUTH_VERIFY_EXP, True)
 
             if self.jwt_validator is not None:
-                self.logger.info("Validating CI Logon token")
+                self.logger.debug("Validating CI Logon token")
                 code, token_or_exception = self.jwt_validator.validate_jwt(token=self.encoded_token,
                                                                            verify_exp=verify_exp)
                 if code is not ValidateCode.VALID:

--- a/fabric_cf/authority/vm_handler_config.yml
+++ b/fabric_cf/authority/vm_handler_config.yml
@@ -41,11 +41,13 @@ runtime:
     default_fedora_36: fedora
     default_fedora_37: fedora
     default_rocky_8: rocky
+    default_rocky_9: rocky
     default_ubuntu_18: ubuntu
     default_ubuntu_20: ubuntu
     default_ubuntu_21: ubuntu
     default_ubuntu_22: ubuntu
     docker_rocky_8: rocky
+    docker_rocky_9: rocky
     docker_ubuntu_20: ubuntu
     docker_ubuntu_22: ubuntu
 playbooks:

--- a/fabric_cf/orchestrator/__main__.py
+++ b/fabric_cf/orchestrator/__main__.py
@@ -84,7 +84,8 @@ def main():
                     # Add a middleware function that puts incoming requests into the task queue
                     @app.app.before_request
                     def enqueue_request():
-                        self.queue.put(request.environ)
+                        if request.method == "GET" and "slices" in request.path:
+                            self.queue.put(request.environ)
 
                     # Add a middleware function that checks the task queue depth and
                     # returns a "too busy" error if it exceeds a certain value
@@ -96,11 +97,11 @@ def main():
                 def serve(self, port, threads):
                     serve(app=app.app, port=port, threads=threads)
 
-            waitress_app = WaitressApp(max_depth=8)
-            waitress_app.serve(port=int(rest_port_str), threads=8)
+            #waitress_app = WaitressApp(max_depth=8)
+            #waitress_app.serve(port=int(rest_port_str), threads=8)
 
             # Start up the server to expose the metrics.
-            #waitress.serve(app, port=int(rest_port_str), threads=8)
+            waitress.serve(app, port=int(rest_port_str), threads=8)
 
             while True:
                 time.sleep(0.0001)

--- a/fabric_cf/orchestrator/__main__.py
+++ b/fabric_cf/orchestrator/__main__.py
@@ -31,17 +31,11 @@ import traceback
 import connexion
 import prometheus_client
 import waitress
-from flask import jsonify, request
 
 from fabric_cf.actor.core.common.constants import Constants
 from fabric_cf.actor.core.util.graceful_interrupt_handler import GracefulInterruptHandler
 from fabric_cf.orchestrator.core.exceptions import OrchestratorException
 from fabric_cf.orchestrator.swagger_server import encoder
-
-
-import queue
-from waitress import serve
-import connexion
 
 
 def main():
@@ -75,30 +69,6 @@ def main():
             app = connexion.App(__name__, specification_dir='swagger_server/swagger/')
             app.json = encoder.JSONEncoder
             app.add_api('swagger.yaml', arguments={'title': 'Fabric Orchestrator API'}, pythonic_params=True)
-
-            class WaitressApp:
-                def __init__(self, max_depth):
-                    self.queue = queue.Queue()
-                    self.max_depth = max_depth
-
-                    # Add a middleware function that puts incoming requests into the task queue
-                    @app.app.before_request
-                    def enqueue_request():
-                        if request.method == "GET" and "slices" in request.path:
-                            self.queue.put(request.environ)
-
-                    # Add a middleware function that checks the task queue depth and
-                    # returns a "too busy" error if it exceeds a certain value
-                    @app.app.before_request
-                    def check_queue_depth():
-                        if self.queue.qsize() > self.max_depth:
-                            return {'message': 'Too many requests are being processed. Please try again later.'}, 503
-
-                def serve(self, port, threads):
-                    serve(app=app.app, port=port, threads=threads)
-
-            #waitress_app = WaitressApp(max_depth=8)
-            #waitress_app.serve(port=int(rest_port_str), threads=8)
 
             # Start up the server to expose the metrics.
             waitress.serve(app, port=int(rest_port_str), threads=8)

--- a/fabric_cf/orchestrator/docker-compose.yml
+++ b/fabric_cf/orchestrator/docker-compose.yml
@@ -37,6 +37,7 @@ services:
       - NEO4J_dbms_connector_http_listen__address=${NEO4J_dbms_connector_http_advertised__address:-0.0.0.0:7474}
       - NEO4J_dbms_connector_https_advertised__address=${NEO4J_dbms_connector_https_advertised__address:-0.0.0.0:7473}
       - NEO4J_dbms_connector_https_listen__address=${NEO4J_dbms_connector_https_advertised__address:-0.0.0.0:7473}
+      - NEO4J_dbms_memory_pagecache_size=${NEO4J_dbms_memory_pagecache_size:-512M}
   database:
     image: fabrictestbed/postgres:12.3
     container_name: orchestrator-db

--- a/fabric_cf/orchestrator/env.template
+++ b/fabric_cf/orchestrator/env.template
@@ -27,6 +27,7 @@ NEO4J_dbms_connector_http_advertised__address=0.0.0.0:9474
 NEO4J_dbms_connector_http_listen__address=0.0.0.0:9474
 NEO4J_dbms_connector_https_advertised__address=0.0.0.0:9473
 NEO4J_dbms_connector_https_listen__address=0.0.0.0:9473
+NEO4J_dbms_memory_pagecache_size=8G
 
 # postgres configuration
 POSTGRES_HOST=database

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,4 +9,4 @@ swagger-ui-bundle
 fabric_fss_utils==1.4.0
 PyYAML
 fabric-message-bus==1.4.0
-fabric-fim==1.4.9
+fabric-fim==1.4.10

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,4 +9,4 @@ swagger-ui-bundle
 fabric_fss_utils==1.4.0
 PyYAML
 fabric-message-bus==1.4.0
-fabric-fim==1.4.6
+fabric-fim==1.4.9

--- a/tools/cleanup.py
+++ b/tools/cleanup.py
@@ -58,6 +58,10 @@ class MainClass:
         self.neo4j_config = config_dict[Constants.CONFIG_SECTION_NEO4J]
         self.database_config = config_dict[Constants.CONFIG_SECTION_DATABASE]
         self.actor_config = config_dict[Constants.CONFIG_SECTION_ACTOR]
+        from fabric_cf.actor.core.container.globals import GlobalsSingleton
+        GlobalsSingleton.get().config_file = config_file
+        GlobalsSingleton.get().load_config()
+        GlobalsSingleton.get().initialized = True
 
     def delete_dead_closing_slice(self, *, days: int):
         actor_db = ActorDatabase(user=self.database_config[Constants.PROPERTY_CONF_DB_USER],
@@ -67,7 +71,7 @@ class MainClass:
                                  logger=self.logger)
         states = [SliceState.Dead.value, SliceState.Closing.value]
         lease_end = datetime.now(timezone.utc) - timedelta(days=days)
-        slices = actor_db.get_slices(state=states, lease_end=lease_end)
+        slices = actor_db.get_slices(states=states, lease_end=lease_end)
         actor_type = self.actor_config[Constants.TYPE]
         for s in slices:
             try:


### PR DESCRIPTION
- Fixed indexing for Postgres
- Optimized `FimHelper::update_node()` to access components and interfaces more efficiently
- Updated `fim` version with index fix improving the ASM update time from 12 seconds to few milliseconds
- Modified `Controller:tick_handler` to process the `close` for expiring slivers and `redeem` for ticketed slivers in a thread pool thus improving the over all processing time for a `TickEvent`. Improved from 839 seconds to 30 seconds in worst case.
- Turned lot of INFO logs to DEBUG logs
- Disable the garbage collection from TimerThread - Will be moved to `db_cleanup.py` which runs as a cron job.