### PR TITLE
Allocation error

### DIFF
--- a/Dockerfile-auth
+++ b/Dockerfile-auth
@@ -1,7 +1,7 @@
 FROM python:3.11.0
 MAINTAINER Komal Thareja<komal.thareja@gmail.com>
 
-ARG HANDLERS_VER=1.6.0
+ARG HANDLERS_VER=1.6.1
 
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app

--- a/fabric_cf/actor/core/policy/broker_simpler_units_policy.py
+++ b/fabric_cf/actor/core/policy/broker_simpler_units_policy.py
@@ -535,7 +535,7 @@ class BrokerSimplerUnitsPolicy(BrokerCalendarPolicy):
 
         return node_id_list
 
-    def __find_first_fit(self, node_id_list: List[str], node_id_to_reservations: dict, inv: InventoryForType,
+    def __find_first_fit(self, node_id_list: List[str], node_id_to_reservations: dict, inv: NetworkNodeInventory,
                          reservation: ABCBrokerReservation) -> Tuple[str, BaseSliver, Any]:
         """
         Find First Available Node which can serve the reservation
@@ -550,6 +550,7 @@ class BrokerSimplerUnitsPolicy(BrokerCalendarPolicy):
         error_msg = None
         self.logger.debug(f"Possible candidates to serve {reservation} candidates# {node_id_list}")
         requested_sliver = reservation.get_requested_resources().get_sliver()
+        is_create = requested_sliver.get_node_map() is None
         for node_id in node_id_list:
             try:
                 self.logger.debug(f"Attempting to allocate {reservation} via graph_node# {node_id}")
@@ -568,7 +569,9 @@ class BrokerSimplerUnitsPolicy(BrokerCalendarPolicy):
                 delegation_id, sliver = inv.allocate(rid=reservation.get_reservation_id(),
                                                      requested_sliver=requested_sliver,
                                                      graph_id=self.combined_broker_model_graph_id,
-                                                     graph_node=graph_node, existing_reservations=existing_reservations)
+                                                     graph_node=graph_node,
+                                                     existing_reservations=existing_reservations,
+                                                     is_create=is_create)
 
                 if delegation_id is not None and sliver is not None:
                     break

--- a/fabric_cf/actor/core/policy/network_node_inventory.py
+++ b/fabric_cf/actor/core/policy/network_node_inventory.py
@@ -229,12 +229,14 @@ class NetworkNodeInventory(InventoryForType):
         return requested_component
 
     def __check_component_labels_and_capacities(self, *, available_component: ComponentSliver, graph_id: str,
-                                                requested_component: ComponentSliver) -> ComponentSliver:
+                                                requested_component: ComponentSliver,
+                                                is_create: bool = False) -> ComponentSliver:
         """
         Check if available component capacities, labels to match requested component
         :param available_component: available component
         :param graph_id: BQM graph id
         :param requested_component: requested component
+        :param is_create: is_create
         :return: requested component annotated with properties in case of success, None otherwise
         """
         if requested_component.get_model() is not None and \
@@ -269,7 +271,7 @@ class NetworkNodeInventory(InventoryForType):
 
         node_map = tuple([graph_id, available_component.node_id])
         requested_component.set_node_map(node_map=node_map)
-        if requested_component.labels is None:
+        if requested_component.labels is None or is_create:
             requested_component.labels = Labels.update(lab=requested_component.get_label_allocations())
 
         return requested_component
@@ -428,7 +430,9 @@ class NetworkNodeInventory(InventoryForType):
             for component in available_components:
                 # check model matches the requested model
                 requested_component = self.__check_component_labels_and_capacities(
-                    available_component=component, graph_id=graph_id, requested_component=requested_component)
+                    available_component=component, graph_id=graph_id,
+                    requested_component=requested_component,
+                    is_create=is_create)
 
                 if requested_component.get_node_map() is not None:
                     self.logger.info(f"Assigning {component.node_id} to component# "

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
     "swagger-ui-bundle==0.0.9",
     "PyYAML",
     "fabric_fss_utils==1.5.0",
-    "fabric-message-bus==1.6.0",
+    "fabric-message-bus==1.6.1b0",
     "fabric-fim==1.6.1",
     "fabric-credmgr-client==1.6.0",
     "ansible"


### PR DESCRIPTION
#355 

Allocation retry against multiple candidate nodes were treated as modify instead of create. Resulting in components being allocated from multiple nodes which results in provisioning failures at AM.

Scenario:

- Candidate nodes detected by Broker for VM [w1, w2, w3]
- Allocation succeeds partially with w1 but eventually fails for some dedicated resources
- Retry for candidate node w2, is being treated as modify and leaves the components allocated in the previous try as is
- Provisioning would fail at AM as w1, does not have components allocated from w2 for the VM