### PR TITLE
fix: set application/json mimetype in cors_response

### DIFF
--- a/fabric_cf/orchestrator/swagger_server/response/cors_response.py
+++ b/fabric_cf/orchestrator/swagger_server/response/cors_response.py
@@ -34,7 +34,7 @@ def cors_response(req: request, status_code: int = 200, body: object = None, x_e
     """
     Return CORS Response object
     """
-    response = Response()
+    response = Response(mimetype='application/json')
     response.status_code = status_code
     response.data = body
     response.headers['Access-Control-Allow-Origin'] = req.headers.get('Origin', '*')


### PR DESCRIPTION
 Fixes #435 

Sets `mimetype='application/json'` in `cors_response()` to prevent Flask's default `text/html` from bleeding through on every endpoint.