### PR TITLE
Fix unsafe lock.locked()/release() idiom across actors

### DIFF
--- a/fabric_cf/actor/core/container/message_service.py
+++ b/fabric_cf/actor/core/container/message_service.py
@@ -67,8 +67,7 @@ class MessageService(AvroConsumerApi):
 
     def stop(self):
         self.shutdown()
-        try:
-            self.thread_lock.acquire()
+        with self.thread_lock:
             temp = self.thread
             self.thread = None
             if temp is not None:
@@ -77,11 +76,6 @@ class MessageService(AvroConsumerApi):
                     temp.join()
                 except Exception as e:
                     self.logger.error("Could not join Message Service thread {}".format(e))
-                finally:
-                    self.thread_lock.release()
-        finally:
-            if self.thread_lock is not None and self.thread_lock.locked():
-                self.thread_lock.release()
 
     def handle_message(self, message: AbcMessageAvro):
         try:

--- a/fabric_cf/actor/core/container/rpc_consumer.py
+++ b/fabric_cf/actor/core/container/rpc_consumer.py
@@ -116,8 +116,7 @@ class RPCConsumer:
 
     def stop(self):
         self.shutdown = True
-        try:
-            self.thread_lock.acquire()
+        with self.thread_lock:
             temp = self.thread
             self.thread = None
             if temp is not None:
@@ -126,11 +125,6 @@ class RPCConsumer:
                     temp.join()
                 except Exception as e:
                     self.logger.error(f"Could not join {self.name} thread {e}")
-                finally:
-                    self.thread_lock.release()
-        finally:
-            if self.thread_lock is not None and self.thread_lock.locked():
-                self.thread_lock.release()
 
     def enqueue(self, incoming):
         try:

--- a/fabric_cf/actor/core/container/rpc_producer.py
+++ b/fabric_cf/actor/core/container/rpc_producer.py
@@ -87,8 +87,7 @@ class RPCProducer(AvroProducerApi):
         """
         Stop the Poller Thread
         """
-        try:
-            self.thread_lock.acquire()
+        with self.thread_lock:
             temp = self.thread
             self.thread = None
             self.running = False
@@ -98,11 +97,6 @@ class RPCProducer(AvroProducerApi):
                     temp.join()
                 except Exception as e:
                     self.logger.error(f"Could not join {self.__class__.__name__} thread {e}")
-                finally:
-                    self.thread_lock.release()
-        finally:
-            if self.thread_lock is not None and self.thread_lock.locked():
-                self.thread_lock.release()
 
     def delivery_check(self):
         """

--- a/fabric_cf/actor/core/core/event_processor.py
+++ b/fabric_cf/actor/core/core/event_processor.py
@@ -148,21 +148,15 @@ class EventProcessor:
 
     def stop(self):
         self.shutdown = True
-        try:
-            self.thread_lock.acquire()
+        with self.thread_lock:
             temp = self.thread
             self.thread = None
             if temp is not None:
-                self.logger.warning("It seems that the Event Processor {self.name} thread is running. Interrupting it")
+                self.logger.warning(f"It seems that the Event Processor {self.name} thread is running. Interrupting it")
                 try:
                     temp.join()
                 except Exception as e:
                     self.logger.error(f"Could not join Event Processor {self.name} thread {e}")
-                finally:
-                    self.thread_lock.release()
-        finally:
-            if self.thread_lock is not None and self.thread_lock.locked():
-                self.thread_lock.release()
 
     def enqueue(self, incoming):
         try:

--- a/fabric_cf/actor/core/delegation/delegation.py
+++ b/fabric_cf/actor/core/delegation/delegation.py
@@ -66,7 +66,7 @@ class Delegation(ABCDelegation):
         self.owner = None
         self.delegation_name = delegation_name
         self.site = site
-        self.thread_lock = threading.Lock()
+        self.thread_lock = threading.RLock()
 
     def __getstate__(self):
         state = self.__dict__.copy()
@@ -85,7 +85,7 @@ class Delegation(ABCDelegation):
         self.slice_object = None
         self.logger = None
         self.policy = None
-        self.thread_lock = threading.Lock()
+        self.thread_lock = threading.RLock()
 
     def restore(self, actor: ABCActorMixin, slice_obj: ABCSlice):
         self.actor = actor
@@ -452,5 +452,9 @@ class Delegation(ABCDelegation):
         self.thread_lock.acquire()
 
     def unlock(self):
-        if self.thread_lock.locked():
+        try:
             self.thread_lock.release()
+        except RuntimeError:
+            # RLock.release() raises if this thread does not hold the lock
+            # (or it is not held at all); treat unlock() as a safe no-op then.
+            pass

--- a/fabric_cf/actor/core/kernel/kernel.py
+++ b/fabric_cf/actor/core/kernel/kernel.py
@@ -75,7 +75,7 @@ class Kernel:
         # All reservations managed by the kernel.
         self.reservations = ReservationSet()
         self.delegations = {}
-        self.lock = threading.Lock()
+        self.lock = threading.RLock()
         self.nothing_pending = threading.Condition()
 
     def amend_reserve(self, *, reservation: ABCReservationMixin):
@@ -518,14 +518,10 @@ class Kernel:
         @param did delegation id
         @return delegation
         """
-        try:
-            if did is not None:
-                self.lock.acquire()
-                return self.delegations.get(did, None)
-        finally:
-            if self.lock.locked():
-                self.lock.release()
-        return None
+        if did is None:
+            return None
+        with self.lock:
+            return self.delegations.get(did, None)
 
     def get_plugin(self) -> ABCBasePlugin:
         """
@@ -1369,13 +1365,9 @@ class Kernel:
             slice_object.unregister_delegation(delegation=delegation)
         finally:
             slice_object.unlock_slice()
-        try:
-            self.lock.acquire()
+        with self.lock:
             if delegation.get_delegation_id() in self.delegations:
                 self.delegations.pop(delegation.get_delegation_id())
-        finally:
-            if self.lock.locked():
-                self.lock.release()
 
     def unregister_reservation(self, *, rid: ID):
         """

--- a/fabric_cf/actor/core/kernel/reservation.py
+++ b/fabric_cf/actor/core/kernel/reservation.py
@@ -146,7 +146,7 @@ class Reservation(ABCReservationMixin):
         self.last_transition_time = None
         self.closed_at = None
         self.last_pending_state = ReservationPendingStates.None_
-        self.thread_lock = threading.Lock()
+        self.thread_lock = threading.RLock()
 
     def __getstate__(self):
         state = self.__dict__.copy()
@@ -177,7 +177,7 @@ class Reservation(ABCReservationMixin):
         self.pending_recover = False
         self.state_transition = False
         self.service_pending = ReservationPendingStates.None_
