### PR TITLE
Seed summary cache at startup and deduplicate broker queries

### DIFF
--- a/fabric_cf/orchestrator/core/bqm_wrapper.py
+++ b/fabric_cf/orchestrator/core/bqm_wrapper.py
@@ -23,6 +23,7 @@
 #
 #
 # Author: Komal Thareja (kthare10@renci.org)
+import threading
 from datetime import datetime, timezone
 
 from fabric_cf.actor.core.common.constants import Constants
@@ -50,6 +51,7 @@ class BqmWrapper:
         self.level = 1
         self.graph_id = None
         self.logger = logger
+        self._condition = threading.Condition(threading.Lock())
 
     def can_refresh(self) -> bool:
         """
@@ -58,24 +60,74 @@ class BqmWrapper:
         """
         current_time = datetime.now(timezone.utc)
 
-        if self.refresh_in_progress:
-            if self.refresh_started_at and \
-                    (current_time - self.refresh_started_at).total_seconds() > self.refresh_interval_in_seconds:
-                if self.logger:
-                    self.logger.warning(
-                        f"BQM refresh has been stuck for "
-                        f"{(current_time - self.refresh_started_at).total_seconds():.0f}s "
-                        f"(timeout={self.refresh_interval_in_seconds}s); allowing new refresh"
-                    )
-                self.refresh_in_progress = False
-                self.refresh_started_at = None
-            else:
-                return False
+        with self._condition:
+            if self.refresh_in_progress:
+                if self.refresh_started_at and \
+                        (current_time - self.refresh_started_at).total_seconds() > self.refresh_interval_in_seconds:
+                    if self.logger:
+                        self.logger.warning(
+                            f"BQM refresh has been stuck for "
+                            f"{(current_time - self.refresh_started_at).total_seconds():.0f}s "
+                            f"(timeout={self.refresh_interval_in_seconds}s); allowing new refresh"
+                        )
+                    self.refresh_in_progress = False
+                    self.refresh_started_at = None
+                    self._condition.notify_all()
+                else:
+                    return False
 
-        if self.last_query_time is None or \
-                (current_time - self.last_query_time).total_seconds() > self.refresh_interval_in_seconds:
+            if self.last_query_time is None or \
+                    (current_time - self.last_query_time).total_seconds() > self.refresh_interval_in_seconds:
+                return True
+            return False
+
+    def start_refresh(self) -> bool:
+        """
+        Attempt to start a refresh. Returns True if this caller should perform
+        the refresh (first caller wins). Returns False if a refresh is already
+        in progress — the caller should then call wait_for_refresh() to block
+        until the in-flight refresh completes.
+        """
+        with self._condition:
+            if self.refresh_in_progress:
+                return False
+            self.refresh_in_progress = True
+            self.refresh_started_at = datetime.now(timezone.utc)
             return True
-        return False
+
+    def finish_refresh(self, *, bqm: str, graph_format: GraphFormat, level: int):
+        """
+        Complete a refresh: save the result and wake all waiting threads.
+        """
+        with self._condition:
+            self.graph_format = graph_format
+            self.bqm = bqm
+            self.last_query_time = datetime.now(timezone.utc)
+            self.refresh_in_progress = False
+            self.refresh_started_at = None
+            self.level = level
+            self._condition.notify_all()
+
+    def abort_refresh(self):
+        """
+        Abort a failed refresh and wake all waiting threads so they can
+        fall back to stale cache or retry.
+        """
+        with self._condition:
+            self.refresh_in_progress = False
+            self.refresh_started_at = None
+            self._condition.notify_all()
+
+    def wait_for_refresh(self, timeout: float = 120) -> str:
+        """
+        Block until an in-flight refresh completes (or times out).
+        Returns the cached value (fresh if the refresh succeeded,
+        stale if it failed or timed out).
+        """
+        with self._condition:
+            if self.refresh_in_progress:
+                self._condition.wait(timeout=timeout)
+            return self.bqm
 
     def save(self, *, bqm: str, graph_format: GraphFormat, level: int):
         """
@@ -90,10 +142,6 @@ class BqmWrapper:
         self.refresh_in_progress = False
         self.refresh_started_at = None
         self.level = level
-
-    def start_refresh(self):
-        self.refresh_in_progress = True
-        self.refresh_started_at = datetime.now(timezone.utc)
 
     def get_bqm(self) -> str:
         """

