### PR TITLE
Propagate DB errors from get_components/get_links (avoid double-allocation)

### DIFF
--- a/fabric_cf/actor/core/plugins/db/actor_database.py
+++ b/fabric_cf/actor/core/plugins/db/actor_database.py
@@ -615,7 +615,10 @@ class ActorDatabase(ABCDatabase):
             return self.db.get_components(node_id=node_id, states=states, component=component, bdf=bdf,
                                           rsv_type=rsv_type, start=start, end=end, excludes=excludes)
         except Exception as e:
+            # Do not swallow DB/infra errors: returning None on failure would be read by
+            # allocation logic as "no components in use", risking double-allocation.
             self.logger.error(e)
+            raise
         finally:
             if self.lock.locked():
                 self.lock.release()
@@ -626,7 +629,10 @@ class ActorDatabase(ABCDatabase):
             return self.db.get_links(node_id=node_id, states=states, rsv_type=rsv_type, start=start,
                                      end=end, excludes=excludes)
         except Exception as e:
+            # Do not swallow DB/infra errors: returning None on failure would be read by
+            # allocation logic as "no bandwidth in use", risking over-allocation.
             self.logger.error(e)
+            raise
         finally:
             if self.lock.locked():
                 self.lock.release()

--- a/fabric_cf/actor/test/unit/test_actor_database_read_errors.py
+++ b/fabric_cf/actor/test/unit/test_actor_database_read_errors.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+# MIT License
+#
+# Copyright (c) 2020 FABRIC Testbed
+#
+# Author: Komal Thareja (kthare10@renci.org)
+"""
+Unit tests: ActorDatabase.get_components / get_links must NOT swallow DB/infra
+errors. Returning None on failure would be read by the allocation logic as
+"nothing in use", risking double-/over-allocation, so these must propagate.
+
+The ActorDatabase is instantiated via __new__ to avoid constructing a real
+PsqlDatabase (no running Postgres required); only the small surface used by the
+methods under test is stubbed.
+"""
+import threading
+import unittest
+from unittest import mock
+
+from fabric_cf.actor.core.plugins.db.actor_database import ActorDatabase
+from fabric_cf.actor.core.common.exceptions import DatabaseException
+
+
+class TestActorDatabaseReadErrorPropagation(unittest.TestCase):
+    def _make(self):
+        db = ActorDatabase.__new__(ActorDatabase)
+        db.db = mock.Mock()
+        db.lock = threading.Lock()
+        db.logger = mock.Mock()
+        return db
+
+    def test_get_components_success_returns_dict(self):
+        db = self._make()
+        db.db.get_components.return_value = {}
+        self.assertEqual(db.get_components(node_id="n", states=[1], rsv_type=["t"]), {})
+
+    def test_get_links_success_returns_dict(self):
+        db = self._make()
+        db.db.get_links.return_value = {"n": 10}
+        self.assertEqual(db.get_links(node_id="n", states=[1], rsv_type=["t"]), {"n": 10})
+
+    def test_get_components_reraises_database_exception(self):
+        db = self._make()
+        db.db.get_components.side_effect = DatabaseException("postgres down")
+        with self.assertRaises(DatabaseException):
+            db.get_components(node_id="n", states=[1], rsv_type=["t"])
+
+    def test_get_links_reraises_database_exception(self):
+        db = self._make()
+        db.db.get_links.side_effect = DatabaseException("postgres down")
+        with self.assertRaises(DatabaseException):
+            db.get_links(node_id="n", states=[1], rsv_type=["t"])
+
+    def test_get_components_propagates_generic_driver_error(self):
+        db = self._make()
+        db.db.get_components.side_effect = RuntimeError("connection reset")
+        with self.assertRaises(RuntimeError):
+            db.get_components(node_id="n", states=[1], rsv_type=["t"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

`ActorDatabase.get_components` and `get_links` caught **all** exceptions, logged, and returned `None`. On success these return a (possibly empty) `dict`, so the *only* time they returned `None` was on a DB/infra error — which the broker allocation path (`get_existing_components` / `get_existing_links`) reads as **"nothing in use"**, risking double-/over-allocation of components (GPUs/NICs) and link bandwidth.

This re-raises instead of swallowing, so a Postgres/infra fault fails the reservation (visible, retryable) rather than silently corrupting allocation.

## Why this is safe

- **Success path unchanged** — still returns the underlying dict (including empty).
- Only the *error* path changes (previously `None`, now raises). Verified callers all tolerate the raise:
  - management (`local_actor.get_components/get_links`) already wraps these in `try/except`;
  - BQM `occupied_link_capacity` already crashed on `None.get()` when the read failed — a clear exception is strictly better;
  - BQM `occupied_node_capacity` now fails the query instead of emitting *understated* occupancy (which would overstate availability);
  - the allocation path fails the reservation instead of double-allocating.

## Tests

Adds `fabric_cf/actor/test/unit/test_actor_database_read_errors.py` (infra-free; `ActorDatabase` built via `__new__`, `self.db` mocked): success returns the dict; `DatabaseException` and generic driver errors propagate. **5 tests pass locally.**

## Merge notes (targets `rel-2.0.1`)

- Touches `fabric_cf/actor/core/plugins/db/actor_database.py`, which is also modified by the lock-idiom PR (#437). If #437 merges first, expect at most a trivial conflict in these two `except` blocks (keep the `raise`, keep #437's removal of the dead `finally`). **Recommended order: #437 → #439 (CI) → this.**
- The test lives in `fabric_cf/actor/test/unit/`; the package `__init__.py` and CI workflow that exercises it come from #439. Different filenames, so no conflict.

Theme 2 of the improvement sweep, scoped tightly to the allocation-critical reads. Follow-up: the same swallow pattern exists in `get_reservations` and the `*_allocations` reads (larger caller set), to be evaluated separately.
