### PR TITLE
Add CI workflow and infra-free unit-test tier

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,53 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main, rel-2.0.1]
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  unit:
+    name: Unit tests (Python ${{ matrix.python-version }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ['3.12', '3.13']
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install package and pytest
+        run: |
+          python -m pip install --upgrade pip
+          # Install the package (runtime deps) plus pytest. We intentionally do
+          # not use the [test] extra, which still pins the unmaintained 'nose'.
+          pip install . pytest
+
+      - name: Byte-compile the whole package (syntax check)
+        run: python -m compileall fabric_cf
+
+      - name: Run unit tests (no infrastructure required)
+        run: pytest fabric_cf/actor/test/unit -v -p no:randomly -m "not integration"
+
+  pip-audit:
+    name: Dependency vulnerability audit (advisory)
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+      - name: Run pip-audit
+        run: |
+          python -m pip install --upgrade pip pip-audit
+          pip-audit --progress-spinner off || true

--- a/fabric_cf/actor/test/unit/__init__.py
+++ b/fabric_cf/actor/test/unit/__init__.py
@@ -1,0 +1,6 @@
+# Unit-test tier: fast, self-contained tests that mock all external
+# dependencies (HTTP/PDP, database, Kafka, Neo4j) and require NO running
+# infrastructure. These are the tests run in CI on every pull request.
+#
+# Infrastructure-dependent tests live elsewhere under fabric_cf/actor/test and
+# should be marked with @pytest.mark.integration so CI can exclude them.

--- a/fabric_cf/actor/test/unit/test_pdp_auth.py
+++ b/fabric_cf/actor/test/unit/test_pdp_auth.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+# MIT License
+#
+# Copyright (c) 2020 FABRIC Testbed
+#
+# Author: Komal Thareja (kthare10@renci.org)
+"""
+Unit tests for PdpAuth.check_access — the PDP authorization path.
+
+These tests mock the outbound HTTP call (requests.post) and the request-builder
+so they exercise only the response-handling / decision logic. They require no
+running PDP or other infrastructure.
+"""
+import unittest
+from unittest import mock
+
+from fabric_cf.actor.security.pdp_auth import PdpAuth, PdpAuthException, ActionId
+
+PDP_MODULE = "fabric_cf.actor.security.pdp_auth"
+
+
+def _permit_response():
+    resp = mock.Mock()
+    resp.status_code = 200
+    resp.json.return_value = {"Response": [{"Decision": "Permit"}]}
+    return resp
+
+
+def _deny_response(reason: str = "not allowed"):
+    resp = mock.Mock()
+    resp.status_code = 200
+    resp.json.return_value = {
+        "Response": [{
+            "Decision": "Deny",
+            "AssociatedAdvice": [{
+                "AttributeAssignment": [{"Value": reason}]
+            }]
+        }]
+    }
+    return resp
+
+
+class TestPdpAuthCheckAccess(unittest.TestCase):
+    def _make(self, enable: bool = True):
+        config = {"enable": enable, "url": "http://pdp.example.invalid/authorize"}
+        return PdpAuth(config=config, logger=mock.Mock())
+
+    @mock.patch(f"{PDP_MODULE}.requests.post")
+    def test_disabled_skips_http_call(self, mock_post):
+        """When PDP is disabled, check_access must return without any HTTP call."""
+        pdp = self._make(enable=False)
+        pdp.check_access(email="u@example.org", project="p", tags=[],
+                         action_id=ActionId.create, resource=None, lease_end_time=None)
+        mock_post.assert_not_called()
+
+    @mock.patch(f"{PDP_MODULE}.requests.post")
+    def test_permit_returns_without_raising(self, mock_post):
+        mock_post.return_value = _permit_response()
+        pdp = self._make(enable=True)
+        with mock.patch.object(pdp, "build_pdp_request", return_value={}):
+            # Should not raise
+            pdp.check_access(email="u@example.org", project="p", tags=[],
+                             action_id=ActionId.create, resource=None, lease_end_time=None)
+        mock_post.assert_called_once()
+
+    @mock.patch(f"{PDP_MODULE}.requests.post")
+    def test_deny_raises_with_reason(self, mock_post):
+        mock_post.return_value = _deny_response(reason="quota exceeded")
+        pdp = self._make(enable=True)
+        with mock.patch.object(pdp, "build_pdp_request", return_value={}):
+            with self.assertRaises(PdpAuthException) as ctx:
+                pdp.check_access(email="u@example.org", project="p", tags=[],
+                                 action_id=ActionId.create, resource=None, lease_end_time=None)
+        self.assertIn("quota exceeded", str(ctx.exception))
+
+    @mock.patch(f"{PDP_MODULE}.requests.post")
+    def test_non_json_response_raises(self, mock_post):
+        resp = mock.Mock()
+        resp.status_code = 200
+        resp.json.side_effect = ValueError("no json")
+        resp.text = "<html>gateway error</html>"
+        mock_post.return_value = resp
+        pdp = self._make(enable=True)
+        with mock.patch.object(pdp, "build_pdp_request", return_value={}):
+            with self.assertRaises(PdpAuthException):
+                pdp.check_access(email="u@example.org", project="p", tags=[],
+                                 action_id=ActionId.create, resource=None, lease_end_time=None)
+
+    @mock.patch(f"{PDP_MODULE}.requests.post")
+    def test_http_error_is_wrapped(self, mock_post):
+        mock_post.side_effect = Exception("connection refused")
+        pdp = self._make(enable=True)
+        with mock.patch.object(pdp, "build_pdp_request", return_value={}):
+            with self.assertRaises(PdpAuthException):
+                pdp.check_access(email="u@example.org", project="p", tags=[],
+                                 action_id=ActionId.create, resource=None, lease_end_time=None)
+
+
+class TestPdpAuthBuildRequest(unittest.TestCase):
+    def test_build_request_requires_project_and_email(self):
+        pdp = PdpAuth(config={"enable": True, "url": "http://x.invalid"}, logger=mock.Mock())
+        with self.assertRaises(PdpAuthException):
+            pdp.build_pdp_request(email=None, project=None, tags=[],
+                                  action_id=ActionId.create, resource=None, lease_end_time=None)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,3 +49,11 @@ Sources = "https://github.com/fabric-testbed/ControlFramework"
 
 [tool.flit.module]
 name = "fabric_cf"
+
+[tool.pytest.ini_options]
+# Register custom markers so @pytest.mark.integration does not warn.
+# Infrastructure-dependent tests (Kafka/Postgres/Neo4j/Schema Registry) should be
+# marked 'integration'; CI runs the unit tier with '-m "not integration"'.
+markers = [
+    "integration: test requires running infrastructure (Kafka, Postgres, Neo4j, Schema Registry)",
+]


### PR DESCRIPTION
## Summary

The repo had **no CI**, and every existing test requires live infrastructure (Kafka/Postgres/Neo4j/Schema Registry), so nothing ran on a pull request. This adds automated checks plus the first tier of infrastructure-free tests.

## Changes

- **`.github/workflows/ci.yml`** — runs on PRs and pushes to `main`/`rel-2.0.1`:
  - **unit** job (Python 3.12 & 3.13): `pip install . pytest`, byte-compile `fabric_cf`, run `pytest fabric_cf/actor/test/unit -m "not integration"`.
  - **pip-audit** job (advisory / `continue-on-error`): dependency vulnerability scan.
- **`fabric_cf/actor/test/unit/`** — new unit-test tier that mocks all external dependencies (no infra needed). First tests cover `PdpAuth.check_access`: disabled-path short-circuit, permit, deny (with reason), non-JSON response, and wrapped HTTP error.
- **`pyproject.toml`** — register the `integration` pytest marker so infra-dependent tests can be marked and excluded from the unit tier.

## Verification

- `pytest fabric_cf/actor/test/unit -m "not integration"` → **6 passed** locally, no marker warnings.
- The CI intentionally installs the package directly (`pip install .`) rather than the `[test]` extra, which still pins the unmaintained `nose`.

Targets `rel-2.0.1` (theme 5 of the improvement sweep). This gives the other `rel-2.0.1` PRs an automated check to run against.

## Follow-ups (separate PRs)

- Mark the existing infrastructure tests with `@pytest.mark.integration` and add a compose-backed integration job.
- Expand the unit tier (e.g. `token_validator`, allocation helpers).