--- a/fabric_cf/orchestrator/core/orchestrator_handler.py
+++ b/fabric_cf/orchestrator/core/orchestrator_handler.py
@@ -147,42 +147,66 @@ class OrchestratorHandler:
         :return str or None
         """
         broker_query_model = None
-        # Always get Fresh copy for advanced resource requests
-        if not start and not end and not includes and not excludes:
+        saved_bqm = None
+        is_cacheable = not start and not end and not includes and not excludes
+        do_query = False
+
+        # Check cache for non-advanced resource requests
+        if is_cacheable:
             saved_bqm = self.controller_state.get_saved_bqm(graph_format=graph_format, level=level)
             if saved_bqm is not None:
-                if force_refresh:
-                    saved_bqm.start_refresh()
-                elif saved_bqm.can_refresh():
-                    saved_bqm.start_refresh()
-                elif saved_bqm.refresh_in_progress and saved_bqm.get_bqm():
-                    # Serve stale cache while a refresh is already in progress
-                    broker_query_model = saved_bqm.get_bqm()
+                if force_refresh or saved_bqm.can_refresh():
+                    if saved_bqm.start_refresh():
+                        # This caller wins — perform the broker query
+                        do_query = True
+                    else:
+                        # Another refresh is in flight — wait for it to complete
+                        broker_query_model = saved_bqm.wait_for_refresh()
                 else:
+                    # Cache is still fresh
                     broker_query_model = saved_bqm.get_bqm()
+            else:
+                # No cache entry yet — need to query
+                do_query = True
 
-        # Request the model from Broker as a fallback
-        if not broker_query_model:
+        # Advanced requests always query the broker directly
+        if not is_cacheable:
+            do_query = True
+
+        if not broker_query_model and do_query:
             broker = self.get_broker(controller=controller)
             if broker is None:
+                if saved_bqm is not None:
+                    saved_bqm.abort_refresh()
                 raise OrchestratorException("Unable to determine broker proxy for this controller. "
                                             "Please check Orchestrator container configuration and logs.")
 
             self.logger.info(f"Sending Query to broker on behalf of {email} Start: {start}, End: {end}, "
                              f"Force: {force_refresh}, Level: {level}, format: {graph_format}")
 
-            model = controller.get_broker_query_model(broker=broker, id_token=token, level=level,
-                                                      graph_format=graph_format, start=start, end=end,
-                                                      includes=includes, excludes=excludes)
+            try:
+                model = controller.get_broker_query_model(broker=broker, id_token=token, level=level,
+                                                          graph_format=graph_format, start=start, end=end,
+                                                          includes=includes, excludes=excludes)
+            except Exception as e:
+                if saved_bqm is not None:
+                    saved_bqm.abort_refresh()
+                raise
+
             if model is None or model.get_model() is None or model.get_model() == '':
+                if saved_bqm is not None:
+                    saved_bqm.abort_refresh()
                 raise OrchestratorException(http_error_code=NOT_FOUND, message=f"Resource(s) not found for "
                                                                                f"level: {level} format: {graph_format}!")
 
             broker_query_model = model.get_model()
 
-            # Do not update cache for advance requests
-            if not start and not end and not includes and not excludes and level > 0:
-                self.controller_state.save_bqm(bqm=broker_query_model, graph_format=graph_format, level=level)
+            # Update cache (not for advanced requests)
+            if is_cacheable and level > 0:
+                if saved_bqm is not None:
+                    saved_bqm.finish_refresh(bqm=broker_query_model, graph_format=graph_format, level=level)
+                else:
+                    self.controller_state.save_bqm(bqm=broker_query_model, graph_format=graph_format, level=level)
 
         return broker_query_model
 
@@ -244,41 +268,66 @@ class OrchestratorHandler:
         :return: JSON string or None
         """
         summary_json = None
-        # Always get fresh copy for advanced resource requests
-        if not start and not end and not includes and not excludes:
+        saved = None
+        is_cacheable = not start and not end and not includes and not excludes
+        do_query = False
+
+        # Check cache for non-advanced resource requests
+        if is_cacheable:
             saved = self.controller_state.get_saved_summary(level=level)
             if saved is not None:
-                if force_refresh:
-                    saved.start_refresh()
-                elif saved.can_refresh():
-                    saved.start_refresh()
-                elif saved.refresh_in_progress and saved.get_bqm():
-                    # Serve stale cache while a refresh is already in progress
-                    summary_json = saved.get_bqm()
+                if force_refresh or saved.can_refresh():
+                    if saved.start_refresh():
+                        # This caller wins — perform the broker query
+                        do_query = True
+                    else:
+                        # Another refresh is in flight — wait for it to complete
+                        summary_json = saved.wait_for_refresh()
                 else:
+                    # Cache is still fresh
                     summary_json = saved.get_bqm()
+            else:
+                # No cache entry yet — need to query
+                do_query = True
 
-        if not summary_json:
+        # Advanced requests always query the broker directly
+        if not is_cacheable:
+            do_query = True
+
+        if not summary_json and do_query:
             broker = self.get_broker(controller=controller)
             if broker is None:
+                if saved is not None:
+                    saved.abort_refresh()
                 raise OrchestratorException("Unable to determine broker proxy for this controller. "
                                             "Please check Orchestrator container configuration and logs.")
 
             self.logger.info(f"Sending Summary Query to broker on behalf of {email} Start: {start}, End: {end}, "
                              f"Force: {force_refresh}, Level: {level}")
 
-            model = controller.get_broker_query_model_summary(broker=broker, id_token=token, level=level,
-                                                               start=start, end=end,
-                                                               includes=includes, excludes=excludes)
+            try:
+                model = controller.get_broker_query_model_summary(broker=broker, id_token=token, level=level,
+                                                                   start=start, end=end,
+                                                                   includes=includes, excludes=excludes)
+            except Exception as e:
+                if saved is not None:
+                    saved.abort_refresh()
+                raise
+
             if model is None or model.get_model() is None or model.get_model() == '':
+                if saved is not None:
+                    saved.abort_refresh()
                 raise OrchestratorException(http_error_code=NOT_FOUND,
                                             message=f"Resource summary not found for level: {level}!")
 
             summary_json = model.get_model()
 
-            # Do not update cache for advance requests
-            if not start and not end and not includes and not excludes and level > 0:
-                self.controller_state.save_summary(summary=summary_json, level=level)
+            # Update cache (not for advanced requests)
+            if is_cacheable and level > 0:
+                if saved is not None:
+                    saved.finish_refresh(bqm=summary_json, graph_format=GraphFormat.GRAPHML, level=level)
+                else:
+                    self.controller_state.save_summary(summary=summary_json, level=level)
 
         return summary_json
 

--- a/fabric_cf/orchestrator/core/orchestrator_kernel.py
+++ b/fabric_cf/orchestrator/core/orchestrator_kernel.py
@@ -56,11 +56,20 @@ class PollEvent(ABCActorEvent):
 
     def process(self):
         from fabric_cf.orchestrator.core.orchestrator_handler import OrchestratorHandler
+        from fabric_cf.orchestrator.core.orchestrator_kernel import OrchestratorKernelSingleton
         oh = OrchestratorHandler()
+        kernel = OrchestratorKernelSingleton.get()
         for graph_format, level in self.model_level_list:
-            oh.discover_broker_query_model(controller=oh.controller_state.controller,
-                                           graph_format=graph_format, force_refresh=True,
-                                           level=level)
+            try:
+                oh.discover_broker_query_model(controller=oh.controller_state.controller,
+                                               graph_format=graph_format, force_refresh=True,
+                                               level=level)
+            except Exception as e:
+                kernel.get_logger().error(f"BQM poll failed for format={graph_format} level={level}: {e}")
+                saved = kernel.get_saved_bqm(graph_format=graph_format, level=level)
+                if saved is not None:
+                    saved.refresh_in_progress = False
+                    saved.refresh_started_at = None
 
 
 class SummaryPollEvent(ABCActorEvent):
@@ -69,10 +78,19 @@ class SummaryPollEvent(ABCActorEvent):
 
     def process(self):
         from fabric_cf.orchestrator.core.orchestrator_handler import OrchestratorHandler
+        from fabric_cf.orchestrator.core.orchestrator_kernel import OrchestratorKernelSingleton
         oh = OrchestratorHandler()
+        kernel = OrchestratorKernelSingleton.get()
         for level in self.level_list:
-            oh.discover_broker_query_model_summary(controller=oh.controller_state.controller,
-                                                    force_refresh=True, level=level)
+            try:
+                oh.discover_broker_query_model_summary(controller=oh.controller_state.controller,
+                                                        force_refresh=True, level=level)
+            except Exception as e:
+                kernel.get_logger().error(f"Summary poll failed for level={level}: {e}")
+                saved = kernel.get_saved_summary(level=level)
+                if saved is not None:
+                    saved.refresh_in_progress = False
+                    saved.refresh_started_at = None
 
 
 class OrchestratorKernel(ABCTick):