-        self.thread_lock = threading.Lock()
+        self.thread_lock = threading.RLock()
 
     def restore(self, *, actor: ABCActorMixin, slice_obj: ABCSlice):
         """
@@ -711,8 +711,12 @@ class Reservation(ABCReservationMixin):
         self.thread_lock.acquire()
 
     def unlock(self):
-        if self.thread_lock.locked():
+        try:
             self.thread_lock.release()
+        except RuntimeError:
+            # RLock.release() raises if this thread does not hold the lock
+            # (or it is not held at all); treat unlock() as a safe no-op then.
+            pass
 
     def service_poa(self):
         pass

--- a/fabric_cf/actor/core/kernel/slice.py
+++ b/fabric_cf/actor/core/kernel/slice.py
@@ -81,7 +81,7 @@ class Slice(ABCSlice):
         self.state_machine = SliceStateMachine(slice_id=slice_id)
         self.dirty = False
         self.config_properties = None
-        self.lock = threading.Lock()
+        self.lock = threading.RLock()
         self.lease_end = None
         self.lease_start = None
         self.project_id = project_id
@@ -102,7 +102,7 @@ class Slice(ABCSlice):
         self.reservations = ReservationSet()
         self.graph = None
         self.delegations = {}
-        self.lock = threading.Lock()
+        self.lock = threading.RLock()
         self.last_updated_time = None
 
     def set_last_updated_time(self, updated: datetime):
@@ -380,8 +380,12 @@ class Slice(ABCSlice):
         self.lock.acquire()
 
     def unlock_slice(self):
-        if self.lock.locked():
+        try:
             self.lock.release()
+        except RuntimeError:
+            # RLock.release() raises if this thread does not hold the lock
+            # (or it is not held at all); treat unlock_slice() as a safe no-op then.
+            pass
 
 
 class SliceFactory:

--- a/fabric_cf/actor/core/manage/kafka/kafka_mgmt_message_processor.py
+++ b/fabric_cf/actor/core/manage/kafka/kafka_mgmt_message_processor.py
@@ -71,8 +71,7 @@ class KafkaMgmtMessageProcessor(AvroConsumerApi):
 
     def stop(self):
         self.shutdown()
-        try:
-            self.thread_lock.acquire()
+        with self.thread_lock:
             temp = self.thread
             self.thread = None
             if temp is not None:
@@ -81,11 +80,6 @@ class KafkaMgmtMessageProcessor(AvroConsumerApi):
                     temp.join()
                 except Exception as e:
                     self.logger.error("Could not join KafkaMgmtMessageProcessor thread {}".format(e))
-                finally:
-                    self.thread_lock.release()
-        finally:
-            if self.thread_lock is not None and self.thread_lock.locked():
-                self.thread_lock.release()
 
     def handle_message(self, message: AbcMessageAvro):
         try:

--- a/fabric_cf/actor/core/plugins/db/actor_database.py
+++ b/fabric_cf/actor/core/plugins/db/actor_database.py
@@ -118,88 +118,65 @@ class ActorDatabase(ABCDatabase):
 
     def get_actor_id_from_name(self, *, actor_name: str) -> int or None:
         try:
-            #self.lock.acquire()
             actor = self.db.get_actor(name=actor_name)
             self.actor_id = actor['act_id']
             self.actor_type = ActorType(actor['act_type'])
             return self.actor_id
         except Exception as e:
             self.logger.error(e)
-        finally:
-            if self.lock.locked():
-                self.lock.release()
         return None
 
     def get_slice_by_id(self, *, slc_id: int) -> ABCSlice or None:
         try:
-            #self.lock.acquire()
             slice_dict = self.db.get_slice_by_id(slc_id=slc_id)
             if slice_dict is not None:
                 pickled_slice = slice_dict.get(Constants.PROPERTY_PICKLE_PROPERTIES)
                 return pickle.loads(pickled_slice)
         except Exception as e:
             self.logger.error(e)
-        finally:
-            if self.lock.locked():
-                self.lock.release()
         return None
 
     def add_slice(self, *, slice_object: ABCSlice):
-        try:
-            slices = self.get_slices(slice_id=slice_object.get_slice_id())
-            if len(slices) > 0:
-                raise DatabaseException("Slice # {} already exists".format(slice_object.get_slice_id()))
+        slices = self.get_slices(slice_id=slice_object.get_slice_id())
+        if len(slices) > 0:
+            raise DatabaseException("Slice # {} already exists".format(slice_object.get_slice_id()))
 
-            properties = pickle.dumps(slice_object)
-            oidc_claim_sub = None
-            email = None
-            if slice_object.get_owner() is not None:
-                oidc_claim_sub = slice_object.get_owner().get_oidc_sub_claim()
-                email = slice_object.get_owner().get_email()
+        properties = pickle.dumps(slice_object)
+        oidc_claim_sub = None
+        email = None
+        if slice_object.get_owner() is not None:
+            oidc_claim_sub = slice_object.get_owner().get_oidc_sub_claim()
+            email = slice_object.get_owner().get_email()
 
-            #self.lock.acquire()
-            self.db.add_slice(slc_guid=str(slice_object.get_slice_id()),
-                              slc_state=slice_object.get_state().value,
-                              slc_name=slice_object.get_name(),
-                              slc_type=slice_object.get_slice_type().value,
-                              slc_resource_type=str(slice_object.get_resource_type()),
-                              properties=properties,
-                              slc_graph_id=slice_object.get_graph_id(),
-                              oidc_claim_sub=oidc_claim_sub, email=email,
-                              lease_end=slice_object.get_lease_end(),
-                              lease_start=slice_object.get_lease_start(),
-                              project_id=slice_object.get_project_id())
-        finally:
-            if self.lock.locked():
-                self.lock.release()
+        self.db.add_slice(slc_guid=str(slice_object.get_slice_id()),
+                          slc_state=slice_object.get_state().value,
+                          slc_name=slice_object.get_name(),
+                          slc_type=slice_object.get_slice_type().value,
+                          slc_resource_type=str(slice_object.get_resource_type()),
+                          properties=properties,
+                          slc_graph_id=slice_object.get_graph_id(),
+                          oidc_claim_sub=oidc_claim_sub, email=email,
+                          lease_end=slice_object.get_lease_end(),
+                          lease_start=slice_object.get_lease_start(),
+                          project_id=slice_object.get_project_id())
 
     def update_slice(self, *, slice_object: ABCSlice):
         # Update the slice only when there are changes to be reflected in database
         if not slice_object.is_dirty():
             return
         slice_object.clear_dirty()
-        try:
-            #self.lock.acquire()
-            properties = pickle.dumps(slice_object)
-            self.db.update_slice(slc_guid=str(slice_object.get_slice_id()),
-                                 slc_name=slice_object.get_name(),
-                                 slc_type=slice_object.get_slice_type().value,
-                                 slc_state=slice_object.get_state().value,
-                                 slc_resource_type=str(slice_object.get_resource_type()),
-                                 properties=properties,
-                                 slc_graph_id=slice_object.get_graph_id(),
-                                 lease_end=slice_object.get_lease_end(), lease_start=slice_object.get_lease_start())
-        finally:
-            if self.lock.locked():
-                self.lock.release()
+        properties = pickle.dumps(slice_object)
+        self.db.update_slice(slc_guid=str(slice_object.get_slice_id()),
+                             slc_name=slice_object.get_name(),
+                             slc_type=slice_object.get_slice_type().value,
+                             slc_state=slice_object.get_state().value,
+                             slc_resource_type=str(slice_object.get_resource_type()),
+                             properties=properties,
+                             slc_graph_id=slice_object.get_graph_id(),
+                             lease_end=slice_object.get_lease_end(), lease_start=slice_object.get_lease_start())
 
     def remove_slice(self, *, slice_id: ID):
-        try:
-            #self.lock.acquire()
-            self.db.remove_slice(slc_guid=str(slice_id))
-        finally:
-            if self.lock.locked():
-                self.lock.release()
+        self.db.remove_slice(slc_guid=str(slice_id))
 
     def get_slices(self, *, slice_id: ID = None, slice_name: str = None, project_id: str = None, email: str = None,
                    states: list[int] = None, oidc_sub: str = None, slc_type: List[SliceTypes] = None,
@@ -208,19 +185,14 @@ class ActorDatabase(ABCDatabase):
                    updated_after: datetime = None) -> List[ABCSlice] or None:
         result = []
         try:
-            try:
-                #self.lock.acquire()
-                slice_type = None
-                if slc_type is not None:
-                    slice_type = [x.value for x in slc_type]
-                sid = str(slice_id) if slice_id is not None else None
-                slices = self.db.get_slices(slice_id=sid, slice_name=slice_name, project_id=project_id, email=email,
-                                            states=states, oidc_sub=oidc_sub, slc_type=slice_type, limit=limit,
-                                            offset=offset, lease_end=lease_end, search=search, exact_match=exact_match,
-                                            updated_after=updated_after)
-            finally:
-                if self.lock.locked():
-                    self.lock.release()
+            slice_type = None
+            if slc_type is not None:
+                slice_type = [x.value for x in slc_type]
+            sid = str(slice_id) if slice_id is not None else None
+            slices = self.db.get_slices(slice_id=sid, slice_name=slice_name, project_id=project_id, email=email,
+                                        states=states, oidc_sub=oidc_sub, slc_type=slice_type, limit=limit,
+                                        offset=offset, lease_end=lease_end, search=search, exact_match=exact_match,
+                                        updated_after=updated_after)
             if slices is not None:
                 for s in slices:
                     pickled_slice = s.get(Constants.PROPERTY_PICKLE_PROPERTIES)
@@ -230,22 +202,16 @@ class ActorDatabase(ABCDatabase):
         except Exception as e:
             self.logger.error(e)
             self.logger.error(traceback.format_exc())
-        finally:
-            if self.lock.locked():
-                self.lock.release()
         return result
 
     def increment_metrics(self, *, project_id: str, oidc_sub: str, slice_count: int = 1) -> bool:
         try:
-            self.lock.acquire()
-            self.db.increment_metrics(project_id=project_id, user_id=oidc_sub, slice_count=slice_count)
+            with self.lock:
+                self.db.increment_metrics(project_id=project_id, user_id=oidc_sub, slice_count=slice_count)
             return True
         except Exception as e:
             self.logger.error(e)
             self.logger.error(traceback.format_exc())
-        finally:
-            if self.lock.locked():
-                self.lock.release()
         return False
 
     def get_metrics(self, *, project_id: str, oidc_sub: str, excluded_projects: List[str] = None) -> list:
@@ -254,9 +220,6 @@ class ActorDatabase(ABCDatabase):
         except Exception as e:
             self.logger.error(e)
             self.logger.error(traceback.format_exc())
-        finally:
-            if self.lock.locked():
-                self.lock.release()
 
     def get_slice_count(self, *, project_id: str = None, email: str = None, states: list[int] = None,
                         oidc_sub: str = None, slc_type: List[SliceTypes] = None,
@@ -270,228 +233,210 @@ class ActorDatabase(ABCDatabase):
         except Exception as e:
             self.logger.error(e)
             self.logger.error(traceback.format_exc())
-        finally:
-            if self.lock.locked():
-                self.lock.release()
         return -1
 
     def add_reservation(self, *, reservation: ABCReservationMixin):
-        try:
-            #self.lock.acquire()
-            self.logger.debug("Adding reservation {} to slice {}".format(reservation.get_reservation_id(),
-                                                                         reservation.get_slice()))
-            properties = pickle.dumps(reservation)
-            oidc_claim_sub = None
-            email = None
-            if reservation.get_slice() is not None and reservation.get_slice().get_owner() is not None:
-                oidc_claim_sub = reservation.get_slice().get_owner().get_oidc_sub_claim()
-                email = reservation.get_slice().get_owner().get_email()
+        self.logger.debug("Adding reservation {} to slice {}".format(reservation.get_reservation_id(),
+                                                                     reservation.get_slice()))
+        properties = pickle.dumps(reservation)
+        oidc_claim_sub = None
+        email = None
+        if reservation.get_slice() is not None and reservation.get_slice().get_owner() is not None:
+            oidc_claim_sub = reservation.get_slice().get_owner().get_oidc_sub_claim()
+            email = reservation.get_slice().get_owner().get_email()
 
-            site = None
-            rsv_type = None
-            components = None
-            host = None
-            ip_subnet = None
-            sliver = None
-            links = []
-            from fabric_cf.actor.core.kernel.reservation_client import ReservationClient
-            if isinstance(reservation, ReservationClient) and reservation.get_leased_resources() and \
-                    reservation.get_leased_resources().get_sliver():
-                sliver = reservation.get_leased_resources().get_sliver()
-            if not sliver and reservation.get_resources() and reservation.get_resources().get_sliver():
-                sliver = reservation.get_resources().get_sliver()
+        site = None
+        rsv_type = None
+        components = None
+        host = None
+        ip_subnet = None
+        sliver = None
+        links = []
+        from fabric_cf.actor.core.kernel.reservation_client import ReservationClient
+        if isinstance(reservation, ReservationClient) and reservation.get_leased_resources() and \
+                reservation.get_leased_resources().get_sliver():
+            sliver = reservation.get_leased_resources().get_sliver()
+        if not sliver and reservation.get_resources() and reservation.get_resources().get_sliver():
+            sliver = reservation.get_resources().get_sliver()
 
-            if sliver:
-                rsv_type = sliver.get_type().name
-                from fim.slivers.network_service import NetworkServiceSliver
-                from fim.slivers.network_node import NodeSliver
+        if sliver:
+            rsv_type = sliver.get_type().name
+            from fim.slivers.network_service import NetworkServiceSliver
+            from fim.slivers.network_node import NodeSliver
 
-                if isinstance(sliver, NetworkServiceSliver) and sliver.interface_info:
-                    site = sliver.get_site()
-                    if sliver.get_gateway():
-                        ip_subnet = sliver.get_gateway().subnet
+            if isinstance(sliver, NetworkServiceSliver) and sliver.interface_info:
+                site = sliver.get_site()
+                if sliver.get_gateway():
+                    ip_subnet = sliver.get_gateway().subnet
 
+                components = []
+                for interface in sliver.interface_info.interfaces.values():
+                    graph_id_node_id_component_id, bqm_if_name = interface.get_node_map()
+                    if ":" in graph_id_node_id_component_id or "#" in graph_id_node_id_component_id:
+                        if "#" in graph_id_node_id_component_id:
+                            split_string = graph_id_node_id_component_id.split("#")
+                        else:
+                            split_string = graph_id_node_id_component_id.split(":")
+                        node_id = split_string[1] if len(split_string) > 1 else None
+                        comp_id = split_string[2] if len(split_string) > 2 else None
+                        bdf = ":".join(split_string[3:]) if len(split_string) > 3 else None
+                        if node_id and comp_id and bdf:
+                            components.append((node_id, comp_id, bdf))
+                if sliver.ero and sliver.capacities:
+                    type, path = sliver.ero.get()
+                    if path and len(path.get()):
+                        for hop in path.get()[0]:
+                            if hop.startswith('link:'):
+                                links.append({"node_id": hop,
+                                              "bw": sliver.capacities.bw})
+
+            elif isinstance(sliver, NodeSliver):
+                site = sliver.get_site()
+                if sliver.get_labels() and sliver.get_labels().instance_parent:
+                    host = sliver.get_labels().instance_parent
+                if sliver.get_label_allocations() and sliver.get_label_allocations().instance_parent:
+                    host = sliver.get_label_allocations().instance_parent
+                if sliver.get_management_ip():
+                    ip_subnet = str(sliver.get_management_ip())
+
+                node_id = reservation.get_graph_node_id()
+                if node_id and sliver.attached_components_info:
                     components = []
-                    for interface in sliver.interface_info.interfaces.values():
-                        graph_id_node_id_component_id, bqm_if_name = interface.get_node_map()
-                        if ":" in graph_id_node_id_component_id or "#" in graph_id_node_id_component_id:
-                            if "#" in graph_id_node_id_component_id:
-                                split_string = graph_id_node_id_component_id.split("#")
-                            else:
-                                split_string = graph_id_node_id_component_id.split(":")
-                            node_id = split_string[1] if len(split_string) > 1 else None
-                            comp_id = split_string[2] if len(split_string) > 2 else None
-                            bdf = ":".join(split_string[3:]) if len(split_string) > 3 else None
-                            if node_id and comp_id and bdf:
-                                components.append((node_id, comp_id, bdf))
-                    if sliver.ero and sliver.capacities:
-                        type, path = sliver.ero.get()
-                        if path and len(path.get()):
-                            for hop in path.get()[0]:
-                                if hop.startswith('link:'):
-                                    links.append({"node_id": hop,
-                                                  "bw": sliver.capacities.bw})
+                    for c in sliver.attached_components_info.devices.values():
+                        if c.get_node_map():
+                            bqm_id, comp_id = c.get_node_map()
+                            if c.labels and c.labels.bdf:
+                                bdf = c.labels.bdf
+                                if isinstance(c.labels.bdf, str):
+                                    bdf = [c.labels.bdf]
+                                for x in bdf:
+                                    components.append((node_id, comp_id, x))
 
-                elif isinstance(sliver, NodeSliver):
-                    site = sliver.get_site()
-                    if sliver.get_labels() and sliver.get_labels().instance_parent:
-                        host = sliver.get_labels().instance_parent
-                    if sliver.get_label_allocations() and sliver.get_label_allocations().instance_parent:
-                        host = sliver.get_label_allocations().instance_parent
-                    if sliver.get_management_ip():
-                        ip_subnet = str(sliver.get_management_ip())
+        term = reservation.get_term()
 
-                    node_id = reservation.get_graph_node_id()
-                    if node_id and sliver.attached_components_info:
-                        components = []
-                        for c in sliver.attached_components_info.devices.values():
-                            if c.get_node_map():
-                                bqm_id, comp_id = c.get_node_map()
-                                if c.labels and c.labels.bdf:
-                                    bdf = c.labels.bdf
-                                    if isinstance(c.labels.bdf, str):
-                                        bdf = [c.labels.bdf]
-                                    for x in bdf:
-                                        components.append((node_id, comp_id, x))
-
-            term = reservation.get_term()
-
-            self.db.add_reservation(slc_guid=str(reservation.get_slice_id()),
-                                    rsv_resid=str(reservation.get_reservation_id()),
-                                    rsv_category=reservation.get_category().value,
-                                    rsv_state=reservation.get_state().value,
-                                    rsv_pending=reservation.get_pending_state().value,
-                                    rsv_joining=reservation.get_join_state().value,
-                                    properties=properties,
-                                    rsv_graph_node_id=reservation.get_graph_node_id(),
-                                    oidc_claim_sub=oidc_claim_sub, email=email, site=site, rsv_type=rsv_type,
-                                    components=components,
-                                    lease_start=term.get_start_time() if term else None,
-                                    lease_end=term.get_end_time() if term else None,
-                                    host=host, ip_subnet=ip_subnet, links=links,
-                                    closed_at=getattr(reservation, 'closed_at', None))
-            self.logger.debug(
-                "Reservation {} added to slice {}".format(reservation.get_reservation_id(), reservation.get_slice()))
-        finally:
-            if self.lock.locked():
-                self.lock.release()
+        self.db.add_reservation(slc_guid=str(reservation.get_slice_id()),
+                                rsv_resid=str(reservation.get_reservation_id()),
+                                rsv_category=reservation.get_category().value,
+                                rsv_state=reservation.get_state().value,
+                                rsv_pending=reservation.get_pending_state().value,
+                                rsv_joining=reservation.get_join_state().value,
+                                properties=properties,
+                                rsv_graph_node_id=reservation.get_graph_node_id(),
+                                oidc_claim_sub=oidc_claim_sub, email=email, site=site, rsv_type=rsv_type,
+                                components=components,
+                                lease_start=term.get_start_time() if term else None,
+                                lease_end=term.get_end_time() if term else None,
+                                host=host, ip_subnet=ip_subnet, links=links,
+                                closed_at=getattr(reservation, 'closed_at', None))
+        self.logger.debug(
+            "Reservation {} added to slice {}".format(reservation.get_reservation_id(), reservation.get_slice()))
 
     def update_reservation(self, *, reservation: ABCReservationMixin):
         # Update the reservation only when there are changes to be reflected in database
         if not reservation.is_dirty():
             return
         reservation.clear_dirty()
-        try:
-            #self.lock.acquire()
-            self.logger.debug("Updating reservation {} in slice {}".format(reservation.get_reservation_id(),
-                                                                           reservation.get_slice()))
+        self.logger.debug("Updating reservation {} in slice {}".format(reservation.get_reservation_id(),
+                                                                       reservation.get_slice()))
 
-            site = None
-            rsv_type = None
-            components = None
-            ip_subnet = None
-            host = None
-            sliver = None
-            links = []
-            from fabric_cf.actor.core.kernel.reservation_client import ReservationClient
-            if isinstance(reservation, ReservationClient) and reservation.get_leased_resources() and \
-                    reservation.get_leased_resources().get_sliver():
-                sliver = reservation.get_leased_resources().get_sliver()
-            if not sliver and reservation.get_resources() and reservation.get_resources().get_sliver():
-                sliver = reservation.get_resources().get_sliver()
+        site = None
+        rsv_type = None
+        components = None
+        ip_subnet = None
+        host = None
+        sliver = None
+        links = []
+        from fabric_cf.actor.core.kernel.reservation_client import ReservationClient
+        if isinstance(reservation, ReservationClient) and reservation.get_leased_resources() and \
+                reservation.get_leased_resources().get_sliver():
+            sliver = reservation.get_leased_resources().get_sliver()
+        if not sliver and reservation.get_resources() and reservation.get_resources().get_sliver():
+            sliver = reservation.get_resources().get_sliver()
 
-            if sliver:
-                rsv_type = sliver.get_type().name
-                from fim.slivers.network_service import NetworkServiceSliver
-                from fim.slivers.network_node import NodeSliver
-                if isinstance(sliver, NetworkServiceSliver) and sliver.interface_info:
-                    site = sliver.get_site()
+        if sliver:
+            rsv_type = sliver.get_type().name
+            from fim.slivers.network_service import NetworkServiceSliver
+            from fim.slivers.network_node import NodeSliver
+            if isinstance(sliver, NetworkServiceSliver) and sliver.interface_info:
+                site = sliver.get_site()
 
-                    if sliver.get_gateway():
-                        ip_subnet = sliver.get_gateway().subnet
+                if sliver.get_gateway():
+                    ip_subnet = sliver.get_gateway().subnet
 
+                components = []
+                for interface in sliver.interface_info.interfaces.values():
+                    graph_id_node_id_component_id, bqm_if_name = interface.get_node_map()
+                    if ":" in graph_id_node_id_component_id or "#" in graph_id_node_id_component_id:
+                        if "#" in graph_id_node_id_component_id:
+                            split_string = graph_id_node_id_component_id.split("#")
+                        else:
+                            split_string = graph_id_node_id_component_id.split(":")
+                        node_id = split_string[1] if len(split_string) > 1 else None
+                        comp_id = split_string[2] if len(split_string) > 2 else None
+                        bdf = ":".join(split_string[3:]) if len(split_string) > 3 else None
+                        if node_id and comp_id and bdf:
+                            components.append((node_id, comp_id, bdf))
+
+                if sliver.ero and sliver.capacities:
+                    type, path = sliver.ero.get()
+                    if path and len(path.get()):
+                        for hop in path.get()[0]:
+                            if hop.startswith('link:'):
+                                links.append({"node_id": hop,
+                                              "bw": sliver.capacities.bw})
+            elif isinstance(sliver, NodeSliver):
+                site = sliver.get_site()
+
+                if sliver.get_labels() and sliver.get_labels().instance_parent:
+                    host = sliver.get_labels().instance_parent
+                if sliver.get_label_allocations() and sliver.get_label_allocations().instance_parent:
+                    host = sliver.get_label_allocations().instance_parent
+                if sliver.get_management_ip():
+                    ip_subnet = str(sliver.get_management_ip())
+                node_id = reservation.get_graph_node_id()
+                if node_id and sliver.attached_components_info:
                     components = []
-                    for interface in sliver.interface_info.interfaces.values():
-                        graph_id_node_id_component_id, bqm_if_name = interface.get_node_map()
-                        if ":" in graph_id_node_id_component_id or "#" in graph_id_node_id_component_id:
-                            if "#" in graph_id_node_id_component_id:
-                                split_string = graph_id_node_id_component_id.split("#")
-                            else:
-                                split_string = graph_id_node_id_component_id.split(":")
-                            node_id = split_string[1] if len(split_string) > 1 else None
-                            comp_id = split_string[2] if len(split_string) > 2 else None
-                            bdf = ":".join(split_string[3:]) if len(split_string) > 3 else None
-                            if node_id and comp_id and bdf:
-                                components.append((node_id, comp_id, bdf))
+                    for c in sliver.attached_components_info.devices.values():
+                        if c.get_node_map():
+                            bqm_id, comp_id = c.get_node_map()
+                            if c.labels and c.labels.bdf:
+                                bdf = c.labels.bdf
+                                if isinstance(c.labels.bdf, str):
+                                    bdf = [c.labels.bdf]
+                                for x in bdf:
+                                    components.append((node_id, comp_id, x))
 
-                    if sliver.ero and sliver.capacities:
-                        type, path = sliver.ero.get()
-                        if path and len(path.get()):
-                            for hop in path.get()[0]:
-                                if hop.startswith('link:'):
-                                    links.append({"node_id": hop,
-                                                  "bw": sliver.capacities.bw})
-                elif isinstance(sliver, NodeSliver):
-                    site = sliver.get_site()
-
-                    if sliver.get_labels() and sliver.get_labels().instance_parent:
-                        host = sliver.get_labels().instance_parent
-                    if sliver.get_label_allocations() and sliver.get_label_allocations().instance_parent:
-                        host = sliver.get_label_allocations().instance_parent
-                    if sliver.get_management_ip():
-                        ip_subnet = str(sliver.get_management_ip())
-                    node_id = reservation.get_graph_node_id()
-                    if node_id and sliver.attached_components_info:
-                        components = []
-                        for c in sliver.attached_components_info.devices.values():
-                            if c.get_node_map():
-                                bqm_id, comp_id = c.get_node_map()
-                                if c.labels and c.labels.bdf:
-                                    bdf = c.labels.bdf
-                                    if isinstance(c.labels.bdf, str):
-                                        bdf = [c.labels.bdf]
-                                    for x in bdf:
-                                        components.append((node_id, comp_id, x))
-
-            term = reservation.get_term()
-            begin = time.time()
-            properties = pickle.dumps(reservation)
-            diff = int(time.time() - begin)
-            if diff > 0:
-                self.logger.info(f"PICKLE TIME: {diff}")
-            begin = time.time()
-            self.db.update_reservation(slc_guid=str(reservation.get_slice_id()),
-                                       rsv_resid=str(reservation.get_reservation_id()),
-                                       rsv_category=reservation.get_category().value,
-                                       rsv_state=reservation.get_state().value,
-                                       rsv_pending=reservation.get_pending_state().value,
-                                       rsv_joining=reservation.get_join_state().value,
-                                       properties=properties,
-                                       rsv_graph_node_id=reservation.get_graph_node_id(),
-                                       site=site, rsv_type=rsv_type, components=components,
-                                       lease_start=term.get_start_time() if term else None,
-                                       lease_end=term.get_end_time() if term else None,
-                                       ip_subnet=ip_subnet, host=host, links=links,
-                                       closed_at=getattr(reservation, 'closed_at', None))
-            diff = int(time.time() - begin)
-            if diff > 0:
-                self.logger.info(f"DB TIME: {diff}")
-        finally:
-            if self.lock.locked():
-                self.lock.release()
+        term = reservation.get_term()
+        begin = time.time()
+        properties = pickle.dumps(reservation)
+        diff = int(time.time() - begin)
+        if diff > 0:
+            self.logger.info(f"PICKLE TIME: {diff}")
+        begin = time.time()
+        self.db.update_reservation(slc_guid=str(reservation.get_slice_id()),
+                                   rsv_resid=str(reservation.get_reservation_id()),
+                                   rsv_category=reservation.get_category().value,
+                                   rsv_state=reservation.get_state().value,
+                                   rsv_pending=reservation.get_pending_state().value,
+                                   rsv_joining=reservation.get_join_state().value,
+                                   properties=properties,
+                                   rsv_graph_node_id=reservation.get_graph_node_id(),
+                                   site=site, rsv_type=rsv_type, components=components,
+                                   lease_start=term.get_start_time() if term else None,
+                                   lease_end=term.get_end_time() if term else None,
+                                   ip_subnet=ip_subnet, host=host, links=links,
+                                   closed_at=getattr(reservation, 'closed_at', None))
+        diff = int(time.time() - begin)
+        if diff > 0:
+            self.logger.info(f"DB TIME: {diff}")
 
     def remove_reservation(self, *, rid: ID):
+        self.logger.debug("Removing reservation {}".format(rid))
         try:
-            #self.lock.acquire()
-            self.logger.debug("Removing reservation {}".format(rid))
-            try:
-                self.db.remove_unit(unt_uid=str(rid))
-            except Exception as e:
-                self.logger.debug("No associated Unit associated with the reservation")
-            self.db.remove_reservation(rsv_resid=str(rid))
-        finally:
-            if self.lock.locked():
-                self.lock.release()
+            self.db.remove_unit(unt_uid=str(rid))
+        except Exception as e:
+            self.logger.debug("No associated Unit associated with the reservation")
+        self.db.remove_reservation(rsv_resid=str(rid))
 
     def _load_reservation_from_pickled_object(self, pickled_res: bytes, slc_id: int) -> ABCReservationMixin or None:
         try:
@@ -546,66 +491,42 @@ class ActorDatabase(ABCDatabase):
     def get_client_reservations(self, *, slice_id: ID = None) -> List[ABCReservationMixin]:
         result = []
         try:
-            #self.lock.acquire()
             sid = str(slice_id) if slice_id is not None else None
             res_dict_list = self.db.get_reservations(slice_id=sid,
                                                      category=[ReservationCategory.Broker.value,
                                                                ReservationCategory.Authority.value])
-            if self.lock.locked():
-                self.lock.release()
             result = self._load_reservations_from_db(res_dict_list=res_dict_list)
         except Exception as e:
             self.logger.error(e)
-        finally:
-            if self.lock.locked():
-                self.lock.release()
         return result
 
     def get_holdings(self, *, slice_id: ID = None) -> List[ABCReservationMixin]:
         result = []
         try:
-            #self.lock.acquire()
             sid = str(slice_id) if slice_id is not None else None
             res_dict_list = self.db.get_reservations(slice_id=sid, category=[ReservationCategory.Client.value])
-            if self.lock.locked():
-                self.lock.release()
             result = self._load_reservations_from_db(res_dict_list=res_dict_list)
         except Exception as e:
             self.logger.error(e)
-        finally:
-            if self.lock.locked():
-                self.lock.release()
         return result
 
     def get_broker_reservations(self) -> List[ABCReservationMixin]:
         result = []
         try:
-            #self.lock.acquire()
             res_dict_list = self.db.get_reservations(category=[ReservationCategory.Broker.value])
-            if self.lock.locked():
-                self.lock.release()
             result = self._load_reservations_from_db(res_dict_list=res_dict_list)
         except Exception as e:
             self.logger.error(e)
-        finally:
-            if self.lock.locked():
-                self.lock.release()
         return result
 
     def get_authority_reservations(self) -> List[ABCReservationMixin]:
         result = []
         try:
-            #self.lock.acquire()
             result = []
             res_dict_list = self.db.get_reservations(category=[ReservationCategory.Authority.value])
-            if self.lock.locked():
-                self.lock.release()
             result = self._load_reservations_from_db(res_dict_list=res_dict_list)
         except Exception as e:
             self.logger.error(e)
-        finally:
-            if self.lock.locked():
-                self.lock.release()
         return result
 
     def get_components(self, *, node_id: str, states: list[int], rsv_type: list[str], component: str = None,
@@ -616,9 +537,6 @@ class ActorDatabase(ABCDatabase):
                                           rsv_type=rsv_type, start=start, end=end, excludes=excludes)
         except Exception as e:
             self.logger.error(e)
-        finally:
-            if self.lock.locked():
-                self.lock.release()
 
     def get_links(self, *, node_id: str, states: list[int], rsv_type: list[str], start: datetime = None,
                   end: datetime = None, excludes: List[str] = None) -> Dict[str, int]:
@@ -627,9 +545,6 @@ class ActorDatabase(ABCDatabase):
                                      end=end, excludes=excludes)
         except Exception as e:
             self.logger.error(e)
-        finally:
-            if self.lock.locked():
-                self.lock.release()
 
     def get_link_allocations(self, *, states: list[int], rsv_type: list[str],
                              start: datetime = None, end: datetime = None) -> list[dict]:
@@ -637,9 +552,6 @@ class ActorDatabase(ABCDatabase):
             return self.db.get_link_allocations(states=states, rsv_type=rsv_type, start=start, end=end)
         except Exception as e:
             self.logger.error(e)
-        finally:
-            if self.lock.locked():
-                self.lock.release()
         return []
 
     def get_component_allocations(self, *, states: list[int],
@@ -648,9 +560,6 @@ class ActorDatabase(ABCDatabase):
             return self.db.get_component_allocations(states=states, start=start, end=end)
         except Exception as e:
             self.logger.error(e)
-        finally:
-            if self.lock.locked():
-                self.lock.release()
         return []
 
     def get_reservations(self, *, slice_id: ID = None, graph_node_id: str = None, project_id: str = None,
@@ -659,72 +568,44 @@ class ActorDatabase(ABCDatabase):
                          end: datetime = None, ip_subnet: str = None, host: str = None) -> List[ABCReservationMixin]:
         result = []
         try:
-            #self.lock.acquire()
             sid = str(slice_id) if slice_id is not None else None
             res_id = str(rid) if rid is not None else None
             res_dict_list = self.db.get_reservations(slice_id=sid, graph_node_id=graph_node_id, host=host, ip_subnet=ip_subnet,
                                                      project_id=project_id, email=email, oidc_sub=oidc_sub, rid=res_id,
                                                      states=states, site=site, rsv_type=rsv_type, start=start, end=end)
-            if self.lock.locked():
-               self.lock.release()
             result = self._load_reservations_from_db(res_dict_list=res_dict_list)
         except Exception as e:
             self.logger.error(e)
-        finally:
-            if self.lock.locked():
-                self.lock.release()
         return result
 
     def get_reservations_by_rids(self, *, rid: List[str]) -> List[ABCReservationMixin]:
         result = []
         try:
-            #self.lock.acquire()
             res_dict_list = self.db.get_reservations_by_rids(rsv_resid_list=rid)
-            if self.lock.locked():
-                self.lock.release()
             result = self._load_reservations_from_db(res_dict_list=res_dict_list)
         except Exception as e:
             self.logger.error(e)
-        finally:
-            if self.lock.locked():
-                self.lock.release()
         return result
 
     def add_broker(self, *, broker: ABCBrokerProxy):
-        try:
-            #self.lock.acquire()
-            self.logger.debug("Adding broker {}({})".format(broker.get_name(), broker.get_guid()))
-            properties = pickle.dumps(broker)
-            self.db.add_proxy(act_id=self.actor_id, prx_name=broker.get_name(), properties=properties)
-        finally:
-            if self.lock.locked():
-                self.lock.release()
+        self.logger.debug("Adding broker {}({})".format(broker.get_name(), broker.get_guid()))
+        properties = pickle.dumps(broker)
+        self.db.add_proxy(act_id=self.actor_id, prx_name=broker.get_name(), properties=properties)
 
     def update_broker(self, *, broker: ABCBrokerProxy):
-        try:
-            #self.lock.acquire()
-            self.logger.debug("Updating broker {}({})".format(broker.get_name(), broker.get_guid()))
-            properties = pickle.dumps(broker)
-            self.db.update_proxy(act_id=self.actor_id, prx_name=broker.get_name(), properties=properties)
-        finally:
-            if self.lock.locked():
-                self.lock.release()
+        self.logger.debug("Updating broker {}({})".format(broker.get_name(), broker.get_guid()))
+        properties = pickle.dumps(broker)
+        self.db.update_proxy(act_id=self.actor_id, prx_name=broker.get_name(), properties=properties)
 
     def remove_broker(self, *, broker: ABCBrokerProxy):
-        try:
-            #self.lock.acquire()
-            self.logger.debug("Removing broker {}({})".format(broker.get_name(), broker.get_guid()))
-            self.db.remove_proxy(act_id=self.actor_id, prx_name=broker.get_name())
-        finally:
-            if self.lock.locked():
-                self.lock.release()
+        self.logger.debug("Removing broker {}({})".format(broker.get_name(), broker.get_guid()))
+        self.db.remove_proxy(act_id=self.actor_id, prx_name=broker.get_name())
 
     def set_actor_name(self, *, name: str):
         self.actor_name = name
 
     def get_brokers(self) -> List[ABCBrokerProxy] or None:
         try:
-            #self.lock.acquire()
             result = []
             broker_dict_list = self.db.get_proxies(act_id=self.actor_id)
             if broker_dict_list is not None:
@@ -736,55 +617,37 @@ class ActorDatabase(ABCDatabase):
         except Exception as e:
             self.logger.error(e)
             self.logger.error(traceback.format_exc())
-        finally:
-            if self.lock.locked():
-                self.lock.release()
         return None
 
     def add_delegation(self, *, delegation: ABCDelegation):
         self.logger.debug("Adding delegation {} to slice {}".format(delegation.get_delegation_id(),
                                                                     delegation.get_slice_id()))
-        try:
-            #self.lock.acquire()
-            properties = pickle.dumps(delegation)
-            self.db.add_delegation(slice_id=str(delegation.get_slice_id()),
-                                   dlg_graph_id=str(delegation.get_delegation_id()),
-                                   dlg_state=delegation.get_state().value,
-                                   properties=properties,
-                                   site=delegation.get_site())
-            self.logger.debug(
-                "Delegation {} added to slice {}".format(delegation.get_delegation_id(),
-                                                         delegation.get_slice_id()))
-        finally:
-            if self.lock.locked():
-                self.lock.release()
+        properties = pickle.dumps(delegation)
+        self.db.add_delegation(slice_id=str(delegation.get_slice_id()),
+                               dlg_graph_id=str(delegation.get_delegation_id()),
+                               dlg_state=delegation.get_state().value,
+                               properties=properties,
+                               site=delegation.get_site())
+        self.logger.debug(
+            "Delegation {} added to slice {}".format(delegation.get_delegation_id(),
+                                                     delegation.get_slice_id()))
 
     def update_delegation(self, *, delegation: ABCDelegation):
         # Update the delegation only when there are changes to be reflected in database
         if not delegation.is_dirty():
             return
         delegation.clear_dirty()
-        try:
-            #self.lock.acquire()
-            self.logger.debug("Updating delegation {} in slice {}".format(delegation.get_delegation_id(),
-                                                                          delegation.get_slice_id()))
-            properties = pickle.dumps(delegation)
-            self.db.update_delegation(dlg_graph_id=str(delegation.get_delegation_id()),
-                                      dlg_state=delegation.get_state().value,
-                                      properties=properties,
-                                      site=delegation.get_site())
-        finally:
-            if self.lock.locked():
-                self.lock.release()
+        self.logger.debug("Updating delegation {} in slice {}".format(delegation.get_delegation_id(),
+                                                                      delegation.get_slice_id()))
+        properties = pickle.dumps(delegation)
+        self.db.update_delegation(dlg_graph_id=str(delegation.get_delegation_id()),
+                                  dlg_state=delegation.get_state().value,
+                                  properties=properties,
+                                  site=delegation.get_site())
 
     def remove_delegation(self, *, dlg_graph_id: str):
-        try:
-            #self.lock.acquire()
-            self.logger.debug("Removing delegation {}".format(dlg_graph_id))
-            self.db.remove_delegation(dlg_graph_id=str(dlg_graph_id))
-        finally:
-            if self.lock.locked():
-                self.lock.release()
+        self.logger.debug("Removing delegation {}".format(dlg_graph_id))
+        self.db.remove_delegation(dlg_graph_id=str(dlg_graph_id))
 
     def _load_delegation_from_pickled_instance(self, pickled_del: bytes, slc_id: int) -> ABCDelegation:
         slice_obj = self.get_slice_by_id(slc_id=slc_id)
@@ -807,32 +670,20 @@ class ActorDatabase(ABCDatabase):
 
     def get_delegation(self, *, dlg_graph_id: str) -> ABCDelegation or None:
         try:
-            #self.lock.acquire()
             dlg_dict = self.db.get_delegation(dlg_graph_id=str(dlg_graph_id))
-            if self.lock.locked():
-                self.lock.release()
             return self._load_delegation_from_db(dlg_dict_list=[dlg_dict])[0]
         except Exception as e:
             self.logger.error(e)
-        finally:
-            if self.lock.locked():
-                self.lock.release()
         return None
 
     def get_delegations(self, *, slice_id: ID = None, states: List[int] = None) -> List[ABCDelegation]:
         result = []
         try:
-            #self.lock.acquire()
             sid = str(slice_id) if slice_id is not None else None
             dlg_dict_list = self.db.get_delegations(slc_guid=sid, states=states)
-            if self.lock.locked():
-                self.lock.release()
             result = self._load_delegation_from_db(dlg_dict_list=dlg_dict_list)
         except Exception as e:
             self.logger.error(e)
-        finally:
-            if self.lock.locked():
-                self.lock.release()
         return result
 
     def add_maintenance_properties(self, *, properties: dict):
@@ -869,33 +720,18 @@ class ActorDatabase(ABCDatabase):
 
     def add_site(self, *, site: Site):
         self.logger.debug(f"Adding site {site.get_name()}")
-        try:
-            #self.lock.acquire()
-            properties = pickle.dumps(site)
-            self.db.add_site(site_name=site.get_name(), state=site.get_state().value, properties=properties)
-            self.logger.debug(f"Site {site.get_name()} added")
-        finally:
-            if self.lock.locked():
-                self.lock.release()
+        properties = pickle.dumps(site)
+        self.db.add_site(site_name=site.get_name(), state=site.get_state().value, properties=properties)
+        self.logger.debug(f"Site {site.get_name()} added")
 
     def update_site(self, *, site: Site):
-        try:
-            #self.lock.acquire()
-            self.logger.debug(f"Updating site {site.get_name()}")
-            properties = pickle.dumps(site)
-            self.db.update_site(site_name=site.get_name(), state=site.get_state().value, properties=properties)
-        finally:
-            if self.lock.locked():
-                self.lock.release()
+        self.logger.debug(f"Updating site {site.get_name()}")
+        properties = pickle.dumps(site)
+        self.db.update_site(site_name=site.get_name(), state=site.get_state().value, properties=properties)
 
     def remove_site(self, *, site_name: str):
-        try:
-            #self.lock.acquire()
-            self.logger.debug(f"Removing site {site_name}")
-            self.db.remove_site(site_name=site_name)
-        finally:
-            if self.lock.locked():
-                self.lock.release()
+        self.logger.debug(f"Removing site {site_name}")
+        self.db.remove_site(site_name=site_name)
 
     def _load_site_from_db(self, site_list: List[dict]) -> List[Site]:
         result = []
@@ -911,60 +747,40 @@ class ActorDatabase(ABCDatabase):
 
     def get_site(self, *, site_name: str) -> Site or None:
         try:
-            #self.lock.acquire()
             site_list = self.db.get_site(site_name=site_name)
-            if self.lock.locked():
-                self.lock.release()
             if site_list is not None and len(site_list) > 0:
                 return self._load_site_from_db(site_list=site_list)[0]
         except Exception as e:
             self.logger.error(e)
             self.logger.error(traceback.format_exc())
-        finally:
-            if self.lock.locked():
-                self.lock.release()
         return None
 
     def get_sites(self) -> List[Site]:
         result = []
         try:
-            #self.lock.acquire()
             site_list = self.db.get_sites()
-            if self.lock.locked():
-                self.lock.release()
             result = self._load_site_from_db(site_list=site_list)
         except Exception as e:
             self.logger.error(e)
-        finally:
-            if self.lock.locked():
-                self.lock.release()
         return result
 
     def add_config_mapping(self, key: str, config_mapping: ConfigurationMapping):
         try:
-            #self.lock.acquire()
             properties = pickle.dumps(config_mapping)
             self.db.add_config_mapping(cfgm_type=key, act_id=self.actor_id, properties=properties)
         except Exception as e:
             self.logger.error(e)
             self.logger.error(traceback.format_exc())
             raise e
-        finally:
-            if self.lock.locked():
-                self.lock.release()
 
     def get_config_mappings(self) -> List[ConfigurationMapping]:
         cfg_map_list = None
         result = []
         try:
-            #self.lock.acquire()
             cfg_map_list = self.db.get_config_mappings(act_id=self.actor_id)
         except Exception as e:
             self.logger.error(e)
             self.logger.error(traceback.format_exc())
-        finally:
-            if self.lock.locked():
-                self.lock.release()
         if cfg_map_list is not None:
             for c in cfg_map_list:
                 pickled_cfg_map = c.get(Constants.PROPERTY_PICKLE_PROPERTIES)
@@ -993,61 +809,40 @@ class ActorDatabase(ABCDatabase):
                  states: list[int] = None, include_res_info: bool = True) -> Union[List[Poa] or None]:
         result = []
         try:
-            try:
-                sliver_id_str = str(sliver_id) if sliver_id is not None else None
-                slice_id_str = str(slice_id) if slice_id is not None else None
+            sliver_id_str = str(sliver_id) if sliver_id is not None else None
+            slice_id_str = str(slice_id) if slice_id is not None else None
 
-                poa_dict_list = self.db.get_poas(poa_guid=poa_id, email=email, sliver_id=sliver_id_str, limit=limit,
-                                                 offset=offset, last_update_time=last_update_time,
-                                                 project_id=project_id, slice_id=slice_id_str, states=states)
-            finally:
-                if self.lock.locked():
-                    self.lock.release()
+            poa_dict_list = self.db.get_poas(poa_guid=poa_id, email=email, sliver_id=sliver_id_str, limit=limit,
+                                             offset=offset, last_update_time=last_update_time,
+                                             project_id=project_id, slice_id=slice_id_str, states=states)
             if poa_dict_list is not None:
                 result = self._load_poa_from_db(poa_dict_list=poa_dict_list, include_res_info=include_res_info)
         except Exception as e:
             self.logger.error(e)
             self.logger.error(traceback.format_exc())
-        finally:
-            if self.lock.locked():
-                self.lock.release()
         return result
 
     def add_poa(self, *, poa: Poa):
-        try:
-            poa_list = self.get_poas(poa_id=poa.poa_id)
-            if len(poa_list) > 0:
-                raise DatabaseException(f"POA # {poa.get_poa_id()} already exists")
+        poa_list = self.get_poas(poa_id=poa.poa_id)
+        if len(poa_list) > 0:
+            raise DatabaseException(f"POA # {poa.get_poa_id()} already exists")
 
-            properties = pickle.dumps(poa)
-            email = None
-            project_id = None
-            slice_id = None
-            if poa.get_slice().get_owner() is not None:
-                email = poa.get_slice().get_owner().get_email()
-                project_id = poa.get_slice().get_project_id()
-                slice_id = str(poa.get_slice().get_slice_id())
+        properties = pickle.dumps(poa)
+        email = None
+        project_id = None
+        slice_id = None
+        if poa.get_slice().get_owner() is not None:
+            email = poa.get_slice().get_owner().get_email()
+            project_id = poa.get_slice().get_project_id()
+            slice_id = str(poa.get_slice().get_slice_id())
 
-            self.db.add_poa(poa_guid=poa.get_poa_id(), sliver_id=str(poa.get_sliver_id()), email=email,
-                            project_id=project_id, slice_id=slice_id, properties=properties,
-                            state=poa.get_state().value)
-        finally:
-            if self.lock.locked():
-                self.lock.release()
+        self.db.add_poa(poa_guid=poa.get_poa_id(), sliver_id=str(poa.get_sliver_id()), email=email,
+                        project_id=project_id, slice_id=slice_id, properties=properties,
+                        state=poa.get_state().value)
 
     def update_poa(self, *, poa: Poa):
-        try:
-            #self.lock.acquire()
-            properties = pickle.dumps(poa)
-            self.db.update_poa(poa_guid=poa.poa_id, state=poa.get_state().value, properties=properties)
-        finally:
-            if self.lock.locked():
-                self.lock.release()
+        properties = pickle.dumps(poa)
+        self.db.update_poa(poa_guid=poa.poa_id, state=poa.get_state().value, properties=properties)
 
     def remove_poa(self, *, poa_id: str):
-        try:
-            #self.lock.acquire()
-            self.db.remove_poa(poa_guid=poa_id)
-        finally:
-            if self.lock.locked():
-                self.lock.release()
+        self.db.remove_poa(poa_guid=poa_id)

--- a/fabric_cf/actor/core/plugins/db/server_actor_database.py
+++ b/fabric_cf/actor/core/plugins/db/server_actor_database.py
@@ -35,51 +35,31 @@ from fabric_cf.actor.core.util.id import ID
 
 class ServerActorDatabase(ActorDatabase, ClientDatabase):
     def add_client(self, *, client: Client):
-        try:
-            #self.lock.acquire()
-            properties = pickle.dumps(client)
-            self.db.add_client(act_id=self.actor_id, clt_name=client.get_name(), clt_guid=str(client.get_guid()),
-                               properties=properties)
-        finally:
-            if self.lock.locked():
-                self.lock.release()
+        properties = pickle.dumps(client)
+        self.db.add_client(act_id=self.actor_id, clt_name=client.get_name(), clt_guid=str(client.get_guid()),
+                           properties=properties)
 
     def update_client(self, *, client: Client):
-        try:
-            #self.lock.acquire()
-            properties = pickle.dumps(client)
-            self.db.update_client(act_id=self.actor_id, clt_name=client.get_name(), properties=properties)
-        finally:
-            if self.lock.locked():
-                self.lock.release()
+        properties = pickle.dumps(client)
+        self.db.update_client(act_id=self.actor_id, clt_name=client.get_name(), properties=properties)
 
     def remove_client(self, *, guid: ID):
-        try:
-            #self.lock.acquire()
-            self.db.remove_client_by_guid(act_id=self.actor_id, clt_guid=str(guid))
-        finally:
-            if self.lock.locked():
-                self.lock.release()
+        self.db.remove_client_by_guid(act_id=self.actor_id, clt_guid=str(guid))
 
     def get_client(self, *, guid: ID) -> Client or None:
         result = None
         try:
-            #self.lock.acquire()
             client_dict = self.db.get_client_by_guid(clt_guid=str(guid))
             if client_dict is not None:
                 pickled_client = client_dict.get(Constants.PROPERTY_PICKLE_PROPERTIES)
                 return pickle.loads(pickled_client)
         except Exception as e:
             self.logger.error(e)
-        finally:
-            if self.lock.locked():
-                self.lock.release()
         return result
 
     def get_clients(self) -> List[Client]:
         result = None
         try:
-            #self.lock.acquire()
             result = []
             client_dict_list = self.db.get_clients()
             if client_dict_list is not None:
@@ -90,7 +70,4 @@ class ServerActorDatabase(ActorDatabase, ClientDatabase):
             return result
         except Exception as e:
             self.logger.error(e)
-        finally:
-            if self.lock.locked():
-                self.lock.release()
         return result

--- a/fabric_cf/actor/core/plugins/handlers/ansible_handler_processor.py
+++ b/fabric_cf/actor/core/plugins/handlers/ansible_handler_processor.py
@@ -117,31 +117,26 @@ class AnsibleHandlerProcessor(HandlerProcessor):
         Shutdown Process Pool, Future Processor
         """
         try:
