### PR TITLE
ABQM - worker information

### DIFF
--- a/fabric_cf/actor/fim/plugins/broker/aggregate_bqm_plugin.py
+++ b/fabric_cf/actor/fim/plugins/broker/aggregate_bqm_plugin.py
@@ -292,27 +292,29 @@ class AggregatedBQMPlugin:
             abqm.add_node(node_id=ns_id, label=ABCPropertyGraph.CLASS_NetworkService, props=ns_props)
             abqm.add_link(node_a=site_sliver.node_id, rel=ABCPropertyGraph.REL_HAS, node_b=ns_id)
 
-            # create a component sliver for every component type/model pairing
-            # and add a node for it linking back to site node
-            for ctype, cdict in site_comps_by_type.items():
-                for cmodel, comp_list in cdict.items():
-                    comp_sliver = ComponentSliver()
-                    # count what is available
-                    comp_sliver.capacities = Capacities()
-                    # count what is taken (ignore those type/model pairings that were unused)
-                    comp_sliver.capacity_allocations = site_allocated_comps_caps_by_type[ctype].get(cmodel) or \
-                                                       Capacities()
-                    comp_sliver.set_type(ctype)
-                    comp_sliver.set_model(cmodel)
-                    comp_sliver.set_name(str(ctype) + '-' + cmodel)
-                    for comp in comp_list:
-                        comp_sliver.capacities = comp_sliver.capacities + comp.capacities
-                    comp_node_id = str(uuid.uuid4())
-                    comp_props = abqm.component_sliver_to_graph_properties_dict(comp_sliver)
-                    abqm.add_node(node_id=comp_node_id, label=ABCPropertyGraph.CLASS_Component,
-                                  props=comp_props)
-                    abqm.add_link(node_a=site_sliver.node_id, rel=ABCPropertyGraph.REL_HAS,
-                                  node_b=comp_node_id)
+            # Site level component information is only passed for query_level=1
+            if kwargs['query_level'] == 1:
+                # create a component sliver for every component type/model pairing
+                # and add a node for it linking back to site node
+                for ctype, cdict in site_comps_by_type.items():
+                    for cmodel, comp_list in cdict.items():
+                        comp_sliver = ComponentSliver()
+                        # count what is available
+                        comp_sliver.capacities = Capacities()
+                        # count what is taken (ignore those type/model pairings that were unused)
+                        comp_sliver.capacity_allocations = site_allocated_comps_caps_by_type[ctype].get(cmodel) or \
+                                                           Capacities()
+                        comp_sliver.set_type(ctype)
+                        comp_sliver.set_model(cmodel)
+                        comp_sliver.set_name(str(ctype) + '-' + cmodel)
+                        for comp in comp_list:
+                            comp_sliver.capacities = comp_sliver.capacities + comp.capacities
+                        comp_node_id = str(uuid.uuid4())
+                        comp_props = abqm.component_sliver_to_graph_properties_dict(comp_sliver)
+                        abqm.add_node(node_id=comp_node_id, label=ABCPropertyGraph.CLASS_Component,
+                                      props=comp_props)
+                        abqm.add_link(node_a=site_sliver.node_id, rel=ABCPropertyGraph.REL_HAS,
+                                      node_b=comp_node_id)
 
         # get all intersite links - add them to the aggregated BQM graph
         intersite_links = cbm.get_intersite_links()

--- a/fabric_cf/actor/test/test_abqm.py
+++ b/fabric_cf/actor/test/test_abqm.py
@@ -86,6 +86,21 @@ class ABQM_Test(unittest.TestCase):
         with open('abqm.json', 'w') as f:
             f.write(abqm_json)
 
+        abqm_level2 = plugin.plug_produce_bqm(cbm=cbm, query_level=2)
+
+        abqm_level2.validate_graph()
+
+        abqm_level2_string = abqm_level2.serialize_graph()
+
+        print('Writing ABQM to abqm_level2.graphml')
+        with open('abqm_level2.graphml', 'w') as f:
+            f.write(abqm_level2_string)
+
+        abqm_level2_json = abqm.serialize_graph(format=GraphFormat.JSON_NODELINK)
+        print('Writing ABQM to abqm_level2.json')
+        with open('abqm_level2.json', 'w') as f:
+            f.write(abqm_level2_json)
+
         print('Writing CBM to cbm.graphml')
         cbm_string = cbm.serialize_graph()
         with open('cbm.graphml', 'w') as f:
@@ -126,5 +141,15 @@ class ABQM_Test(unittest.TestCase):
         print('Writing ABQM to abqm-from-cbm.graphml')
         with open('abqm-from-cbm.graphml', 'w') as f:
             f.write(abqm_string)
+
+        abqm2 = plugin.plug_produce_bqm(cbm=cbm, query_level=2)
+
+        abqm2.validate_graph()
+
+        abqm2_string = abqm2.serialize_graph()
+
+        print('Writing ABQM to abqm2-from-cbm.graphml')
+        with open('abqm2-from-cbm.graphml', 'w') as f:
+            f.write(abqm2_string)
 
         self.n4j_imp.delete_all_graphs()


### PR DESCRIPTION
- Added a node for each worker connected to the Site Composite Node in ABQM; include capacities and capacity_allocations
- Added a component node for each component/model pair including capacities and capacity_allocations
- Indicate site as Active when a specific worker is in Maintenance including the workers' maintenance state as well

#313 