### PR TITLE
Slice expiry reminder emails and redirect nginx logs to files for file beats

### DIFF
--- a/fabric_cf/actor/boot/configuration.py
+++ b/fabric_cf/actor/boot/configuration.py
@@ -45,6 +45,10 @@ class GlobalConfig:
         if Constants.CONFIG_SECTION_O_AUTH in config:
             self.oauth = config.get(Constants.CONFIG_SECTION_O_AUTH)
 
+        self.smtp = {}
+        if Constants.CONFIG_SECTION_SMTP in config:
+            self.smtp = config.get(Constants.CONFIG_SECTION_SMTP)
+
         self.database = {}
         if Constants.CONFIG_SECTION_DATABASE in config:
             self.database = config.get(Constants.CONFIG_SECTION_DATABASE)
@@ -86,6 +90,12 @@ class GlobalConfig:
         Return oauth config
         """
         return self.oauth
+
+    def get_smtp(self) -> dict:
+        """
+        Return smtp config
+        """
+        return self.smtp
 
     def get_database(self) -> dict:
         """
@@ -424,6 +434,10 @@ class Configuration:
         if self.global_config is not None:
             return self.global_config.get_oauth()
         return None
+
+    def get_smtp_config(self) -> dict:
+        if self.global_config:
+            return self.global_config.get_smtp()
 
     def get_actor_config(self) -> ActorConfig:
         """

--- a/fabric_cf/actor/core/common/constants.py
+++ b/fabric_cf/actor/core/common/constants.py
@@ -173,6 +173,8 @@ class Constants:
     PROPERTY_CONF_O_AUTH_TRL_REFRESH = "trl-refresh"
     PROPERTY_CONF_O_AUTH_VERIFY_EXP = "verify-exp"
 
+    CONFIG_SECTION_SMTP = "smtp"
+
     CONFIG_SECTION_DATABASE = "database"
     PROPERTY_CONF_DB_USER = "db-user"
     PROPERTY_CONF_DB_PASSWORD = "db-password"

--- a/fabric_cf/actor/core/core/controller.py
+++ b/fabric_cf/actor/core/core/controller.py
@@ -87,6 +87,9 @@ class Controller(ActorMixin, ABCController):
                                                                  thread_name_prefix=self.__class__.__name__)
         self.pluggable_registry = PluggableRegistry()
 
+        self.combined_broker_model = None
+        self.combined_broker_model_graph_id = None
+
     def __getstate__(self):
         state = self.__dict__.copy()
         del state['recovered']
@@ -112,6 +115,8 @@ class Controller(ActorMixin, ABCController):
         del state['thread_pool']
         if hasattr(self, 'pluggable_registry'):
             del state['pluggable_registry']
+
+        del state['combined_broker_model']
 
         return state
 

--- a/fabric_cf/actor/core/kernel/slice_state_machine.py
+++ b/fabric_cf/actor/core/kernel/slice_state_machine.py
@@ -323,7 +323,7 @@ class SliceStateMachine:
                                                  ReservationStates.Failed, ReservationStates.CloseFail):
                     self.state = SliceState.Closing
 
-            if self.state in [SliceState.AllocatedOK, SliceState.AllocatedError]:
+            elif self.state in [SliceState.AllocatedOK, SliceState.AllocatedError]:
                 if not bins.has_state_other_than(ReservationStates.Active, ReservationStates.Closed,
                                                  ReservationStates.CloseFail):
                     if not has_error:

--- a/fabric_cf/actor/core/util/smtp.py
+++ b/fabric_cf/actor/core/util/smtp.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+# MIT License
+#
+# Copyright (c) 2024 FABRIC Testbed
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+#
+# Author: Komal Thareja (kthare10@renci.org)
+import smtplib
+from email.mime.multipart import MIMEMultipart
+from email.mime.text import MIMEText
+
+
+def send_email(*, smtp_config: dict, to_email: str, subject: str, body: str):
+    """
+    Send Email to a user
+    :param smtp_config: SMTP config parameters
+    :param to_email:    User's email
+    :param subject:     Email subject
+    :param body         Email body
+
+    :@raise Exception in case of error
+    """
+    # Create the message container
+    msg = MIMEMultipart()
+    msg['From'] = smtp_config.get("from_email")
+    msg['To'] = to_email
+    msg['Subject'] = subject
+    msg.add_header('Reply-To', smtp_config.get("reply_to_email"))
+
+    # Attach the message body
+    msg.attach(MIMEText(body, 'plain'))
+
+    try:
+        # Establish an SMTP connection and send the email
+        server = smtplib.SMTP(smtp_config.get("smtp_server"), smtp_config.get("smtp_port"))
+        server.starttls()  # Upgrade to TLS
+        server.login(smtp_config.get("smtp_user"), smtp_config.get("smtp_password"))
+        server.sendmail(smtp_config.get("from_email"), to_email, msg.as_string())
+        # print(f"Email successfully sent to {to_email}")
+    finally:
+        server.quit()

--- a/fabric_cf/actor/core/util/smtp.py
+++ b/fabric_cf/actor/core/util/smtp.py
@@ -28,6 +28,34 @@ from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
 
 
+# Function to load the email template from a file and replace placeholders
+from typing import Tuple
+
+
+def load_and_update_template(*, template_path: str, user: str, slice_name: str, hours_left: float) -> Tuple[str, str]:
+    """
+    Load the Email body from the template
+    @param template_path: location of the template
+    @param user: user name
+    @param slice_name: slice name
+    @param hours_left: hours left
+    @return: Subject and Body
+    """
+    with open(template_path, 'r') as template_file:
+        email_template = template_file.read()
+
+    # Replace placeholders with actual values
+    email_content = email_template.replace('<User>', user) \
+        .replace('<slice_name>', slice_name) \
+        .replace('<hours_left>', str(hours_left))
+
+    # Extract the subject and the body from the email content
+    subject_line = email_content.split('\n')[0].replace("Subject: ", "")
+    email_body = "\n".join(email_content.split('\n')[1:])
+
+    return subject_line, email_body
+
+
 def send_email(*, smtp_config: dict, to_email: str, subject: str, body: str):
     """
     Send Email to a user