-            self.lock.acquire()
-            self.executor.shutdown(wait=True)
-            self.stopped = True
-            for f, u in self.futures:
-                f.cancel()
+            with self.lock:
+                self.executor.shutdown(wait=True)
+                self.stopped = True
+                for f, u in self.futures:
+                    f.cancel()
 
-            temp = self.thread
-            self.thread = None
-            if temp is not None:
-                self.logger.warning("It seems that the future thread is running. Interrupting it")
-                try:
-                    with self.future_lock:
-                        self.future_lock.notify_all()
-                    temp.join()
-                except Exception as e:
-                    self.logger.error("Could not join future thread {}".format(e))
-                    self.logger.error(traceback.format_exc())
-                finally:
-                    self.lock.release()
+                temp = self.thread
+                self.thread = None
+                if temp is not None:
+                    self.logger.warning("It seems that the future thread is running. Interrupting it")
+                    try:
+                        with self.future_lock:
+                            self.future_lock.notify_all()
+                        temp.join()
+                    except Exception as e:
+                        self.logger.error("Could not join future thread {}".format(e))
+                        self.logger.error(traceback.format_exc())
         except Exception as e:
             self.logger.error(f"Exception occurred {e}")
             self.logger.error(traceback.format_exc())
-        finally:
-            if self.lock.locked():
-                self.lock.release()
 
     def set_logger(self, *, logger):
         self.logger = logger

