### PR TITLE
Changes needed for AL2S-AM updates

### DIFF
--- a/fabric_cf/actor/core/policy/network_service_inventory.py
+++ b/fabric_cf/actor/core/policy/network_service_inventory.py
@@ -104,6 +104,9 @@ class NetworkServiceInventory(InventoryForType):
                     if allocated_vlan in available_vlan_range:
                         available_vlan_range.remove(allocated_vlan)
 
+        if available_vlan_range is None or len(available_vlan_range) == 0:
+            raise BrokerException(error_code=ExceptionErrorCode.INSUFFICIENT_RESOURCES,
+                                  msg=f"No VLANs available!")
         return available_vlan_range
 
     def allocate_ifs(self, *, requested_ns: NetworkServiceSliver, requested_ifs: InterfaceSliver,

--- a/fabric_cf/actor/core/policy/network_service_inventory.py
+++ b/fabric_cf/actor/core/policy/network_service_inventory.py
@@ -24,6 +24,7 @@
 #
 # Author: Komal Thareja (kthare10@renci.org)
 import ipaddress
+import random
 import traceback
 from ipaddress import IPv6Network, IPv4Network
 from typing import List, Tuple
@@ -158,7 +159,7 @@ class NetworkServiceInventory(InventoryForType):
                                                             existing_reservations=existing_reservations)
 
                 if requested_vlan is None:
-                    requested_ifs.labels.vlan = str(vlan_range[0])
+                    requested_ifs.labels.vlan = str(random.choice(vlan_range))
                     return requested_ifs
 
                 if requested_vlan not in vlan_range:
@@ -182,14 +183,14 @@ class NetworkServiceInventory(InventoryForType):
                                                             existing_reservations=existing_reservations)
                 if bqm_ifs.get_type() != InterfaceType.FacilityPort:
                     # Allocate the first available VLAN
-                    requested_ifs.labels.vlan = str(vlan_range[0])
-                    requested_ifs.label_allocations = Labels(vlan=str(vlan_range[0]))
+                    requested_ifs.labels.vlan = str(random.choice(vlan_range))
+                    requested_ifs.label_allocations = Labels(vlan=requested_ifs.labels.vlan)
                 else:
                     if requested_ifs.labels is None:
                         return requested_ifs
 
                     if requested_ifs.labels.vlan is None:
-                        requested_ifs.labels.vlan = str(vlan_range[0])
+                        requested_ifs.labels.vlan = str(random.choice(vlan_range))
 
                     if int(requested_ifs.labels.vlan) not in vlan_range:
                         raise BrokerException(error_code=ExceptionErrorCode.FAILURE,
@@ -272,7 +273,7 @@ class NetworkServiceInventory(InventoryForType):
 
             if requested_ns.label_allocations is None:
                 requested_ns.label_allocations = Labels()
-            requested_ns.label_allocations.vlan = str(vlans_range[0])
+            requested_ns.label_allocations.vlan = str(random.choice(vlans_range))
         except Exception as e:
             self.logger.error(f"Error in allocate_vNIC: {e}")
             self.logger.error(traceback.format_exc())
@@ -442,7 +443,7 @@ class NetworkServiceInventory(InventoryForType):
             vlan_range = self.__extract_vlan_range(labels=bqm_interface.labels)
             available_vlans = self.__exclude_allocated_vlans(available_vlan_range=vlan_range, bqm_ifs=bqm_interface,
                                                              existing_reservations=existing_reservations)
-            vlan = str(available_vlans[0])
+            vlan = str(random.choice(available_vlans))
             ifs_labels = Labels.update(ifs_labels, vlan=vlan)
 
         requested_ifs.labels = ifs_labels

--- a/fabric_cf/actor/core/policy/network_service_inventory.py
+++ b/fabric_cf/actor/core/policy/network_service_inventory.py
@@ -54,7 +54,8 @@ class NetworkServiceInventory(InventoryForType):
                 for v_r in labels.vlan_range:
                     vlans = v_r.split("-")
                     for x in list(range(int(vlans[0]), int(vlans[1]) + 1)):
-                        vlan_range.append(x)
+                        if x not in vlan_range:
+                            vlan_range.append(x)
             else:
                 vlans = labels.vlan_range.split("-")
                 vlan_range = list(range(int(vlans[0]), int(vlans[1]) + 1))

--- a/fabric_cf/actor/core/policy/network_service_inventory.py
+++ b/fabric_cf/actor/core/policy/network_service_inventory.py
@@ -162,7 +162,8 @@ class NetworkServiceInventory(InventoryForType):
                                                             existing_reservations=existing_reservations)
 
                 if requested_vlan is None:
-                    requested_ifs.labels.vlan = str(random.choice(vlan_range))
+                    #requested_ifs.labels.vlan = str(random.choice(vlan_range))
+                    requested_ifs.labels.vlan = str(vlan_range[0])
                     return requested_ifs
 
                 if requested_vlan not in vlan_range:
@@ -186,14 +187,16 @@ class NetworkServiceInventory(InventoryForType):
                                                             existing_reservations=existing_reservations)
                 if bqm_ifs.get_type() != InterfaceType.FacilityPort:
                     # Allocate the first available VLAN
-                    requested_ifs.labels.vlan = str(random.choice(vlan_range))
+                    #requested_ifs.labels.vlan = str(random.choice(vlan_range))
+                    requested_ifs.labels.vlan = str(vlan_range[0])
                     requested_ifs.label_allocations = Labels(vlan=requested_ifs.labels.vlan)
                 else:
                     if requested_ifs.labels is None:
                         return requested_ifs
 
                     if requested_ifs.labels.vlan is None:
-                        requested_ifs.labels.vlan = str(random.choice(vlan_range))
+                        #requested_ifs.labels.vlan = str(random.choice(vlan_range))
+                        requested_ifs.labels.vlan = str(vlan_range[0])
 
                     if int(requested_ifs.labels.vlan) not in vlan_range:
                         raise BrokerException(error_code=ExceptionErrorCode.FAILURE,
@@ -276,7 +279,8 @@ class NetworkServiceInventory(InventoryForType):
 
             if requested_ns.label_allocations is None:
                 requested_ns.label_allocations = Labels()
-            requested_ns.label_allocations.vlan = str(random.choice(vlans_range))
+            #requested_ns.label_allocations.vlan = str(random.choice(vlans_range))
+            requested_ns.label_allocations.vlan = str(vlans_range[0])
         except Exception as e:
             self.logger.error(f"Error in allocate_vNIC: {e}")
             self.logger.error(traceback.format_exc())
@@ -446,7 +450,8 @@ class NetworkServiceInventory(InventoryForType):
             vlan_range = self.__extract_vlan_range(labels=bqm_interface.labels)
             available_vlans = self.__exclude_allocated_vlans(available_vlan_range=vlan_range, bqm_ifs=bqm_interface,
                                                              existing_reservations=existing_reservations)
-            vlan = str(random.choice(available_vlans))
+            #vlan = str(random.choice(available_vlans))
+            vlan = str(available_vlans[0])
             ifs_labels = Labels.update(ifs_labels, vlan=vlan)
 
         requested_ifs.labels = ifs_labels

--- a/fabric_cf/orchestrator/core/orchestrator_slice_wrapper.py
+++ b/fabric_cf/orchestrator/core/orchestrator_slice_wrapper.py
@@ -276,7 +276,8 @@ class OrchestratorSliceWrapper:
 
                         ifs.set_node_map(node_map=node_map)
                         peer_ifs_labels = ifs_mapping.get_peer_ifs().get_labels()
-                        ifs.set_peer_labels(lab=peer_ifs_labels)
+                        if peer_ifs_labels is not None:
+                            ifs.set_peer_labels(lab=peer_ifs_labels)
                         # Peer_ifs is AL2S in ASM
                         if peer_ifs_labels is not None and peer_ifs_labels.ipv4_subnet is not None:
                             interface = ipaddress.IPv4Interface(peer_ifs_labels.ipv4_subnet)


### PR DESCRIPTION
- AL2S AM needs to know the remote provider name in the AL2S Handler, using local_name field in Peer Labels for that. Orchestrator was overriding it, small fix to retain the value passed by user
- AL2S AM needs VLAN allocation to be random, since sometimes the first available vlan even though reported to be available fails to provision. Liang suggested to change the vlan allocation to random.