--- a/fabric_cf/actor/fim/asm_update_thread.py
+++ b/fabric_cf/actor/fim/asm_update_thread.py
@@ -43,14 +43,17 @@ class AsmUpdateException(Exception):
 
 class AsmEvent:
     def __init__(self, *, graph_id: str, sliver: BaseSliver, reservation_id: str,
-                 state: str, error_message: str):
+                 state: str, error_message: str, logger: logging.Logger = None):
         self.graph_id = graph_id
         self.sliver = sliver
         self.reservation_id = reservation_id
         self.state = state
         self.error_message = error_message
+        self.logger = logger
 
     def process(self):
+        if self.logger:
+            self.logger.info(f"AsmEvent for Res# {self.reservation_id} State: {self.state} Graph: {self.graph_id}")
         FimHelper.update_node(graph_id=self.graph_id, sliver=self.sliver, reservation_id=self.reservation_id,
                               state=self.state, error_message=self.error_message)
 
@@ -124,7 +127,7 @@ class AsmUpdateThread:
                 error_message: str):
         try:
             event = AsmEvent(graph_id=graph_id, sliver=sliver, reservation_id=rid,
-                             state=reservation_state, error_message=error_message)
+                             state=reservation_state, error_message=error_message, logger=self.logger)
             self.event_queue.put_nowait(event)
             with self.condition:
                 self.condition.notify_all()

--- a/fabric_cf/actor/fim/asm_update_thread.py
+++ b/fabric_cf/actor/fim/asm_update_thread.py
@@ -53,7 +53,7 @@ class AsmEvent:
 
     def process(self):
         if self.logger:
-            self.logger.info(f"AsmEvent for Res# {self.reservation_id} State: {self.state} Graph: {self.graph_id}")
+            self.logger.debug(f"AsmEvent for Res# {self.reservation_id} State: {self.state} Graph: {self.graph_id}")
         FimHelper.update_node(graph_id=self.graph_id, sliver=self.sliver, reservation_id=self.reservation_id,
                               state=self.state, error_message=self.error_message)
 