--- a/fabric_cf/actor/core/plugins/substrate/db/substrate_actor_database.py
+++ b/fabric_cf/actor/core/plugins/substrate/db/substrate_actor_database.py
@@ -49,35 +49,29 @@ class SubstrateActorDatabase(ServerActorDatabase, ABCSubstrateDatabase):
         return result
 
     def add_unit(self, *, u: Unit):
-        try:
-            if u.get_resource_type() is None:
-                raise DatabaseException(Constants.INVALID_ARGUMENT)
-            #self.lock.acquire()
-            if self.get_unit(uid=u.get_id()) is not None:
-                self.logger.info("unit {} is already present in database".format(u.get_id()))
-                return
+        if u.get_resource_type() is None:
+            raise DatabaseException(Constants.INVALID_ARGUMENT)
+        if self.get_unit(uid=u.get_id()) is not None:
+            self.logger.info("unit {} is already present in database".format(u.get_id()))
+            return
 
-            slice_id = str(u.get_slice_id())
-            parent = None
-            if u.get_parent_id() is not None:
-                parent = self.get_unit(uid=u.get_parent_id())
-            parent_id = None
-            if parent is not None:
-                parent_id = parent['unt_id']
-            res_id = str(u.get_reservation_id())
+        slice_id = str(u.get_slice_id())
+        parent = None
+        if u.get_parent_id() is not None:
+            parent = self.get_unit(uid=u.get_parent_id())
+        parent_id = None
+        if parent is not None:
+            parent_id = parent['unt_id']
+        res_id = str(u.get_reservation_id())
 
