### PR TITLE
disable console logging

### DIFF
--- a/fabric_cf/actor/core/util/log_helper.py
+++ b/fabric_cf/actor/core/util/log_helper.py
@@ -73,6 +73,12 @@ class LogHelper:
 
         #logging.basicConfig(handlers=[file_handler], format=log_format, force=True)
         #file_handler.addFilter(LogHelper.thread_id_filter)
+
+        # Disable console logging to prevent /var partition from filling up with container logs
+        console_log = logging.getLogger()
+        console_handler = logging.StreamHandler()
+        console_handler.setLevel(logging.CRITICAL)
+        console_log.addHandler(console_handler)
         return log
 
     @staticmethod


### PR DESCRIPTION
disable console logging to avoid increased disk usage in `/var` partition.