--- a/fabric_cf/actor/fim/fim_helper.py
+++ b/fabric_cf/actor/fim/fim_helper.py
@@ -316,8 +316,8 @@ class FimHelper:
         return delegation.get_details() if delegation is not None else None
 
     @staticmethod
-    def update_node(*, graph_id: str, sliver: BaseSliver, reservation_id: str,
-                 state: str, error_message: str):
+    def update_node(*, sliver: BaseSliver, reservation_id: str, state: str, error_message: str, graph_id: str = None,
+                    asm_graph: ABCASMPropertyGraph = None):
         """
         Update Sliver Node in ASM
         :param graph_id:
@@ -325,12 +325,17 @@ class FimHelper:
         :param reservation_id:
         :param state:
         :param error_message:
+        :param asm_graph:
         :return:
         """
         if sliver is None:
             return
-        graph = FimHelper.get_graph(graph_id=graph_id)
-        asm_graph = Neo4jASMFactory.create(graph=graph)
+        if graph_id is None and asm_graph is None:
+            return
+        if graph_id:
+            graph = FimHelper.get_graph(graph_id=graph_id)
+            asm_graph = Neo4jASMFactory.create(graph=graph)
+
         neo4j_topo = ExperimentTopology()
         neo4j_topo.cast(asm_graph=asm_graph)
 

--- a/fabric_cf/orchestrator/config.orchestrator.yaml
+++ b/fabric_cf/orchestrator/config.orchestrator.yaml
@@ -91,9 +91,9 @@ smtp:
   smtp_port: 587
   smtp_user: fabric_cf@fabric-testbed.net
   smtp_password:
-  from_email: fabric_cf
+  from_email: fabric_cf@fabric-testbed.net
   reply_to_email: no-reply@fabric-testbed.net
-  template_path: ./slice_expiration_template.txt
+  template_path: /etc/fabric/actor/config/slice_expiration_template.txt
 
 database:
   db-user: fabric

--- a/fabric_cf/orchestrator/config.orchestrator.yaml
+++ b/fabric_cf/orchestrator/config.orchestrator.yaml
@@ -93,6 +93,7 @@ smtp:
   smtp_password:
   from_email: fabric_cf
   reply_to_email: no-reply@fabric-testbed.net
+  template_path: ./slice_expiration_template.txt
 
 database:
   db-user: fabric

--- a/fabric_cf/orchestrator/config.orchestrator.yaml
+++ b/fabric_cf/orchestrator/config.orchestrator.yaml
@@ -86,6 +86,14 @@ oauth:
   key-refresh: 00:10:00
   verify-exp: True
 
+smtp:
+  smtp_server: mail.fabric-testbed.net
+  smtp_port: 587
+  smtp_user: fabric_cf@fabric-testbed.net
+  smtp_password:
+  from_email: fabric_cf
+  reply_to_email: no-reply@fabric-testbed.net
+
 database:
   db-user: fabric
   db-password: fabric

--- a/fabric_cf/orchestrator/core/orchestrator_handler.py
+++ b/fabric_cf/orchestrator/core/orchestrator_handler.py
@@ -134,6 +134,7 @@ class OrchestratorHandler:
         :param end: end time
         :param includes: comma separated lists of sites to include
         :param excludes: comma separated lists of sites to exclude