-            properties = pickle.dumps(u)
-            self.db.add_unit(slc_guid=slice_id, rsv_resid=res_id,
-                             unt_uid=str(u.get_id()), unt_unt_id=parent_id,
-                             unt_state=u.get_state().value, properties=properties)
-        finally:
-            if self.lock.locked():
-                self.lock.release()
+        properties = pickle.dumps(u)
+        self.db.add_unit(slc_guid=slice_id, rsv_resid=res_id,
+                         unt_uid=str(u.get_id()), unt_unt_id=parent_id,
+                         unt_state=u.get_state().value, properties=properties)
 
     def get_units(self, *, rid: ID):
         result = None
         try:
-            #self.lock.acquire()
             result = []
             unit_dict_list = self.db.get_units(rsv_resid=str(rid))
             if unit_dict_list is not None:
@@ -88,24 +82,11 @@ class SubstrateActorDatabase(ServerActorDatabase, ABCSubstrateDatabase):
             return result
         except Exception as e:
             self.logger.error(e)
-        finally:
-            if self.lock.locked():
-                self.lock.release()
         return result
 
     def remove_unit(self, *, uid: ID):
-        try:
-            #self.lock.acquire()
-            self.db.remove_unit(unt_uid=str(uid))
-        finally:
-            if self.lock.locked():
-                self.lock.release()
+        self.db.remove_unit(unt_uid=str(uid))
 
     def update_unit(self, *, u: Unit):
