### PR TITLE
Kafka consumer refactoring

### DIFF
--- a/Dockerfile-auth
+++ b/Dockerfile-auth
@@ -1,7 +1,7 @@
 FROM python:3.11.0
 MAINTAINER Komal Thareja<komal.thareja@gmail.com>
 
-ARG HANDLERS_VER=1.6.0
+ARG HANDLERS_VER=1.6.1
 
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app

--- a/Dockerfile-auth
+++ b/Dockerfile-auth
@@ -25,7 +25,7 @@ RUN mkdir -p "/etc/fabric/actor/config"
 RUN mkdir -p "/var/log/actor"
 RUN cp /usr/local/lib/python3.11/site-packages/fabric_mb/message_bus/schema/*.avsc /etc/fabric/message_bus/schema
 RUN pip3 install fabric-am-handlers==${HANDLERS_VER}
-RUN pip3 install fabric-message-bus==1.6.1rc1
+RUN pip3 install fabric-message-bus==1.6.1rc2
 RUN sh /usr/src/app/install.sh
 
 ENTRYPOINT ["/usr/src/app/docker-entrypoint.sh"]

--- a/Dockerfile-auth
+++ b/Dockerfile-auth
@@ -25,7 +25,7 @@ RUN mkdir -p "/etc/fabric/actor/config"
 RUN mkdir -p "/var/log/actor"
 RUN cp /usr/local/lib/python3.11/site-packages/fabric_mb/message_bus/schema/*.avsc /etc/fabric/message_bus/schema
 RUN pip3 install fabric-am-handlers==${HANDLERS_VER}
-RUN pip3 install fabric-message-bus==1.6.1rc0
+RUN pip3 install fabric-message-bus==1.6.1rc1
 RUN sh /usr/src/app/install.sh
 
 ENTRYPOINT ["/usr/src/app/docker-entrypoint.sh"]

--- a/Dockerfile-auth
+++ b/Dockerfile-auth
@@ -25,6 +25,7 @@ RUN mkdir -p "/etc/fabric/actor/config"
 RUN mkdir -p "/var/log/actor"
 RUN cp /usr/local/lib/python3.11/site-packages/fabric_mb/message_bus/schema/*.avsc /etc/fabric/message_bus/schema
 RUN pip3 install fabric-am-handlers==${HANDLERS_VER}
+RUN pip3 install fabric-message-bus==1.6.1rc0
 RUN sh /usr/src/app/install.sh
 
 ENTRYPOINT ["/usr/src/app/docker-entrypoint.sh"]

--- a/Dockerfile-auth
+++ b/Dockerfile-auth
@@ -25,7 +25,7 @@ RUN mkdir -p "/etc/fabric/actor/config"
 RUN mkdir -p "/var/log/actor"
 RUN cp /usr/local/lib/python3.11/site-packages/fabric_mb/message_bus/schema/*.avsc /etc/fabric/message_bus/schema
 RUN pip3 install fabric-am-handlers==${HANDLERS_VER}
-RUN pip3 install fabric-message-bus==1.6.1rc2
+RUN pip3 install fabric-message-bus==1.6.1rc3
 RUN sh /usr/src/app/install.sh
 
 ENTRYPOINT ["/usr/src/app/docker-entrypoint.sh"]

--- a/Dockerfile-auth
+++ b/Dockerfile-auth
@@ -25,7 +25,7 @@ RUN mkdir -p "/etc/fabric/actor/config"
 RUN mkdir -p "/var/log/actor"
 RUN cp /usr/local/lib/python3.11/site-packages/fabric_mb/message_bus/schema/*.avsc /etc/fabric/message_bus/schema
 RUN pip3 install fabric-am-handlers==${HANDLERS_VER}
-RUN pip3 install fabric-message-bus==1.6.1rc3
+RUN pip3 install fabric-message-bus==1.6.1
 RUN sh /usr/src/app/install.sh
 
 ENTRYPOINT ["/usr/src/app/docker-entrypoint.sh"]

--- a/fabric_cf/__init__.py
+++ b/fabric_cf/__init__.py
@@ -1,2 +1,2 @@
-__version__ = "1.6.1"
+__version__ = "1.6.2"
 __VERSION__ = __version__

--- a/fabric_cf/actor/boot/configuration.py
+++ b/fabric_cf/actor/boot/configuration.py
@@ -462,7 +462,7 @@ class Configuration:
         return self.global_config.runtime.get(Constants.PROPERTY_CONF_KAFKA_KEY_SCHEMA, None)
 
     def get_kafka_consumer_commit_batch_size(self) -> int:
-        return int(self.global_config.runtime.get(Constants.PROPERTY_CONF_KAFKA_BATCH_SIZE, 10))
+        return int(self.global_config.runtime.get(Constants.PROPERTY_CONF_KAFKA_BATCH_SIZE, 1))
 
     def get_kafka_consumer_poll_timeout(self) -> int:
         return int(self.global_config.runtime.get(Constants.PROPERTY_CONF_KAFKA_POLL_TIMEOUT, 250))

--- a/fabric_cf/actor/boot/configuration.py
+++ b/fabric_cf/actor/boot/configuration.py
@@ -462,10 +462,10 @@ class Configuration:
         return self.global_config.runtime.get(Constants.PROPERTY_CONF_KAFKA_KEY_SCHEMA, None)
 
     def get_kafka_consumer_commit_batch_size(self) -> int:
-        return self.global_config.runtime.get(Constants.PROPERTY_CONF_KAFKA_KEY_SCHEMA, 10)
+        return int(self.global_config.runtime.get(Constants.PROPERTY_CONF_KAFKA_KEY_SCHEMA, 10))
 
-    def get_kafka_consumer_poll_timeout(self) -> float:
-        return self.global_config.runtime.get(Constants.PROPERTY_CONF_KAFKA_KEY_SCHEMA, 0.25)
+    def get_kafka_consumer_poll_timeout(self) -> int:
+        return int(self.global_config.runtime.get(Constants.PROPERTY_CONF_KAFKA_KEY_SCHEMA, 250))
 
     def get_kafka_consumer_enable_auto_commit(self) -> bool:
         return self.global_config.runtime.get(Constants.PROPERTY_CONF_KAFKA_ENABLE_AUTO_COMMIT, True)

--- a/fabric_cf/actor/boot/configuration.py
+++ b/fabric_cf/actor/boot/configuration.py
@@ -461,6 +461,15 @@ class Configuration:
     def get_kafka_key_schema_location(self) -> str or None:
         return self.global_config.runtime.get(Constants.PROPERTY_CONF_KAFKA_KEY_SCHEMA, None)
 
+    def get_kafka_consumer_commit_batch_size(self) -> int:
+        return self.global_config.runtime.get(Constants.PROPERTY_CONF_KAFKA_KEY_SCHEMA, 10)
+
+    def get_kafka_consumer_poll_timeout(self) -> float:
+        return self.global_config.runtime.get(Constants.PROPERTY_CONF_KAFKA_KEY_SCHEMA, 0.25)
+
+    def get_kafka_consumer_enable_auto_commit(self) -> bool:
+        return self.global_config.runtime.get(Constants.PROPERTY_CONF_KAFKA_ENABLE_AUTO_COMMIT, True)
+
     def get_kafka_value_schema_location(self) -> str or None:
         return self.global_config.runtime.get(Constants.PROPERTY_CONF_KAFKA_VALUE_SCHEMA, None)
 

--- a/fabric_cf/actor/boot/configuration.py
+++ b/fabric_cf/actor/boot/configuration.py
@@ -453,13 +453,14 @@ class Configuration:
         if self.global_config is not None:
             return self.global_config.get_neo4j_config()
 
-        return None
-
     def get_rpc_retries(self) -> int:
         return self.global_config.runtime.get(Constants.PROPERTY_CONF_RPC_RETRIES, 5)
 
     def get_kafka_key_schema_location(self) -> str or None:
         return self.global_config.runtime.get(Constants.PROPERTY_CONF_KAFKA_KEY_SCHEMA, None)
+
+    def get_kafka_consumer_auto_commit_interval(self) -> int:
+        return int(self.global_config.runtime.get(Constants.PROPERTY_CONF_KAFKA_AUTO_COMMIT_INTERVAL), 5)
 
     def get_kafka_consumer_commit_batch_size(self) -> int:
         return int(self.global_config.runtime.get(Constants.PROPERTY_CONF_KAFKA_BATCH_SIZE, 1))

--- a/fabric_cf/actor/boot/configuration.py
+++ b/fabric_cf/actor/boot/configuration.py
@@ -462,10 +462,10 @@ class Configuration:
         return self.global_config.runtime.get(Constants.PROPERTY_CONF_KAFKA_KEY_SCHEMA, None)
 
     def get_kafka_consumer_commit_batch_size(self) -> int:
-        return int(self.global_config.runtime.get(Constants.PROPERTY_CONF_KAFKA_KEY_SCHEMA, 10))
+        return int(self.global_config.runtime.get(Constants.PROPERTY_CONF_KAFKA_BATCH_SIZE, 10))
 
     def get_kafka_consumer_poll_timeout(self) -> int:
-        return int(self.global_config.runtime.get(Constants.PROPERTY_CONF_KAFKA_KEY_SCHEMA, 250))
+        return int(self.global_config.runtime.get(Constants.PROPERTY_CONF_KAFKA_POLL_TIMEOUT, 250))
 
     def get_kafka_consumer_enable_auto_commit(self) -> bool:
         return self.global_config.runtime.get(Constants.PROPERTY_CONF_KAFKA_ENABLE_AUTO_COMMIT, True)

--- a/fabric_cf/actor/core/common/constants.py
+++ b/fabric_cf/actor/core/common/constants.py
@@ -87,6 +87,10 @@ class Constants:
 
     PROPERTY_PICKLE_PROPERTIES = "properties"
 
+    PROPERTY_CONF_KAFKA_POLL_TIMEOUT = "consumer.poll.timeout"
+    PROPERTY_CONF_KAFKA_BATCH_SIZE = "commit.batch.size"
+    PROPERTY_CONF_KAFKA_ENABLE_AUTO_COMMIT = "enable.auto.commit"
+
     CONFIG_SECTION_RUNTIME = "runtime"
     PROPERTY_CONF_KAFKA_SERVER = "kafka-server"
     PROPERTY_CONF_KAFKA_SCHEMA_REGISTRY = "kafka-schema-registry-url"

--- a/fabric_cf/actor/core/common/constants.py
+++ b/fabric_cf/actor/core/common/constants.py
@@ -89,6 +89,7 @@ class Constants:
 
     PROPERTY_CONF_KAFKA_POLL_TIMEOUT = "consumer.poll.timeout"
     PROPERTY_CONF_KAFKA_BATCH_SIZE = "commit.batch.size"
+    PROPERTY_CONF_KAFKA_AUTO_COMMIT_INTERVAL = "auto.commit.interval.ms"
     PROPERTY_CONF_KAFKA_ENABLE_AUTO_COMMIT = "enable.auto.commit"
 
     CONFIG_SECTION_RUNTIME = "runtime"

--- a/fabric_cf/actor/core/container/globals.py
+++ b/fabric_cf/actor/core/container/globals.py
@@ -262,6 +262,14 @@ class Globals:
 
         return conf
 
+    def get_kafka_config_schema_registry_client(self) -> dict:
+        """
+        Get Producer Config
+        @return producer config
+        """
+        if self.config and self.config.get_runtime_config():
+            return {"url": self.config.get_kafka_schema_registry() }
+
     def get_kafka_config_producer(self) -> dict:
         """
         Get Producer Config
@@ -280,7 +288,7 @@ class Globals:
                 Constants.SSL_CERTIFICATE_LOCATION: self.config.get_kafka_ssl_cert_location(),
                 Constants.SSL_KEY_LOCATION: self.config.get_kafka_ssl_key_location(),
                 Constants.SSL_KEY_PASSWORD: self.config.get_kafka_ssl_key_password(),
-                Constants.SCHEMA_REGISTRY_URL: self.config.get_kafka_schema_registry(),
+                #Constants.SCHEMA_REGISTRY_URL: self.config.get_kafka_schema_registry(),
                 Constants.PROPERTY_CONF_KAFKA_REQUEST_TIMEOUT_MS: self.config.get_kafka_request_timeout_ms(),
                 Constants.PROPERTY_CONF_KAFKA_MAX_MESSAGE_SIZE: self.config.get_kafka_max_message_size()}
 
@@ -324,7 +332,8 @@ class Globals:
         value_schema_file = self.config.get_kafka_value_schema_location()
 
         from fabric_mb.message_bus.producer import AvroProducerApi
-        producer = AvroProducerApi(producer_conf=conf, key_schema_location=key_schema_file,
+        producer = AvroProducerApi(producer_conf=conf,
+                                   schema_registry_conf=self.get_kafka_config_schema_registry_client(),
                                    value_schema_location=value_schema_file, logger=self.get_logger())
         return producer
 
@@ -334,11 +343,10 @@ class Globals:
         @return producer
         """
         conf = self.get_kafka_config_producer()
-        key_schema_file = self.config.get_kafka_key_schema_location()
         value_schema_file = self.config.get_kafka_value_schema_location()
 
         from fabric_cf.actor.core.container.rpc_producer import RPCProducer
-        producer = RPCProducer(producer_conf=conf, key_schema_location=key_schema_file,
+        producer = RPCProducer(producer_conf=conf, schema_registry_conf=self.get_kafka_config_schema_registry_client(),
                                value_schema_location=value_schema_file, logger=self.get_logger(),
                                actor=actor, retries=self.config.get_rpc_retries())
         return producer

--- a/fabric_cf/actor/core/container/globals.py
+++ b/fabric_cf/actor/core/container/globals.py
@@ -299,6 +299,22 @@ class Globals:
 
         return conf
 
+    def get_kafka_consumer_poll_timeout(self):
+        if self.get_config():
+            return self.get_config().get_kafka_consumer_poll_timeout()
+
+    def get_kafka_consumer_commit_batch_size(self):
+        if self.get_config():
+            return self.get_config().get_kafka_consumer_commit_batch_size()
+
+    def get_kafka_key_schema_location(self):
+        if self.get_config():
+            return self.get_config().get_kafka_key_schema_location()
+
+    def get_kafka_value_schema_location(self):
+        if self.get_config():
+            return self.get_config().get_kafka_value_schema_location()
+
     def get_kafka_config_consumer(self) -> dict:
         """
         Get Consumer config
@@ -311,6 +327,7 @@ class Globals:
         group_id = self.config.get_kafka_cons_group_id()
 
         conf['auto.offset.reset'] = 'earliest'
+        conf[Constants.PROPERTY_CONF_KAFKA_ENABLE_AUTO_COMMIT] = self.get_config().get_kafka_consumer_enable_auto_commit()
 
         sasl_username = self.config.get_kafka_cons_user_name()
         sasl_password = self.config.get_kafka_cons_user_pwd()
@@ -343,12 +360,17 @@ class Globals:
         @return producer
         """
         conf = self.get_kafka_config_producer()
+        key_schema_file = self.config.get_kafka_key_schema_location()
         value_schema_file = self.config.get_kafka_value_schema_location()
 
         from fabric_cf.actor.core.container.rpc_producer import RPCProducer
-        producer = RPCProducer(producer_conf=conf, schema_registry_conf=self.get_kafka_config_schema_registry_client(),
+        producer = RPCProducer(producer_conf=conf, key_schema_location=key_schema_file,
                                value_schema_location=value_schema_file, logger=self.get_logger(),
                                actor=actor, retries=self.config.get_rpc_retries())
+        # Uncomment for 1.7
+        #producer = RPCProducer(producer_conf=conf, schema_registry_conf=self.get_kafka_config_schema_registry_client(),
+        #                       value_schema_location=value_schema_file, logger=self.get_logger(),
+        #                       actor=actor, retries=self.config.get_rpc_retries())
         return producer
 
     def get_simple_kafka_producer(self):

--- a/fabric_cf/actor/core/container/globals.py
+++ b/fabric_cf/actor/core/container/globals.py
@@ -288,7 +288,7 @@ class Globals:
                 Constants.SSL_CERTIFICATE_LOCATION: self.config.get_kafka_ssl_cert_location(),
                 Constants.SSL_KEY_LOCATION: self.config.get_kafka_ssl_key_location(),
                 Constants.SSL_KEY_PASSWORD: self.config.get_kafka_ssl_key_password(),
-                #Constants.SCHEMA_REGISTRY_URL: self.config.get_kafka_schema_registry(),
+                Constants.SCHEMA_REGISTRY_URL: self.config.get_kafka_schema_registry(),
                 Constants.PROPERTY_CONF_KAFKA_REQUEST_TIMEOUT_MS: self.config.get_kafka_request_timeout_ms(),
                 Constants.PROPERTY_CONF_KAFKA_MAX_MESSAGE_SIZE: self.config.get_kafka_max_message_size()}
 

--- a/fabric_cf/actor/core/container/globals.py
+++ b/fabric_cf/actor/core/container/globals.py
@@ -350,7 +350,8 @@ class Globals:
 
         from fabric_mb.message_bus.producer import AvroProducerApi
         producer = AvroProducerApi(producer_conf=conf,
-                                   schema_registry_conf=self.get_kafka_config_schema_registry_client(),
+                                   key_schema_location=key_schema_file,
+                                   #schema_registry_conf=self.get_kafka_config_schema_registry_client(),
                                    value_schema_location=value_schema_file, logger=self.get_logger())
         return producer
 

--- a/fabric_cf/actor/core/container/globals.py
+++ b/fabric_cf/actor/core/container/globals.py
@@ -307,6 +307,14 @@ class Globals:
         if self.get_config():
             return self.get_config().get_kafka_consumer_commit_batch_size()
 
+    def get_kafka_consumer_auto_commit_interval(self):
+        if self.get_config():
+            return self.get_config().get_kafka_consumer_auto_commit_interval()
+
+    def get_kafka_consumer_enable_auto_commit(self):
+        if self.get_config():
+            return self.get_config().get_kafka_consumer_enable_auto_commit()
+
     def get_kafka_key_schema_location(self):
         if self.get_config():
             return self.get_config().get_kafka_key_schema_location()
@@ -321,23 +329,26 @@ class Globals:
         @return consumer config
         """
         if self.config is None or self.config.get_runtime_config() is None:
-            return None
-        conf = self.get_kafka_config_producer()
+            conf = self.get_kafka_config_producer()
 
-        group_id = self.config.get_kafka_cons_group_id()
+            group_id = self.get_config().get_kafka_cons_group_id()
 
-        conf['auto.offset.reset'] = 'earliest'
-        conf[Constants.PROPERTY_CONF_KAFKA_ENABLE_AUTO_COMMIT] = self.get_config().get_kafka_consumer_enable_auto_commit()
+            conf['auto.offset.reset'] = 'earliest'
+            enable_auto_commit = self.get_kafka_consumer_enable_auto_commit()
+            if enable_auto_commit:
+                conf[Constants.PROPERTY_CONF_KAFKA_AUTO_COMMIT_INTERVAL] = self.get_kafka_consumer_auto_commit_interval()
+            else:
+                conf[Constants.PROPERTY_CONF_KAFKA_ENABLE_AUTO_COMMIT] = enable_auto_commit
 
-        sasl_username = self.config.get_kafka_cons_user_name()
-        sasl_password = self.config.get_kafka_cons_user_pwd()
+            sasl_username = self.get_config().get_kafka_cons_user_name()
+            sasl_password = self.get_config().get_kafka_cons_user_pwd()
 
-        if sasl_username is not None and sasl_username != '' and sasl_password is not None and sasl_password != '':
-            conf[Constants.SASL_USERNAME] = sasl_username
-            conf[Constants.SASL_PASSWORD] = sasl_password
-        conf[Constants.GROUP_ID] = group_id
-        conf[Constants.PROPERTY_CONF_KAFKA_FETCH_MAX_MESSAGE_SIZE] = self.config.get_kafka_max_message_size()
-        return conf
+            if sasl_username is not None and sasl_username != '' and sasl_password is not None and sasl_password != '':
+                conf[Constants.SASL_USERNAME] = sasl_username
+                conf[Constants.SASL_PASSWORD] = sasl_password
+            conf[Constants.GROUP_ID] = group_id
+            conf[Constants.PROPERTY_CONF_KAFKA_FETCH_MAX_MESSAGE_SIZE] = self.get_config().get_kafka_max_message_size()
+            return conf
 
     def get_kafka_producer(self):
         """

--- a/fabric_cf/actor/core/container/globals.py
+++ b/fabric_cf/actor/core/container/globals.py
@@ -328,7 +328,7 @@ class Globals:
         Get Consumer config
         @return consumer config
         """
-        if self.config is None or self.config.get_runtime_config() is None:
+        if self.config and self.config.get_runtime_config():
             conf = self.get_kafka_config_producer()
 
             group_id = self.get_config().get_kafka_cons_group_id()

--- a/fabric_cf/actor/core/container/message_service.py
+++ b/fabric_cf/actor/core/container/message_service.py
@@ -36,11 +36,18 @@ from fabric_cf.actor.core.common.exceptions import KafkaServiceException
 
 
 class MessageService(AvroConsumerApi):
-    def __init__(self, *, consumer_conf: dict, schema_registry_conf: dict, value_schema_location: str,
-                 topics: List[str], consumer_thread, batch_size: int = 5, logger: logging.Logger = None, sync: bool = False):
-        super(MessageService, self).__init__(consumer_conf=consumer_conf, schema_registry_conf=schema_registry_conf,
+    # uncomment for 1.7
+    #def __init__(self, *, consumer_conf: dict, schema_registry_conf: dict, value_schema_location: str,
+    #             topics: List[str], consumer_thread, batch_size: int = 5, logger: logging.Logger = None, sync: bool = False):
+    #    super(MessageService, self).__init__(consumer_conf=consumer_conf, schema_registry_conf=schema_registry_conf,
+    #                                         value_schema_location=value_schema_location, topics=topics,
+    #                                         batch_size=batch_size, logger=logger)
+    def __init__(self, *, consumer_conf: dict, key_schema_location, value_schema_location: str,
+                 topics: List[str], consumer_thread, batch_size: int = 5, logger: logging.Logger = None,
+                 poll_timeout: float = 0.25):
+        super(MessageService, self).__init__(consumer_conf=consumer_conf, key_schema_location=key_schema_location,
                                              value_schema_location=value_schema_location, topics=topics,
-                                             batch_size=batch_size, logger=logger, sync=sync)
+                                             batch_size=batch_size, logger=logger, poll_timeout=poll_timeout)
         self.consumer_thread = consumer_thread
         self.thread_lock = threading.Lock()
         self.thread = None

--- a/fabric_cf/actor/core/container/message_service.py
+++ b/fabric_cf/actor/core/container/message_service.py
@@ -44,7 +44,7 @@ class MessageService(AvroConsumerApi):
     #                                         batch_size=batch_size, logger=logger)
     def __init__(self, *, consumer_conf: dict, key_schema_location, value_schema_location: str,
                  topics: List[str], consumer_thread, batch_size: int = 5, logger: logging.Logger = None,
-                 poll_timeout: float = 0.25):
+                 poll_timeout: int = 250):
         super(MessageService, self).__init__(consumer_conf=consumer_conf, key_schema_location=key_schema_location,
                                              value_schema_location=value_schema_location, topics=topics,
                                              batch_size=batch_size, logger=logger, poll_timeout=poll_timeout)

--- a/fabric_cf/actor/core/container/rpc_consumer.py
+++ b/fabric_cf/actor/core/container/rpc_consumer.py
@@ -1,0 +1,184 @@
+#!/usr/bin/env python3
+# MIT License
+#
+# Copyright (c) 2020 FABRIC Testbed
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+#
+# Author: Komal Thareja (kthare10@renci.org)
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, List
+import logging
+import queue
+import threading
+import time
+import traceback
+
+
+from fabric_mb.message_bus.messages.abc_message_avro import AbcMessageAvro
+from fabric_cf.actor.core.util.iterable_queue import IterableQueue
+
+if TYPE_CHECKING:
+    from fabric_cf.actor.core.proxies.kafka.services.actor_service import ActorService
+    from fabric_cf.actor.core.manage.kafka.services.kafka_actor_service import KafkaActorService
+
+
+class RPCConsumerException(Exception):
+    pass
+
+
+class RPCConsumer:
+    MANAGEMENT_MESSAGES = [AbcMessageAvro.claim_resources,
+                           AbcMessageAvro.reclaim_resources,
+                           AbcMessageAvro.get_slices_request,
+                           AbcMessageAvro.get_reservations_request,
+                           AbcMessageAvro.get_reservations_state_request,
+                           AbcMessageAvro.get_delegations,
+                           AbcMessageAvro.get_reservation_units_request,
+                           AbcMessageAvro.get_unit_request,
+                           AbcMessageAvro.get_broker_query_model_request,
+                           AbcMessageAvro.add_slice,
+                           AbcMessageAvro.update_slice,
+                           AbcMessageAvro.remove_slice,
+                           AbcMessageAvro.close_reservations,
+                           AbcMessageAvro.update_reservation,
+                           AbcMessageAvro.remove_reservation,
+                           AbcMessageAvro.extend_reservation,
+                           AbcMessageAvro.close_delegations,
+                           AbcMessageAvro.remove_delegation,
+                           AbcMessageAvro.maintenance_request,
+                           AbcMessageAvro.get_sites_request]
+
+    def __init__(self, *, kafka_service: ActorService, kafka_mgmt_service: KafkaActorService,
+                 logger: logging.Logger = None):
+        self.message_queue = queue.Queue()
+        self.thread_lock = threading.Lock()
+        self.condition = threading.Condition()
+        self.thread = None
+        self.shutdown = False
+        self.name = self.__class__.__name__
+        if logger is None:
+            self.logger = logging.Logger(self.name)
+        else:
+            self.logger = logger
+        self.kafka_service = kafka_service
+        self.kafka_mgmt_service = kafka_mgmt_service
+
+    def __getstate__(self):
+        state = self.__dict__.copy()
+        del state['message_queue']
+        del state['thread_lock']
+        del state['condition']
+        del state['thread']
+        del state['shutdown']
+        del state['logger']
+
+    def __setstate__(self, state):
+        self.message_queue = queue.Queue()
+        self.thread_lock = threading.Lock()
+        self.condition = threading.Condition()
+        self.thread = None
+        self.shutdown = False
+        self.logger = None
+
+    def set_logger(self, *, logger: logging.Logger):
+        self.logger = logger
+
+    def start(self):
+        try:
+            self.thread_lock.acquire()
+            if self.thread is not None:
+                raise RPCConsumerException(f"{self.name} has already been started")
+
+            self.thread = threading.Thread(target=self.__run, name=self.name, daemon=True)
+            self.thread.start()
+            self.logger.debug(f"{self.name} has been started")
+        finally:
+            self.thread_lock.release()
+
+    def stop(self):
+        self.shutdown = True
+        try:
+            self.thread_lock.acquire()
+            temp = self.thread
+            self.thread = None
+            if temp is not None:
+                self.logger.warning(f"It seems that the f{self.name} thread is running. Interrupting it")
+                try:
+                    temp.join()
+                except Exception as e:
+                    self.logger.error(f"Could not join {self.name} thread {e}")
+                finally:
+                    self.thread_lock.release()
+        finally:
+            if self.thread_lock is not None and self.thread_lock.locked():
+                self.thread_lock.release()
+
+    def enqueue(self, incoming):
+        try:
+            self.message_queue.put_nowait(incoming)
+            with self.condition:
+                self.condition.notify_all()
+            self.logger.debug("Added message to queue {}".format(incoming.__class__.__name__))
+        except Exception as e:
+            self.logger.error(f"Failed to queue message: {incoming.__class__.__name__} e: {e}")
+
+    def __dequeue(self, queue_obj: queue.Queue):
+        events = []
+        if not queue_obj.empty():
+            try:
+                for event in IterableQueue(source_queue=queue_obj):
+                    events.append(event)
+            except Exception as e:
+                self.logger.error(f"Error while adding message to queue! e: {e}")
+                self.logger.error(traceback.format_exc())
+        return events
+
+    def __process_messages(self, *, messages: list):
+        for message in messages:
+            try:
+                begin = time.time()
+                if message.get_message_name() in self.MANAGEMENT_MESSAGES:
+                    self.kafka_mgmt_service.process(message=message)
+                else:
+                    self.kafka_service.process(message=message)
+                diff = int(time.time() - begin)
+                if diff > 0:
+                    self.logger.info(f"Event {m.__class__.__name__} TIME: {diff}")
+            except Exception as e:
+                self.logger.error(f"Error while processing message {type(m)}, {e}")
+                self.logger.error(traceback.format_exc())
+
+    def __run(self):
+        while True:
+            with self.condition:
+                while not self.shutdown and self.message_queue.empty():
+                    self.condition.wait()
+
+            if self.shutdown:
+                break
+
+            if self.shutdown:
+                self.logger.info(f"{self.name} exiting")
+                return
+
+            messages = self.__dequeue(self.message_queue)
+            self.__process_messages(messages=messages)

--- a/fabric_cf/actor/core/container/rpc_consumer.py
+++ b/fabric_cf/actor/core/container/rpc_consumer.py
@@ -162,9 +162,9 @@ class RPCConsumer:
                     self.kafka_service.process(message=message)
                 diff = int(time.time() - begin)
                 if diff > 0:
-                    self.logger.info(f"Event {m.__class__.__name__} TIME: {diff}")
+                    self.logger.info(f"Event {message.__class__.__name__} TIME: {diff}")
             except Exception as e:
-                self.logger.error(f"Error while processing message {type(m)}, {e}")
+                self.logger.error(f"Error while processing message {type(message)}, {e}")
                 self.logger.error(traceback.format_exc())
 
     def __run(self):

--- a/fabric_cf/actor/core/container/rpc_producer.py
+++ b/fabric_cf/actor/core/container/rpc_producer.py
@@ -54,9 +54,9 @@ class RPCProducer(AvroProducerApi):
                          AbcMessageAvro.update_lease: RPCRequestType.UpdateLease,
                          AbcMessageAvro.update_ticket: RPCRequestType.UpdateTicket}
 
-    def __init__(self, *, producer_conf: dict, key_schema_location, value_schema_location: str, actor: ABCActorMixin,
+    def __init__(self, *, producer_conf: dict, schema_registry_conf, value_schema_location: str, actor: ABCActorMixin,
                  logger: logging.Logger = None, retries: int = 5):
-        super(RPCProducer, self).__init__(producer_conf=producer_conf, key_schema_location=key_schema_location,
+        super(RPCProducer, self).__init__(producer_conf=producer_conf, schema_registry_conf=schema_registry_conf,
                                           value_schema_location=value_schema_location, logger=logger, retries=retries)
         self.actor = actor
         self.thread_lock = threading.Lock()
@@ -73,9 +73,7 @@ class RPCProducer(AvroProducerApi):
                 raise KafkaServiceException(f"{self.__class__.__name__} has already been started")
 
             self.running = True
-            self.thread = threading.Thread(target=self.delivery_check)
-            self.thread.setName(self.__class__.__name__)
-            self.thread.setDaemon(True)
+            self.thread = threading.Thread(target=self.delivery_check, name=self.__class__.__name__, daemon=True)
             self.thread.start()
             self.logger.debug(f"{self.__class__.__name__} has been started")
         finally:

--- a/fabric_cf/actor/core/container/rpc_producer.py
+++ b/fabric_cf/actor/core/container/rpc_producer.py
@@ -53,10 +53,14 @@ class RPCProducer(AvroProducerApi):
     AVRO_RPC_TYPE_MAP = {AbcMessageAvro.close: RPCRequestType.Close,
                          AbcMessageAvro.update_lease: RPCRequestType.UpdateLease,
                          AbcMessageAvro.update_ticket: RPCRequestType.UpdateTicket}
-
-    def __init__(self, *, producer_conf: dict, schema_registry_conf, value_schema_location: str, actor: ABCActorMixin,
-                 logger: logging.Logger = None, retries: int = 5):
-        super(RPCProducer, self).__init__(producer_conf=producer_conf, schema_registry_conf=schema_registry_conf,
+    # Uncomment for 1.7
+    #def __init__(self, *, producer_conf: dict, schema_registry_conf, value_schema_location: str, actor: ABCActorMixin,
+    #             logger: logging.Logger = None, retries: int = 5):
+        #super(RPCProducer, self).__init__(producer_conf=producer_conf, schema_registry_conf=schema_registry_conf,
+        #                                  value_schema_location=value_schema_location, logger=logger, retries=retries)
+    def __init__(self, *, producer_conf: dict, key_schema_location: str, value_schema_location: str,
+                 actor: ABCActorMixin, logger: logging.Logger = None, retries: int = 5):
+        super(RPCProducer, self).__init__(producer_conf=producer_conf, key_schema_location=key_schema_location,
                                           value_schema_location=value_schema_location, logger=logger, retries=retries)
         self.actor = actor
         self.thread_lock = threading.Lock()

--- a/fabric_cf/actor/core/core/actor.py
+++ b/fabric_cf/actor/core/core/actor.py
@@ -898,7 +898,9 @@ class ActorMixin(ABCActorMixin):
                                                                              class_name=class_name)()
             kafka_mgmt_service.set_logger(logger=self.logger)
 
-            self.rpc_consumer = RPCConsumer(kafka_service=kafka_service, kafka_mgmt_service=kafka_mgmt_service)
+            self.rpc_consumer = RPCConsumer(kafka_service=kafka_service,
+                                            kafka_mgmt_service=kafka_mgmt_service,
+                                            logger=self.logger)
 
             # Incoming Message Service
             from fabric_cf.actor.core.container.globals import GlobalsSingleton

--- a/fabric_cf/actor/core/core/actor.py
+++ b/fabric_cf/actor/core/core/actor.py
@@ -914,6 +914,8 @@ class ActorMixin(ABCActorMixin):
             else:
                 topics = [topic]
             consumer_conf = GlobalsSingleton.get().get_kafka_config_consumer()
+            if self.message_service is None:
+                self.message_service = []
             for x in topics:
                 consumer_conf[Constants.GROUP_ID] += x
                 msg_svc = MessageService(consumer_conf=consumer_conf,

--- a/fabric_cf/actor/core/core/actor.py
+++ b/fabric_cf/actor/core/core/actor.py
@@ -917,10 +917,13 @@ class ActorMixin(ABCActorMixin):
             for x in topics:
                 consumer_conf[Constants.GROUP_ID] += x
                 msg_svc = MessageService(consumer_conf=consumer_conf,
-                                         schema_registry_conf=GlobalsSingleton.get().get_kafka_config_schema_registry_client(),
-                                         value_schema_location=GlobalsSingleton.get().get_config().get_kafka_value_schema_location(),
+                                         key_schema_location=GlobalsSingleton.get().get_kafka_key_schema_location(),
+                                         #schema_registry_conf=GlobalsSingleton.get().get_kafka_config_schema_registry_client(),
+                                         value_schema_location=GlobalsSingleton.get().get_kafka_value_schema_location(),
                                          topics=[x], logger=self.logger,
-                                         consumer_thread=self.rpc_consumer)
+                                         consumer_thread=self.rpc_consumer,
+                                         batch_size=GlobalsSingleton.get().get_kafka_consumer_commit_batch_size(),
+                                         poll_timeout=GlobalsSingleton.get().get_kafka_consumer_poll_timeout())
                 self.message_service.append(msg_svc)
         except Exception as e:
             self.logger.error(traceback.format_exc())

--- a/fabric_cf/actor/core/core/actor.py
+++ b/fabric_cf/actor/core/core/actor.py
@@ -916,8 +916,11 @@ class ActorMixin(ABCActorMixin):
             consumer_conf = GlobalsSingleton.get().get_kafka_config_consumer()
             if self.message_service is None:
                 self.message_service = []
+            cnt = 0
             for x in topics:
-                consumer_conf[Constants.GROUP_ID] += x
+                if cnt:
+                    consumer_conf[Constants.GROUP_ID] += x
+                cnt += 1
                 msg_svc = MessageService(consumer_conf=consumer_conf,
                                          key_schema_location=GlobalsSingleton.get().get_kafka_key_schema_location(),
                                          #schema_registry_conf=GlobalsSingleton.get().get_kafka_config_schema_registry_client(),

--- a/fabric_cf/actor/core/manage/kafka/services/kafka_service.py
+++ b/fabric_cf/actor/core/manage/kafka/services/kafka_service.py
@@ -39,7 +39,7 @@ class KafkaService:
     def set_logger(self, *, logger):
         self.logger = logger
         if self.producer is not None:
-            self.producer.set_logger(logger=logger)
+            self.producer.logger=logger
 
     def update_status(self, *, incoming: ResultAvro, outgoing: ResultAvro):
         outgoing.set_code(incoming.get_code())

--- a/fabric_cf/actor/core/policy/broker_simpler_units_policy.py
+++ b/fabric_cf/actor/core/policy/broker_simpler_units_policy.py
@@ -535,7 +535,7 @@ class BrokerSimplerUnitsPolicy(BrokerCalendarPolicy):
 
         return node_id_list
 
-    def __find_first_fit(self, node_id_list: List[str], node_id_to_reservations: dict, inv: InventoryForType,
+    def __find_first_fit(self, node_id_list: List[str], node_id_to_reservations: dict, inv: NetworkNodeInventory,
                          reservation: ABCBrokerReservation) -> Tuple[str, BaseSliver, Any]:
         """
         Find First Available Node which can serve the reservation
@@ -550,6 +550,7 @@ class BrokerSimplerUnitsPolicy(BrokerCalendarPolicy):
         error_msg = None
         self.logger.debug(f"Possible candidates to serve {reservation} candidates# {node_id_list}")
         requested_sliver = reservation.get_requested_resources().get_sliver()
+        is_create = requested_sliver.get_node_map() is None
         for node_id in node_id_list:
             try:
                 self.logger.debug(f"Attempting to allocate {reservation} via graph_node# {node_id}")
@@ -568,7 +569,9 @@ class BrokerSimplerUnitsPolicy(BrokerCalendarPolicy):
                 delegation_id, sliver = inv.allocate(rid=reservation.get_reservation_id(),
                                                      requested_sliver=requested_sliver,
                                                      graph_id=self.combined_broker_model_graph_id,
-                                                     graph_node=graph_node, existing_reservations=existing_reservations)
+                                                     graph_node=graph_node,
+                                                     existing_reservations=existing_reservations,
+                                                     is_create=is_create)
 
                 if delegation_id is not None and sliver is not None:
                     break

--- a/fabric_cf/actor/core/policy/network_node_inventory.py
+++ b/fabric_cf/actor/core/policy/network_node_inventory.py
@@ -407,7 +407,7 @@ class NetworkNodeInventory(InventoryForType):
 
         self.logger.debug(f"requested_components: {requested_components.devices.values()} for reservation# {rid}")
         for name, requested_component in requested_components.devices.items():
-            if not is_create:
+            if not is_create and requested_component.get_node_map() is not None:
                 self.logger.debug(f"==========Ignoring Allocated component: {requested_component} for modify")
                 # TODO exclude already allocated component to the same reservation
                 continue
@@ -476,6 +476,7 @@ class NetworkNodeInventory(InventoryForType):
                                   msg=f"resource type: {graph_node.get_type()}")
 
         delegation_id = None
+        requested_capacities = None
         # For create, we need to allocate the VM
         if is_create:
             # Always use requested capacities to be mapped from flavor i.e. capacity hints

--- a/fabric_cf/actor/core/policy/network_node_inventory.py
+++ b/fabric_cf/actor/core/policy/network_node_inventory.py
@@ -229,12 +229,14 @@ class NetworkNodeInventory(InventoryForType):
         return requested_component
 
     def __check_component_labels_and_capacities(self, *, available_component: ComponentSliver, graph_id: str,
-                                                requested_component: ComponentSliver) -> ComponentSliver:
+                                                requested_component: ComponentSliver,
+                                                is_create: bool = False) -> ComponentSliver:
         """
         Check if available component capacities, labels to match requested component
         :param available_component: available component
         :param graph_id: BQM graph id
         :param requested_component: requested component
+        :param is_create: is_create
         :return: requested component annotated with properties in case of success, None otherwise
         """
         if requested_component.get_model() is not None and \
@@ -269,7 +271,7 @@ class NetworkNodeInventory(InventoryForType):
 
         node_map = tuple([graph_id, available_component.node_id])
         requested_component.set_node_map(node_map=node_map)
-        if requested_component.labels is None:
+        if requested_component.labels is None or is_create:
             requested_component.labels = Labels.update(lab=requested_component.get_label_allocations())
 
         return requested_component
@@ -428,7 +430,9 @@ class NetworkNodeInventory(InventoryForType):
             for component in available_components:
                 # check model matches the requested model
                 requested_component = self.__check_component_labels_and_capacities(
-                    available_component=component, graph_id=graph_id, requested_component=requested_component)
+                    available_component=component, graph_id=graph_id,
+                    requested_component=requested_component,
+                    is_create=is_create)
 
                 if requested_component.get_node_map() is not None:
                     self.logger.info(f"Assigning {component.node_id} to component# "

--- a/fabric_cf/actor/fim/plugins/broker/aggregate_bqm_plugin.py
+++ b/fabric_cf/actor/fim/plugins/broker/aggregate_bqm_plugin.py
@@ -118,6 +118,9 @@ class AggregatedBQMPlugin:
 
                     if allocated_sliver.attached_components_info is not None:
                         for allocated_component in allocated_sliver.attached_components_info.devices.values():
+                            # Ignore components without any allocations
+                            if not allocated_component.capacity_allocations:
+                                continue
                             rt = allocated_component.resource_type
                             rm = allocated_component.resource_model
                             if occupied_component_capacities[rt].get(rm) is None:

--- a/fabric_cf/authority/config.al2s.am.yaml
+++ b/fabric_cf/authority/config.al2s.am.yaml
@@ -48,7 +48,7 @@ runtime:
   rpc.retries: 5
   commit.batch.size: 10
   enable.auto.commit: False
-  consumer.poll.timeout: 0.25
+  consumer.poll.timeout: 250
 
 logging:
   ## The directory in which actor should create log files.

--- a/fabric_cf/authority/config.al2s.am.yaml
+++ b/fabric_cf/authority/config.al2s.am.yaml
@@ -46,7 +46,7 @@ runtime:
   kafka.request.timeout.ms: 120000
   rpc.request.timeout.seconds: 900
   rpc.retries: 5
-  commit.batch.size: 10
+  commit.batch.size: 1
   enable.auto.commit: False
   consumer.poll.timeout: 250
 

--- a/fabric_cf/authority/config.al2s.am.yaml
+++ b/fabric_cf/authority/config.al2s.am.yaml
@@ -46,6 +46,9 @@ runtime:
   kafka.request.timeout.ms: 120000
   rpc.request.timeout.seconds: 900
   rpc.retries: 5
+  commit.batch.size: 10
+  enable.auto.commit: False
+  consumer.poll.timeout: 0.25
 
 logging:
   ## The directory in which actor should create log files.

--- a/fabric_cf/authority/config.net.am.yaml
+++ b/fabric_cf/authority/config.net.am.yaml
@@ -48,7 +48,7 @@ runtime:
   rpc.retries: 5
   commit.batch.size: 10
   enable.auto.commit: False
-  consumer.poll.timeout: 0.25
+  consumer.poll.timeout: 250
 
 logging:
   ## The directory in which actor should create log files.

--- a/fabric_cf/authority/config.net.am.yaml
+++ b/fabric_cf/authority/config.net.am.yaml
@@ -46,7 +46,7 @@ runtime:
   kafka.request.timeout.ms: 120000
   rpc.request.timeout.seconds: 900
   rpc.retries: 5
-  commit.batch.size: 10
+  commit.batch.size: 1
   enable.auto.commit: False
   consumer.poll.timeout: 250
 

--- a/fabric_cf/authority/config.net.am.yaml
+++ b/fabric_cf/authority/config.net.am.yaml
@@ -46,6 +46,9 @@ runtime:
   kafka.request.timeout.ms: 120000
   rpc.request.timeout.seconds: 900
   rpc.retries: 5
+  commit.batch.size: 10
+  enable.auto.commit: False
+  consumer.poll.timeout: 0.25
 
 logging:
   ## The directory in which actor should create log files.

--- a/fabric_cf/authority/config.site.am.geni.yaml
+++ b/fabric_cf/authority/config.site.am.geni.yaml
@@ -50,7 +50,7 @@ runtime:
   rpc.retries: 5
   commit.batch.size: 10
   enable.auto.commit: False
-  consumer.poll.timeout: 0.25
+  consumer.poll.timeout: 250
 
 logging:
   ## The directory in which actor should create log files.

--- a/fabric_cf/authority/config.site.am.geni.yaml
+++ b/fabric_cf/authority/config.site.am.geni.yaml
@@ -48,6 +48,9 @@ runtime:
   rpc.request.timeout.seconds: 1200
   message.max.bytes: 2097176
   rpc.retries: 5
+  commit.batch.size: 10
+  enable.auto.commit: False
+  consumer.poll.timeout: 0.25
 
 logging:
   ## The directory in which actor should create log files.

--- a/fabric_cf/authority/config.site.am.geni.yaml
+++ b/fabric_cf/authority/config.site.am.geni.yaml
@@ -48,7 +48,7 @@ runtime:
   rpc.request.timeout.seconds: 1200
   message.max.bytes: 2097176
   rpc.retries: 5
-  commit.batch.size: 10
+  commit.batch.size: 1
   enable.auto.commit: False
   consumer.poll.timeout: 250
 

--- a/fabric_cf/authority/config.site.am.yaml
+++ b/fabric_cf/authority/config.site.am.yaml
@@ -48,6 +48,9 @@ runtime:
   rpc.request.timeout.seconds: 1200
   message.max.bytes: 1048588
   rpc.retries: 5
+  commit.batch.size: 10
+  enable.auto.commit: False
+  consumer.poll.timeout: 0.25
 
 logging:
   ## The directory in which actor should create log files.

--- a/fabric_cf/authority/config.site.am.yaml
+++ b/fabric_cf/authority/config.site.am.yaml
@@ -50,7 +50,7 @@ runtime:
   rpc.retries: 5
   commit.batch.size: 10
   enable.auto.commit: False
-  consumer.poll.timeout: 0.25
+  consumer.poll.timeout: 250
 
 logging:
   ## The directory in which actor should create log files.

--- a/fabric_cf/authority/config.site.am.yaml
+++ b/fabric_cf/authority/config.site.am.yaml
@@ -48,7 +48,7 @@ runtime:
   rpc.request.timeout.seconds: 1200
   message.max.bytes: 1048588
   rpc.retries: 5
-  commit.batch.size: 10
+  commit.batch.size: 1
   enable.auto.commit: False
   consumer.poll.timeout: 250
 

--- a/fabric_cf/broker/config.broker.yaml
+++ b/fabric_cf/broker/config.broker.yaml
@@ -48,6 +48,9 @@ runtime:
   rpc.request.timeout.seconds: 1200
   message.max.bytes: 1048588
   rpc.retries: 5
+  commit.batch.size: 10
+  enable.auto.commit: False
+  consumer.poll.timeout: 0.25
 
 logging:
   ## The directory in which actor should create log files.

--- a/fabric_cf/broker/config.broker.yaml
+++ b/fabric_cf/broker/config.broker.yaml
@@ -50,7 +50,7 @@ runtime:
   rpc.retries: 5
   commit.batch.size: 10
   enable.auto.commit: False
-  consumer.poll.timeout: 0.25
+  consumer.poll.timeout: 250
 
 logging:
   ## The directory in which actor should create log files.

--- a/fabric_cf/broker/config.broker.yaml
+++ b/fabric_cf/broker/config.broker.yaml
@@ -48,7 +48,7 @@ runtime:
   rpc.request.timeout.seconds: 1200
   message.max.bytes: 1048588
   rpc.retries: 5
-  commit.batch.size: 10
+  commit.batch.size: 1
   enable.auto.commit: False
   consumer.poll.timeout: 250
 

--- a/fabric_cf/orchestrator/config.orchestrator.yaml
+++ b/fabric_cf/orchestrator/config.orchestrator.yaml
@@ -50,7 +50,7 @@ runtime:
   maint.project.id: 990d8a8b-7e50-4d13-a3be-0f133ffa8653
   message.max.bytes: 1048588
   rpc.retries: 5
-  commit.batch.size: 10
+  commit.batch.size: 1
   enable.auto.commit: False
   consumer.poll.timeout: 250
 

--- a/fabric_cf/orchestrator/config.orchestrator.yaml
+++ b/fabric_cf/orchestrator/config.orchestrator.yaml
@@ -50,6 +50,9 @@ runtime:
   maint.project.id: 990d8a8b-7e50-4d13-a3be-0f133ffa8653
   message.max.bytes: 1048588
   rpc.retries: 5
+  commit.batch.size: 10
+  enable.auto.commit: False
+  consumer.poll.timeout: 0.25
 
 logging:
   ## The directory in which actor should create log files.

--- a/fabric_cf/orchestrator/config.orchestrator.yaml
+++ b/fabric_cf/orchestrator/config.orchestrator.yaml
@@ -52,7 +52,7 @@ runtime:
   rpc.retries: 5
   commit.batch.size: 10
   enable.auto.commit: False
-  consumer.poll.timeout: 0.25
+  consumer.poll.timeout: 250
 
 logging:
   ## The directory in which actor should create log files.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
     "swagger-ui-bundle==0.0.9",
     "PyYAML",
     "fabric_fss_utils==1.5.0",
-    "fabric-message-bus==1.6.0",
+    "fabric-message-bus==1.6.1b0",
     "fabric-fim==1.6.1",
     "fabric-credmgr-client==1.6.0",
     "ansible"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
     "swagger-ui-bundle==0.0.9",
     "PyYAML",
     "fabric_fss_utils==1.5.0",
-    "fabric-message-bus==1.6.1rc0",
+    "fabric-message-bus==1.6.1rc1",
     #"fabric-message-bus==1.6.1b1",
     "fabric-fim==1.6.1",
     "fabric-credmgr-client==1.6.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
     "swagger-ui-bundle==0.0.9",
     "PyYAML",
     "fabric_fss_utils==1.5.0",
-    "fabric-message-bus==1.6.1rc1",
+    "fabric-message-bus==1.6.1rc2",
     #"fabric-message-bus==1.6.1b1",
     "fabric-fim==1.6.1",
     "fabric-credmgr-client==1.6.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,8 @@ dependencies = [
     "swagger-ui-bundle==0.0.9",
     "PyYAML",
     "fabric_fss_utils==1.5.0",
-    "fabric-message-bus==1.6.1b1",
+    "fabric-message-bus==1.6.1rc0",
+    #"fabric-message-bus==1.6.1b1",
     "fabric-fim==1.6.1",
     "fabric-credmgr-client==1.6.0",
     "ansible"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
     "swagger-ui-bundle==0.0.9",
     "PyYAML",
     "fabric_fss_utils==1.5.0",
-    "fabric-message-bus==1.6.1b0",
+    "fabric-message-bus==1.6.1b1",
     "fabric-fim==1.6.1",
     "fabric-credmgr-client==1.6.0",
     "ansible"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
     "swagger-ui-bundle==0.0.9",
     "PyYAML",
     "fabric_fss_utils==1.5.0",
-    "fabric-message-bus==1.6.1rc3",
+    "fabric-message-bus==1.6.1",
     #"fabric-message-bus==1.6.1b1",
     "fabric-fim==1.6.1",
     "fabric-credmgr-client==1.6.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
     "swagger-ui-bundle==0.0.9",
     "PyYAML",
     "fabric_fss_utils==1.5.0",
-    "fabric-message-bus==1.6.1rc2",
+    "fabric-message-bus==1.6.1rc3",
     #"fabric-message-bus==1.6.1b1",
     "fabric-fim==1.6.1",
     "fabric-credmgr-client==1.6.0",


### PR DESCRIPTION
**Observation**: Several slices are reported to have one or more slivers reported as Closed with error "Redeem/Ticket timeout"
Investigating the Kafka topics and CF logs, noticed that the message for such slivers was not received on the Site AMs and processed resulting in a timeout on Orchestrator.

**Addition Problems Observed**:
- Observation: Kafka brokers are accessible via IPv4 and IPv6, lot of sites complain about connection failures on either of those
-  Fix: Added explicit entries to `/etc/hosts` to point to IPv4 or IPv6 depending on Site's capability cleared this failures
- This did not resolve the Redeem/Ticket timeouts

**Real Root Cause**:
- Kafka Consumer thread was setup to use default configuration for offset commits i.e. auto commit with default auto commit interval set to 5 seconds. With this setting, every 5 seconds, the latest offset is commited.
- Kafka Consumer thread was doing two things and took upto 3-5 seconds on the worst case:
   - Reading the message
   - Reconstructing it and also processing
- Due to the above two things, offsets being committed before they could be processed by the consumer thread resulted in missed messages at Sites and timeouts on orchestrator.

**Solution**:
- Added RPCConsumer thread responsible for processing the incoming messages
- Refactored the consumer thread to just pick up the message and add to RPCConsumer thread's queue
- Disabled auto commits and modified the consumer thread to commit the offset after the message has been read and added to RPCConsumer queue. This ensures that no message from Kafka broker is missed.

Tested on dev with a loop of a slice based on the notebook shared by a user: https://learn.fabric-testbed.net/forums/topic/error-in-creating-a-cluster-with-multiple-nodes/