+        :param email: Email of the user on whose behalf the request is initiated
         :return str or None
         """
         broker_query_model = None

--- a/fabric_cf/orchestrator/core/orchestrator_handler.py
+++ b/fabric_cf/orchestrator/core/orchestrator_handler.py
@@ -515,7 +515,7 @@ class OrchestratorHandler:
             # Slice has sliver modifications - add/remove/update for slivers requiring AM updates
             graph_id = slice_obj.get_graph_id()
             modify_state = slice_object.has_sliver_updates_at_authority()
-            if modify_state and slice_object.has_topology_diffs(topology_diff=topology_diff):
+            if modify_state or slice_object.has_topology_diffs(topology_diff=topology_diff):
                 FimHelper.delete_graph(graph_id=slice_obj.get_graph_id())
                 graph_id = asm_graph.get_graph_id()
             else:

--- a/fabric_cf/orchestrator/core/orchestrator_handler.py
+++ b/fabric_cf/orchestrator/core/orchestrator_handler.py
@@ -503,7 +503,7 @@ class OrchestratorHandler:
                                                     slice_obj=slice_obj, logger=self.logger)
 
             # Compute the reservations
-            computed_reservations = slice_object.modify(new_slice_graph=asm_graph)
+            topology_diff, computed_reservations = slice_object.modify(new_slice_graph=asm_graph)
             slice_object.update_topology(topology=topology)
 
             # Check if Test Bed or site is in maintenance
@@ -512,12 +512,17 @@ class OrchestratorHandler:
             # Add any new reservations to the database
             slice_object.add_reservations()
 
-            FimHelper.delete_graph(graph_id=slice_obj.get_graph_id())
-
             # Slice has sliver modifications - add/remove/update for slivers requiring AM updates
+            graph_id = slice_obj.get_graph_id()
             modify_state = slice_object.has_sliver_updates_at_authority()
+            if modify_state and slice_object.has_topology_diffs(topology_diff=topology_diff):
+                FimHelper.delete_graph(graph_id=slice_obj.get_graph_id())
+                graph_id = asm_graph.get_graph_id()
+            else:
+                if asm_graph:
+                    asm_graph.delete_graph()
 
-            slice_obj.graph_id = asm_graph.get_graph_id()
+            slice_obj.graph_id = graph_id
             config_props = slice_obj.get_config_properties()
             config_props[Constants.PROJECT_ID] = project
             config_props[Constants.TAGS] = ','.join(tags)

--- a/fabric_cf/orchestrator/core/orchestrator_handler.py
+++ b/fabric_cf/orchestrator/core/orchestrator_handler.py
@@ -513,14 +513,9 @@ class OrchestratorHandler:
             slice_object.add_reservations()
 
             # Slice has sliver modifications - add/remove/update for slivers requiring AM updates
-            graph_id = slice_obj.get_graph_id()
             modify_state = slice_object.has_sliver_updates_at_authority()
-            if modify_state or slice_object.has_topology_diffs(topology_diff=topology_diff):
-                FimHelper.delete_graph(graph_id=slice_obj.get_graph_id())
-                graph_id = asm_graph.get_graph_id()
-            else:
-                if asm_graph:
-                    asm_graph.delete_graph()
+            FimHelper.delete_graph(graph_id=slice_obj.get_graph_id())
+            graph_id = asm_graph.get_graph_id()
 
             slice_obj.graph_id = graph_id
             config_props = slice_obj.get_config_properties()

--- a/fabric_cf/orchestrator/core/orchestrator_slice_wrapper.py
+++ b/fabric_cf/orchestrator/core/orchestrator_slice_wrapper.py
@@ -41,7 +41,7 @@ from fim.slivers.capacities_labels import CapacityHints, Labels
 from fim.slivers.instance_catalog import InstanceCatalog
 from fim.slivers.network_node import NodeSliver, NodeType
 from fim.slivers.network_service import NetworkServiceSliver
-from fim.slivers.topology_diff import WhatsModifiedFlag
+from fim.slivers.topology_diff import WhatsModifiedFlag, TopologyDiff
 from fim.user import ServiceType, ExperimentTopology, InterfaceType
 
 from fabric_cf.actor.core.common.constants import ErrorCodes, Constants
@@ -460,7 +460,7 @@ class OrchestratorSliceWrapper:
             sliver_to_res_mapping[nn_id] = reservation.get_reservation_id()
         return reservations, sliver_to_res_mapping
 
-    def modify(self, *, new_slice_graph: ABCASMPropertyGraph) -> List[LeaseReservationAvro]:
+    def modify(self, *, new_slice_graph: ABCASMPropertyGraph) -> Tuple[TopologyDiff, List[LeaseReservationAvro]]:
         """
         Modify an existing slice
         :param new_slice_graph New Slice Graph
@@ -478,8 +478,8 @@ class OrchestratorSliceWrapper:
         ns_peered_reservations = []
         ns_mapping = {}
 