-        try:
-            #self.lock.acquire()
-            properties = pickle.dumps(u)
-            self.db.update_unit(unt_uid=str(u.get_id()), properties=properties)
-        finally:
-            if self.lock.locked():
-                self.lock.release()
+        properties = pickle.dumps(u)
+        self.db.update_unit(unt_uid=str(u.get_id()), properties=properties)

--- a/fabric_cf/actor/fim/asm_update_thread.py
+++ b/fabric_cf/actor/fim/asm_update_thread.py
@@ -107,8 +107,7 @@ class AsmUpdateThread:
 
     def stop(self):
         self.shutdown = True
-        try:
-            self.thread_lock.acquire()
+        with self.thread_lock:
             temp = self.thread
             self.thread = None
             if temp is not None:
@@ -117,11 +116,6 @@ class AsmUpdateThread:
                     temp.join()
                 except Exception as e:
                     self.logger.error(f"Could not join {self.name} thread {e}")
-                finally:
-                    self.thread_lock.release()
-        finally:
-            if self.thread_lock is not None and self.thread_lock.locked():
-                self.thread_lock.release()
 
     def enqueue(self, *, graph_id: str, sliver: BaseSliver, rid: str, reservation_state: str,
                 error_message: str):

--- a/fabric_cf/orchestrator/core/advance_scheduling_thread.py
+++ b/fabric_cf/orchestrator/core/advance_scheduling_thread.py
@@ -92,8 +92,7 @@ class AdvanceSchedulingThread:
         :return:
         """
         self.stopped = True
-        try:
-            self.thread_lock.acquire()
+        with self.thread_lock:
             temp = self.thread
             self.thread = None
             if temp is not None:
@@ -106,11 +105,6 @@ class AdvanceSchedulingThread:
                     temp.join()
                 except Exception as e:
                     self.logger.error(f"Could not join {self.__class__.__name__} thread {e}")
-                finally:
-                    self.thread_lock.release()
-        finally:
-            if self.thread_lock is not None and self.thread_lock.locked():
-                self.thread_lock.release()
 
     def run(self):
         """