@@ -233,6 +251,14 @@ class OrchestratorKernel(ABCTick):
                                                graph_format=GraphFormat.GRAPHML,
                                                force_refresh=True, level=0)
         self.load_model(model=model)
+
+        try:
+            summary = oh.discover_broker_query_model_summary(
+                controller=self.get_management_actor(),
+                force_refresh=True, level=2)
+            self.get_logger().info("Successfully seeded summary cache for level 2")
+        except Exception as e:
+            self.get_logger().warning(f"Failed to seed summary cache at startup: {e}")
 
         self.get_logger().info("Starting SliceDeferThread")
         self.defer_thread = SliceDeferThread(kernel=self)

--- a/fabric_cf/orchestrator/core/orchestrator_kernel.py
+++ b/fabric_cf/orchestrator/core/orchestrator_kernel.py
@@ -66,10 +66,6 @@ class PollEvent(ABCActorEvent):
                                                level=level)
             except Exception as e:
                 kernel.get_logger().error(f"BQM poll failed for format={graph_format} level={level}: {e}")
-                saved = kernel.get_saved_bqm(graph_format=graph_format, level=level)
-                if saved is not None:
-                    saved.refresh_in_progress = False
-                    saved.refresh_started_at = None
 
 
 class SummaryPollEvent(ABCActorEvent):
@@ -87,10 +83,6 @@ class SummaryPollEvent(ABCActorEvent):
                                                         force_refresh=True, level=level)
             except Exception as e:
                 kernel.get_logger().error(f"Summary poll failed for level={level}: {e}")
-                saved = kernel.get_saved_summary(level=level)
-                if saved is not None:
-                    saved.refresh_in_progress = False
-                    saved.refresh_started_at = None
 
 
 class OrchestratorKernel(ABCTick):
@@ -280,16 +272,14 @@ class OrchestratorKernel(ABCTick):
             self.lock.acquire()
             model_level_list = []
             for cached_bqm in self.bqm_cache.values():
-                if cached_bqm.can_refresh():
-                    cached_bqm.start_refresh()
+                if cached_bqm.can_refresh() and cached_bqm.start_refresh():
                     model_level_list.append((cached_bqm.get_graph_format(), cached_bqm.get_level()))
             if self.event_processor is not None and len(model_level_list) > 0:
                 self.event_processor.enqueue(incoming=PollEvent(model_level_list=model_level_list))
 
             summary_level_list = []
             for cached_summary in self.summary_cache.values():
-                if cached_summary.can_refresh():
-                    cached_summary.start_refresh()
+                if cached_summary.can_refresh() and cached_summary.start_refresh():
                     summary_level_list.append(cached_summary.get_level())
             if self.event_processor is not None and len(summary_level_list) > 0:
                 self.event_processor.enqueue(incoming=SummaryPollEvent(level_list=summary_level_list))


### PR DESCRIPTION
## Summary
- Seed the summary cache (level 2) at startup in `start_threads()` so that `SummaryPollEvent` periodic refresh works from the first tick cycle instead of waiting for the first HTTP request
- Add thread-safe refresh deduplication using `threading.Condition` in `BqmWrapper` — only one broker query runs per cache key at a time; concurrent callers wait and receive the fresh result
- Add `finish_refresh()`, `abort_refresh()`, and `wait_for_refresh()` primitives to `BqmWrapper` for proper lifecycle management
- Refactor `discover_broker_query_model` and `discover_broker_query_model_summary` to use the new primitives, with proper error handling (`abort_refresh` on failure)
- Add error handling in `PollEvent` and `SummaryPollEvent` process methods to log failures

## Test plan
- [ ] Verify orchestrator starts normally with the summary cache seed (try/except prevents startup failure)
- [ ] After startup, confirm `summary_cache` has a `SUMMARY-2` entry and periodic `SummaryPollEvent` fires
- [ ] Send concurrent `force_refresh=True` requests and verify only one broker query is sent (check logs for single "Sending Summary Query" per batch)
- [ ] Simulate broker query failure and confirm `abort_refresh()` wakes waiting threads without getting stuck
- [ ] Verify periodic poll skips when a user-triggered refresh is already in flight

🤖 Generated with [Claude Code](https://claude.com/claude-code)