-        if topology_diff is None:
-            return reservations
+        if not topology_diff:
+            return topology_diff, reservations
 
         node_res_mapping = {}
 
@@ -624,7 +624,7 @@ class OrchestratorSliceWrapper:
         for x in modified_reservations:
             self.computed_reservations.append(x)
 
-        return self.computed_reservations
+        return topology_diff, self.computed_reservations
 
     def __check_modify_on_fabnetv4ext(self, *, rid: str, req_sliver: NetworkServiceSliver) -> NetworkServiceSliver:
         if req_sliver.get_type() != ServiceType.FABNetv4Ext:
@@ -704,21 +704,47 @@ class OrchestratorSliceWrapper:
 
         return req_sliver
 
-    def update_topology(self, *, topology: ExperimentTopology):
-        for x in self.computed_reservations:
-            sliver = x.get_sliver()
-            node_name = sliver.get_name()
-            if isinstance(sliver, NodeSliver) and node_name in topology.nodes:
-                node = topology.nodes[node_name]
-                node.set_properties(labels=sliver.labels,
-                                    label_allocations=sliver.label_allocations,
-                                    capacity_allocations=sliver.capacity_allocations,
-                                    reservation_info=sliver.reservation_info,
-                                    node_map=sliver.node_map,
-                                    management_ip=sliver.management_ip,
-                                    capacity_hints=sliver.capacity_hints,
-                                    capacities=sliver.capacities)
+    def update_topology(self, *, topology: ExperimentTopology = None,
+                        asm_graph: ABCASMPropertyGraph = None):
+        if topology:
+            for x in self.computed_reservations:
+                sliver = x.get_sliver()
+                node_name = sliver.get_name()
+                if isinstance(sliver, NodeSliver) and node_name in topology.nodes:
+                    node = topology.nodes[node_name]
+                    node.set_properties(labels=sliver.labels,
+                                        label_allocations=sliver.label_allocations,
+                                        capacity_allocations=sliver.capacity_allocations,
+                                        reservation_info=sliver.reservation_info,
+                                        node_map=sliver.node_map,
+                                        management_ip=sliver.management_ip,
+                                        capacity_hints=sliver.capacity_hints,
+                                        capacities=sliver.capacities)
 
     def has_sliver_updates_at_authority(self):
         return len(self.computed_reservations) or len(self.computed_remove_reservations) or \
                len(self.computed_modify_reservations) or len(self.computed_modify_properties_reservations)
+
+    def has_topology_diffs(self, *, topology_diff: TopologyDiff) -> bool:
+        """
+        Check if there any updates in topology
+        :param topology_diff: topology difference object
+        """
+        ret_val = False
+        if not topology_diff:
+            ret_val = False
+
+        if len(topology_diff.added.nodes) or len(topology_diff.added.components) or \
+                len(topology_diff.added.services) or len(topology_diff.added.interfaces):
+            ret_val = True
+
+        if len(topology_diff.removed.nodes) or len(topology_diff.removed.components) or \
+                len(topology_diff.removed.services) or len(topology_diff.removed.interfaces):
+            ret_val = True
+
+        if len(topology_diff.modified.nodes) or len(topology_diff.modified.components) or \
+                len(topology_diff.modified.services) or len(topology_diff.modified.interfaces):
+            ret_val = True
+
+        self.logger.debug(f"Topology diff found: {ret_val}")
+        return ret_val