--- a/fabric_cf/orchestrator/core/orchestrator_slice_wrapper.py
+++ b/fabric_cf/orchestrator/core/orchestrator_slice_wrapper.py
@@ -79,7 +79,7 @@ class OrchestratorSliceWrapper:
         self.computed_remove_reservations = []
         # Reservations trigger ModifyLease (AM)
         self.computed_modify_properties_reservations = []
-        self.thread_lock = threading.Lock()
+        self.thread_lock = threading.RLock()
         self.start = None
         self.end = None
         self.lifetime = None
@@ -96,8 +96,12 @@ class OrchestratorSliceWrapper:
         Unlock slice
         :return:
         """
-        if self.thread_lock.locked():
+        try:
             self.thread_lock.release()
+        except RuntimeError:
+            # RLock.release() raises if this thread does not hold the lock
+            # (or it is not held at all); treat unlock() as a safe no-op then.
+            pass
 
     def get_computed_reservations(self) -> List[TicketReservationAvro]:
         """

--- a/fabric_cf/orchestrator/core/reservation_status_update_thread.py
+++ b/fabric_cf/orchestrator/core/reservation_status_update_thread.py
@@ -85,8 +85,7 @@ class ReservationStatusUpdateThread:
         """
         self.stopped = True
         self.stopped_worker.set()
-        try:
-            self.thread_lock.acquire()
+        with self.thread_lock:
             temp = self.thread
             self.thread = None
             if temp is not None:
@@ -95,11 +94,6 @@ class ReservationStatusUpdateThread:
                     temp.join()
                 except Exception as e:
                     self.logger.error("Could not join ReservationStatusUpdateThread thread {}".format(e))
-                finally:
-                    self.thread_lock.release()
-        finally:
-            if self.thread_lock is not None and self.thread_lock.locked():
-                self.thread_lock.release()
 
     def periodic(self):
         """

