### PR TITLE
Add timeouts to outbound HTTP calls; harden PDP client

### DIFF
--- a/fabric_cf/actor/security/pdp_auth.py
+++ b/fabric_cf/actor/security/pdp_auth.py
@@ -90,9 +90,15 @@ class PdpAuth:
     Responsible for Authorization against PDP
     """
 
+    # (connect, read) timeout in seconds for the outbound PDP call. Kept short so a
+    # hung/slow AuthZForce PDP cannot stall the calling actor thread indefinitely.
+    DEFAULT_TIMEOUT = (3, 10)
+
     def __init__(self, *, config: dict, logger=None):
         self.config = config
-        self.logger = logger
+        # Default to a module logger so every code path (including the "PDP disabled"
+        # fast path and error handlers) can log without dereferencing a None logger.
+        self.logger = logger if logger is not None else logging.getLogger(__name__)
 
     @staticmethod
     def _headers() -> dict:
@@ -168,7 +174,8 @@ class PdpAuth:
 
         # send request to PDP
         try:
-            response = requests.post(url=self.config['url'], headers=self._headers(), json=pdp_request)
+            response = requests.post(url=self.config['url'], headers=self._headers(), json=pdp_request,
+                                     timeout=self.config.get('timeout', self.DEFAULT_TIMEOUT))
 
             try:
                 response_json = response.json()

--- a/fabric_cf/aits/orchestrator_helper.py
+++ b/fabric_cf/aits/orchestrator_helper.py
@@ -38,6 +38,8 @@ class Status(enum.Enum):
 
 class OrchestratorHelper:
     HTTP_OK = 200
+    # (connect, read) timeout in seconds so helper calls cannot hang indefinitely.
+    HTTP_TIMEOUT = (10, 60)
     PROP_DATA = "data"
     PROP_SLIVERS = "slivers"
     PROP_SLICES = "slices"
@@ -58,12 +60,12 @@ class OrchestratorHelper:
 
     def resources(self, level: int = 1):
         url = f"{self.host}/resources?level={level}&force_refresh=true"
-        return requests.get(url, headers=self.headers, verify=False)
+        return requests.get(url, headers=self.headers, verify=False, timeout=self.HTTP_TIMEOUT)
 
     def portal_resources(self, graph_format: GraphFormat = GraphFormat.JSON_NODELINK):
         url = f"{self.host}/portalresources?graph_format={graph_format.name}"
         headers = {'accept': 'application/json'}
-        return requests.get(url, headers=headers, verify=False)
+        return requests.get(url, headers=headers, verify=False, timeout=self.HTTP_TIMEOUT)
 
     def create(self, slice_graph: str, slice_name: str,
                lease_end_time: str = None) -> Tuple[Status, Union[list, requests.Response]]:
@@ -71,7 +73,8 @@ class OrchestratorHelper:
             url = f"{self.host}/slices/create?name={slice_name}&ssh_key={self.ssh_key}"
         else:
             url = f"{self.host}/slices/create?name={slice_name}&ssh_key={self.ssh_key}&lease_end_time={lease_end_time}"
-        response = requests.post(url, headers=self.headers_with_content, verify=False, data=slice_graph)
+        response = requests.post(url, headers=self.headers_with_content, verify=False, data=slice_graph,
+                                 timeout=self.HTTP_TIMEOUT)
         if response.status_code == self.HTTP_OK:
             reservations = response.json()[self.PROP_DATA]
             return Status.OK, reservations
@@ -80,7 +83,7 @@ class OrchestratorHelper:
 
     def delete(self, slice_id: str) -> Tuple[Status, requests.Response]:
         url = f"{self.host}/slices/delete/{slice_id}"
-        response = requests.delete(url, headers=self.headers, verify=False)
+        response = requests.delete(url, headers=self.headers, verify=False, timeout=self.HTTP_TIMEOUT)
         if response.status_code == self.HTTP_OK:
             return Status.OK, response
         else:
@@ -92,7 +95,7 @@ class OrchestratorHelper:
         if slice_id is not None:
             url = f"{self.host}/slices/{slice_id}?graph_format=GRAPHML"
 
-        response = requests.get(url, headers=self.headers, verify=False)
+        response = requests.get(url, headers=self.headers, verify=False, timeout=self.HTTP_TIMEOUT)
         if response.status_code == self.HTTP_OK:
             slices = response.json()[self.PROP_DATA]
             return Status.OK, slices
@@ -104,7 +107,7 @@ class OrchestratorHelper:
         if sliver_id is not None:
             url = f"{self.host}/slivers/{sliver_id}?slice_id={slice_id}"
 
-        response = requests.get(url, headers=self.headers, verify=False)
+        response = requests.get(url, headers=self.headers, verify=False, timeout=self.HTTP_TIMEOUT)
         if response.status_code == self.HTTP_OK:
             reservations = response.json()[self.PROP_DATA]
             return Status.OK, reservations
@@ -123,7 +126,7 @@ class OrchestratorHelper:
         try:
             # Set the tokens
             url = f"{self.host}/slices/renew/{slice_id}?new_lease_end_time={new_lease_end_time}"
-            response = requests.post(url, headers=self.headers, verify=False)
+            response = requests.post(url, headers=self.headers, verify=False, timeout=self.HTTP_TIMEOUT)
             if response.status_code != self.HTTP_OK:
                 return Status.FAILURE, response
 


### PR DESCRIPTION
## Summary

Outbound `requests.*` calls had **no timeout**, so a hung or slow peer could block the calling thread indefinitely. In `pdp_auth` this happens on the authorization path, stalling the actor thread (and, in the kernel event loop, slice operations container-wide).

## Changes

- **`fabric_cf/actor/security/pdp_auth.py`**
  - Add a `(connect, read)` timeout to the PDP `POST`, overridable via the `timeout` config key (default `(3, 10)`).
  - Default `self.logger` to a module logger when `logger=None`, so the "PDP disabled" fast path and the error handlers can no longer crash with `AttributeError` on a `None` logger.
- **`fabric_cf/aits/orchestrator_helper.py`**
  - Add a class-level `HTTP_TIMEOUT = (10, 60)` and apply it to all helper calls.

## Verification

- `python -m compileall` passes; no `requests.*` call in `fabric_cf` lacks a `timeout` anymore.
- No behavior change on the success path; only bounds the wait on a stalled peer.

Targets `rel-2.0.1` (theme 4 of the improvement sweep). Related: verifying NSO/status handling in AMHandlers is a separate PR.