--- a/fabric_cf/orchestrator/core/orchestrator_slice_wrapper.py
+++ b/fabric_cf/orchestrator/core/orchestrator_slice_wrapper.py
@@ -333,7 +333,7 @@ class OrchestratorSliceWrapper:
                         if sliver.labels is None:
                             sliver.labels = Labels()
                         sliver.labels = Labels.update(sliver.labels,
-                                                      local_name=f"{self.slice_obj.get_slice_name()}-{ifs.peer_labels.account_id}")
+                                                      local_name=f"{self.slice_obj.get_slice_name()}")
 
                 # Generate reservation for the sliver
                 reservation = self.reservation_converter.generate_reservation(sliver=sliver,

--- a/fabric_cf/orchestrator/docker-compose.yml
+++ b/fabric_cf/orchestrator/docker-compose.yml
@@ -84,6 +84,7 @@ services:
       - ../../../secrets/snakeoil-ca-1.crt:/etc/fabric/message_bus/ssl/cacert.pem
       - ../../../secrets/kafkacat1.client.key:/etc/fabric/message_bus/ssl/client.key
       - ../../../secrets/kafkacat1-ca1-signed.pem:/etc/fabric/message_bus/ssl/client.pem
+      - ./slice_expiration_template.txt:/etc/fabric/actor/config/slice_expiration_template.txt
       #- ./state_recovery.lock:/usr/src/app/state_recovery.lock
 networks:
   frontend:

--- a/fabric_cf/orchestrator/docker-compose.yml
+++ b/fabric_cf/orchestrator/docker-compose.yml
@@ -14,6 +14,7 @@ services:
       - ./nginx/default.conf:/etc/nginx/conf.d/default.conf
       - ./certs/fullchain.pem:/etc/ssl/public.pem
       - ./certs/privkey.pem:/etc/ssl/private.pem
+      - /opt/data/production/logs/nginx/orchestrator:/var/log/nginx
     restart: always
   neo4j:
     image: fabrictestbed/neo4j-apoc:5.3.0

--- a/fabric_cf/orchestrator/setup.sh
+++ b/fabric_cf/orchestrator/setup.sh
@@ -45,6 +45,7 @@ config=$3
 mkdir -p $name/logs $name/pg_data/data $name/pg_data/logs $name/neo4j/data $name/neo4j/imports $name/neo4j/logs $name/pdp/conf $name/pdp/policies
 echo $neo4jpwd > $name/neo4j/password
 cp fabricTags.OrchestratorTags.xml $name/pdp/policies
+cp slice_expiration_template.txt $name/
 cp env.template $name/.env
 cp $config $name/config.yaml
 cp -R nginx $name/

--- a/fabric_cf/orchestrator/slice_expiration_template.txt
+++ b/fabric_cf/orchestrator/slice_expiration_template.txt
@@ -1,4 +1,4 @@
-Subject: Urgent: Your Slice <slice_name> Will Expire Soon
+Subject: FABRIC Reminders | Urgent: Your Slice <slice_name> Will Expire Soon
 
 Dear <User>,
 

--- a/fabric_cf/orchestrator/slice_expiration_template.txt
+++ b/fabric_cf/orchestrator/slice_expiration_template.txt
@@ -1,0 +1,21 @@
+Subject: Urgent: Your Slice <slice_name> Will Expire Soon
+
+Dear <User>,
+
+We hope your experience with FABRIC has been productive.
+
+This is a reminder that your slice <slice_name> is scheduled to expire in <hours_left> hours. Once expired, the resources associated with your slice will be automatically released, which may result in the loss of any unsaved data or unfinished experiments.
+
+If you need additional time for your work, we encourage you to extend the slice before it expires. Alternatively, please ensure that you capture all necessary results from your experiments to avoid data loss.
+
+Here are a few steps you can take:
+- **Extend the Slice**: If your experiment requires more time, you can extend your slice duration from the FABRIC portal.
+- **Save Results**: If you're finished with your experiment, please download and store any critical results before the slice expires.
+
+If you have any questions or need assistance, feel free to reach out to us. We're here to support you!
+
+Thank you for using FABRIC, and we look forward to your continued success.
+
+Best regards,
+The FABRIC Team
+https://portal.fabric-testbed.net/

--- a/tools/audit.py
+++ b/tools/audit.py
@@ -248,6 +248,10 @@ class MainClass:
         return ansible_helper.get_result_callback()
 
     def clean_sliver_close_fail(self):
+        """
+        Clean the slivers in Close Fail state
+        @return:
+        """
         try:
             actor_type = self.actor_config[Constants.TYPE]
             if actor_type.lower() != ActorType.Broker.name.lower():
@@ -264,7 +268,7 @@ class MainClass:
                 term = s.get_term()
                 end = term.get_end_time() if term else None
                 now = datetime.now(timezone.utc)
-                if end and end <= now:
+                if end and end < now:
                     actor_db.remove_reservation(rid=s.get_reservation_id())
 
         except Exception as e:
@@ -272,6 +276,15 @@ class MainClass:
             self.logger.error(traceback.format_exc())
 
     def send_slice_expiry_email_warnings(self):
+        """
+        Sends warning emails to users whose slices are about to expire within 12 hours or 6 hours.
+
+        This function checks the expiration times of active slices and sends warning emails to the
+        slice owners if the slice is set to expire in less than 12 hours or 6 hours. The function is
+        intended to run periodically (e.g., once an hour) and uses a template for email content.
+
+        @return: None: This function does not return any value but sends out emails and logs the process.
+        """
         actor_type = self.actor_config[Constants.TYPE]
         if actor_type.lower() != ActorType.Orchestrator.name.lower():
             return
@@ -328,6 +341,10 @@ class MainClass:
                         self.logger.error(f"Failed to send email: Error: {e}")
 
     def clean_sliver_inconsistencies(self):
+        """
+        Clean up any sliver inconsistencies between CF, Libvirt and Openstack
+        @return:
+        """
         try:
             actor_type = self.actor_config[Constants.TYPE]
             if actor_type.lower() != ActorType.Authority.name.lower() or self.am_config_dict is None:

--- a/tools/audit.py
+++ b/tools/audit.py
@@ -308,7 +308,7 @@ class MainClass:
                 hours_left = diff.total_seconds() // 3600
 
                 # Check if it's 12 hours or 6 hours before expiration
-                if 6 < hours_left <= 12:
+                if 11 < hours_left <= 12:
                     # Send a 12-hour prior warning email
                     try:
                         subject, body = load_and_update_template(
@@ -324,7 +324,7 @@ class MainClass:
                     except Exception as e:
                         self.logger.error(f"Failed to send email: Error: {e}")
 
-                elif 1 < hours_left <= 6:
+                elif 5 < hours_left <= 6:
                     # Send a 6-hour prior warning email
                     try:
                         subject, body = load_and_update_template(

--- a/tools/db_cli.py
+++ b/tools/db_cli.py
@@ -46,7 +46,7 @@ class MainClass:
     GlobalsSingleton.get().load_config()
     GlobalsSingleton.get().initialized = True
 
-    def __init__(self, user: str, password: str, db: str, host: str = '127.0.0.1:5432'):
+    def __init__(self, user: str, password: str, db: str, host: str = 'orchestrator-db:5432'):
         self.logger = logging.getLogger("db-cli")
         file_handler = RotatingFileHandler('./db_cli.log', backupCount=5, maxBytes=50000)
         logging.basicConfig(level=logging.DEBUG,
@@ -54,7 +54,7 @@ class MainClass:
                             handlers=[logging.StreamHandler(), file_handler])
 
         self.db = ActorDatabase(user=user, password=password, database=db, db_host=host, logger=self.logger)
-        self.neo4j_config = {"url": "neo4j://0.0.0.0:9687",
+        self.neo4j_config = {"url": "neo4j://orchestrator-neo4j:9687",
                              "user": "neo4j",
                              "pass": "password",
                              "import_host_dir": "/Users/kthare10/renci/code/fabric/ControlFramework/neo4j1/imports/",
@@ -63,10 +63,10 @@ class MainClass:
     def get_slices(self, email: str = None, slice_id: str = None, slice_name: str = None):
         try:
             if slice_id is not None:
-                slice_obj = self.db.get_slice(slice_id=ID(uid=slice_id))
+                slice_obj = self.db.get_slices(slice_id=ID(uid=slice_id))
                 slice_list = [slice_obj]
             elif email is not None:
-                slice_list = self.db.get_slice_by_email(email=email)
+                slice_list = self.db.get_slices(email=email)
             else:
                 slice_list = self.db.get_slices()
 


### PR DESCRIPTION
- Added support in audit to check for slices close to expiry and sends warning emails to the slice owners if the slice is set to expire in less than 12 hours or 6 hours.
- Uses mail.fabric-testbed.net
- Also updated nginx config to redirect access and error logs to a location to be picked up by filebeats