--- a/fabric_cf/orchestrator/core/slice_defer_thread.py
+++ b/fabric_cf/orchestrator/core/slice_defer_thread.py
@@ -95,8 +95,7 @@ class SliceDeferThread:
         :return:
         """
         self.stopped = True
-        try:
-            self.thread_lock.acquire()
+        with self.thread_lock:
             temp = self.thread
             self.thread = None
             if temp is not None:
@@ -108,11 +107,6 @@ class SliceDeferThread:
                     temp.join()
                 except Exception as e:
                     self.logger.error(f"Could not join SliceDeferThread thread {e}")
-                finally:
-                    self.thread_lock.release()
-        finally:
-            if self.thread_lock is not None and self.thread_lock.locked():
-                self.thread_lock.release()
 
     def run(self):
         """


### PR DESCRIPTION
## Summary

`threading.Lock` has no ownership concept, and `Lock.locked()` reports whether **any** thread holds the lock. The pervasive idiom

```python
if lock.locked():
    lock.release()
```

can therefore release a lock held by a **different** thread, silently destroying mutual exclusion (or raising `RuntimeError: release unlocked lock`). This removes every occurrence (~90 sites across 18 files), with the fix chosen per how each site actually uses its lock.

## Changes by pattern

- **Domain objects with `lock()`/`unlock()` pairs** (`reservation.py`, `slice.py`, `delegation.py`, `orchestrator_slice_wrapper.py`, `kernel.py`): backing lock switched to `RLock` (owner-aware); `unlock()` now does an ownership-safe `release()` wrapped in `try/except RuntimeError`, so a non-owner or unpaired `unlock()` is a safe no-op instead of releasing another thread's lock.
- **Thread `stop()`/`shutdown()` methods** (8 thread classes + `event_processor`, `ansible_handler_processor`): the manual `acquire()` + double-`finally` release replaced with a single `with self.thread_lock:` block — released exactly once, by the owning thread.
- **DB layer** (`actor_database`, `server_actor_database`, `substrate_actor_database`): the lock was disabled (all `acquire()` commented out) except in `increment_metrics`, so the dead `finally: if self.lock.locked(): self.lock.release()` blocks could release the lock `increment_metrics` legitimately held. Dead boilerplate removed; `increment_metrics` moved to `with self.lock:`.

## Verification

- No query/SQL/return-value/behavior changes; the DB edits are pure lock-boilerplate removal.
- `python -m compileall fabric_cf` passes; zero `.locked()` calls remain.

## Out of scope (separate findings, behavior preserved here)

- `event_processor.stop()` still doesn't notify its condition before `join()` (deadlock finding).
- `ansible_handler_processor.shutdown()` still holds its lock across `executor.shutdown(wait=True)`/`join()`.