### PR TITLE
Audit and cleanup consistencies

### DIFF
--- a/tools/audit.py
+++ b/tools/audit.py
@@ -308,7 +308,6 @@ class MainClass:
                         # Extract UUID if found
                         if match:
                             sliver_id = match.group(1)
-                            print("Sliver Id:", sliver_id)
                             if sliver_id not in cf_active_sliver_ids:
                                 result_2 = self.execute_ansible(inventory_path=inventory_location,
                                                                 playbook_path=vm_playbook_path,
@@ -316,7 +315,7 @@ class MainClass:
                                                                 ansible_python_interpreter=ansible_python_interpreter)
                                 self.logger.info(f"Deleted instance: {vm_name}; result: {result_2.get_json_result_ok()}")
                         else:
-                            print("Sliver Id not found in the input string.")
+                            self.logger.error(f"Sliver Id not found in the input string: {vm_name}")
                     except Exception as e:
                         self.logger.error(f"Failed to cleanup CF and openstack inconsistencies instance: {instance} vm: {vm_name}: {e}")
                         self.logger.error(traceback.format_exc())

--- a/tools/audit.py
+++ b/tools/audit.py
@@ -269,8 +269,11 @@ class MainClass:
                                      db_host=self.database_config[Constants.PROPERTY_CONF_DB_HOST],
                                      logger=self.logger)
 
-            states = [ReservationStates.Active.value, ReservationStates.ActiveTicketed.value,
-                      ReservationStates.Failed.value]
+            states = [ReservationStates.Active.value,
+                      ReservationStates.ActiveTicketed.value,
+                      ReservationStates.Ticketed.value,
+                      ReservationStates.Nascent.value]
+            
             resource_type = ["VM"]
 
             # Get the Active Slivers from CF

--- a/tools/audit.py
+++ b/tools/audit.py
@@ -252,7 +252,7 @@ class MainClass:
                 return
             inventory_location = pb_section.get(AmConstants.PB_INVENTORY)
             pb_dir = pb_section.get(AmConstants.PB_LOCATION)
-            vm_playbook_name = pb_section.get(AmConstants.CLEAN_ALL)
+            vm_playbook_name = pb_section.get("VM")
             if inventory_location is None or pb_dir is None or vm_playbook_name is None:
                 return
 
@@ -281,10 +281,11 @@ class MainClass:
                     cf_active_sliver_ids.append(s.get_reservation_id())
 
             # Get the VMs from Openstack
-            result_1 = self.execute_ansible(inventory_path=inventory_location,
-                                            playbook_path=vm_playbook_path,
-                                            extra_vars={"operation": "list"},
-                                            ansible_python_interpreter=ansible_python_interpreter)
+            result_callback_1 = self.execute_ansible(inventory_path=inventory_location,
+                                                     playbook_path=vm_playbook_path,
+                                                     extra_vars={"operation": "list"},
+                                                     ansible_python_interpreter=ansible_python_interpreter)
+            result_1 = result_callback_1.get_json_result_ok()
 
             os_vms = {}
             if result_1 and result_1.get('openstack_servers'):
@@ -310,7 +311,7 @@ class MainClass:
                                                             playbook_path=vm_playbook_path,
                                                             extra_vars={"operation": "delete", "vmname": vm_name},
                                                             ansible_python_interpreter=ansible_python_interpreter)
-                            self.logger.info(f"Deleted instance: {vm_name}; result: {result_2}")
+                            self.logger.info(f"Deleted instance: {vm_name}; result: {result_2.get_json_result_ok()}")
                     else:
                         print("Sliver Id not found in the input string.")
                 except Exception as e:
@@ -334,7 +335,7 @@ class MainClass:
                                                                  playbook_path=vm_playbook_path,
                                                                  extra_vars={"operation": "delete", "host": str(host)},
                                                                  ansible_python_interpreter=ansible_python_interpreter)
-                                self.logger.info(f"Deleted instance: {instance}; result: {results_4}")
+                                self.logger.info(f"Deleted instance: {instance}; result: {results_4.get_json_result_ok()}")
                 except Exception as e:
                     self.logger.error(f"Failed to cleanup openstack and virsh inconsistencies on {host}: {e}")
                     self.logger.error(traceback.format_exc())

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/sh
 
-echo "0 2 * * * root /usr/local/bin/python3.11 /usr/src/app/audit.py -f /etc/fabric/actor/config/config.yaml -d 30 -c slices -o remove" >> /etc/crontab
+echo "0 2 * * * root /usr/local/bin/python3.11 /usr/src/app/audit.py -f /etc/fabric/actor/config/config.yaml -a  /etc/fabric/actor/config/vm_handler_config.yml -d 30 -c audit -o audit" >> /etc/crontab
+#echo "0 2 * * * root /usr/local/bin/python3.11 /usr/src/app/audit.py -f /etc/fabric/actor/config/config.yaml -d 30 -c slices -o remove" >> /etc/crontab
 #echo "*/15 * * * * root /usr/local/bin/python3.11 /usr/src/app/audit.py -f /etc/fabric/actor/config/config.yaml -c slivers -o close" >> /etc/crontab
 service cron reload
 service cron restart

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/sh
 
-echo "0 2 * * * root /usr/local/bin/python3.11 /usr/src/app/audit.py -f /etc/fabric/actor/config/config.yaml -a  /etc/fabric/actor/config/vm_handler_config.yml -d 30 -c audit -o audit" >> /etc/crontab
+echo "0 * * * * root /usr/local/bin/python3.11 /usr/src/app/audit.py -f /etc/fabric/actor/config/config.yaml -a  /etc/fabric/actor/config/vm_handler_config.yml -d 30 -c audit -o audit" >> /etc/crontab
 #echo "0 2 * * * root /usr/local/bin/python3.11 /usr/src/app/audit.py -f /etc/fabric/actor/config/config.yaml -d 30 -c slices -o remove" >> /etc/crontab
 #echo "*/15 * * * * root /usr/local/bin/python3.11 /usr/src/app/audit.py -f /etc/fabric/actor/config/config.yaml -c slivers -o close" >> /etc/crontab
 service cron reload


### PR DESCRIPTION
Update audit script:
- Run every hour and do the following
  - Identify inconsistencies between CF and Openstack and cleanup leaked slivers
  - Identify inconsistencies between Openstack and libvirt and cleanup orphaned instances