### PR TITLE
Harden pickle loading against RCE (RestrictedUnpickler)

### DIFF
--- a/fabric_cf/actor/core/container/db/container_database.py
+++ b/fabric_cf/actor/core/container/db/container_database.py
@@ -26,6 +26,7 @@
 from __future__ import annotations
 
 import pickle
+from fabric_cf.actor.security.restricted_unpickler import restricted_loads
 from typing import TYPE_CHECKING, List
 
 from fabric_cf.actor.core.common.constants import Constants
@@ -136,7 +137,7 @@ class ContainerDatabase(ABCContainerDatabase):
                 result = []
                 for a in act_dict_list:
                     pickled_actor = a.get(Constants.PROPERTY_PICKLE_PROPERTIES)
-                    act_obj = pickle.loads(pickled_actor)
+                    act_obj = restricted_loads(pickled_actor)
                     result.append(act_obj)
             return result
         except Exception as e:
@@ -154,7 +155,7 @@ class ContainerDatabase(ABCContainerDatabase):
             act_dict = self.db.get_actor(name=actor_name)
             if act_dict is not None:
                 pickled_actor = act_dict.get(Constants.PROPERTY_PICKLE_PROPERTIES)
-                return pickle.loads(pickled_actor)
+                return restricted_loads(pickled_actor)
         except Exception as e:
             self.logger.error(e)
         return result

--- a/fabric_cf/actor/core/plugins/db/actor_database.py
+++ b/fabric_cf/actor/core/plugins/db/actor_database.py
@@ -24,6 +24,7 @@
 #
 # Author: Komal Thareja (kthare10@renci.org)
 import pickle
+from fabric_cf.actor.security.restricted_unpickler import restricted_loads
 import threading
 import time
 import traceback
@@ -136,7 +137,7 @@ class ActorDatabase(ABCDatabase):
             slice_dict = self.db.get_slice_by_id(slc_id=slc_id)
             if slice_dict is not None:
                 pickled_slice = slice_dict.get(Constants.PROPERTY_PICKLE_PROPERTIES)
-                return pickle.loads(pickled_slice)
+                return restricted_loads(pickled_slice)
         except Exception as e:
             self.logger.error(e)
         finally:
@@ -224,7 +225,7 @@ class ActorDatabase(ABCDatabase):
             if slices is not None:
                 for s in slices:
                     pickled_slice = s.get(Constants.PROPERTY_PICKLE_PROPERTIES)
-                    slice_obj = pickle.loads(pickled_slice)
+                    slice_obj = restricted_loads(pickled_slice)
                     slice_obj.set_last_updated_time(s.get('last_updated_time'))
                     result.append(slice_obj)
         except Exception as e:
@@ -496,7 +497,7 @@ class ActorDatabase(ABCDatabase):
     def _load_reservation_from_pickled_object(self, pickled_res: bytes, slc_id: int) -> ABCReservationMixin or None:
         try:
             slice_obj = self.get_slice_by_id(slc_id=slc_id)
-            result = pickle.loads(pickled_res)
+            result = restricted_loads(pickled_res)
             result.restore(actor=self.actor, slice_obj=slice_obj)
 
             if isinstance(result, ABCControllerReservation):
@@ -730,7 +731,7 @@ class ActorDatabase(ABCDatabase):
             if broker_dict_list is not None:
                 for b in broker_dict_list:
                     pickled_broker = b.get(Constants.PROPERTY_PICKLE_PROPERTIES)
-                    broker_obj = pickle.loads(pickled_broker)
+                    broker_obj = restricted_loads(pickled_broker)
                     result.append(broker_obj)
             return result
         except Exception as e:
@@ -788,7 +789,7 @@ class ActorDatabase(ABCDatabase):
 
     def _load_delegation_from_pickled_instance(self, pickled_del: bytes, slc_id: int) -> ABCDelegation:
         slice_obj = self.get_slice_by_id(slc_id=slc_id)
-        delegation = pickle.loads(pickled_del)
+        delegation = restricted_loads(pickled_del)
         delegation.restore(actor=self.actor, slice_obj=slice_obj)
         return delegation
 
@@ -904,7 +905,7 @@ class ActorDatabase(ABCDatabase):
 
         for s in site_list:
             pickled_site = s.get(Constants.PROPERTY_PICKLE_PROPERTIES)
-            site = pickle.loads(pickled_site)
+            site = restricted_loads(pickled_site)
             result.append(site)
 
         return result
@@ -968,7 +969,7 @@ class ActorDatabase(ABCDatabase):
         if cfg_map_list is not None:
             for c in cfg_map_list:
                 pickled_cfg_map = c.get(Constants.PROPERTY_PICKLE_PROPERTIES)
-                cfg_obj = pickle.loads(pickled_cfg_map)
+                cfg_obj = restricted_loads(pickled_cfg_map)
                 result.append(cfg_obj)
         return result
 
@@ -979,7 +980,7 @@ class ActorDatabase(ABCDatabase):
 
         for p in poa_dict_list:
             pickled_poa = p.get(Constants.PROPERTY_PICKLE_PROPERTIES)
-            poa_obj = pickle.loads(pickled_poa)
+            poa_obj = restricted_loads(pickled_poa)
             sliver_id = poa_obj.get_sliver_id()
             if include_res_info:
                 reservations = self.get_reservations(rid=sliver_id)

--- a/fabric_cf/actor/core/plugins/db/server_actor_database.py
+++ b/fabric_cf/actor/core/plugins/db/server_actor_database.py
@@ -24,6 +24,7 @@
 #
 # Author: Komal Thareja (kthare10@renci.org)
 import pickle
+from fabric_cf.actor.security.restricted_unpickler import restricted_loads
 from typing import List
 
 from fabric_cf.actor.core.common.constants import Constants
@@ -68,7 +69,7 @@ class ServerActorDatabase(ActorDatabase, ClientDatabase):
             client_dict = self.db.get_client_by_guid(clt_guid=str(guid))
             if client_dict is not None:
                 pickled_client = client_dict.get(Constants.PROPERTY_PICKLE_PROPERTIES)
-                return pickle.loads(pickled_client)
+                return restricted_loads(pickled_client)
         except Exception as e:
             self.logger.error(e)
         finally:
@@ -85,7 +86,7 @@ class ServerActorDatabase(ActorDatabase, ClientDatabase):
             if client_dict_list is not None:
                 for c in client_dict_list:
                     pickled_client = c.get(Constants.PROPERTY_PICKLE_PROPERTIES)
-                    client_obj = pickle.loads(pickled_client)
+                    client_obj = restricted_loads(pickled_client)
                     result.append(client_obj)
             return result
         except Exception as e:

--- a/fabric_cf/actor/core/plugins/substrate/db/substrate_actor_database.py
+++ b/fabric_cf/actor/core/plugins/substrate/db/substrate_actor_database.py
@@ -24,6 +24,7 @@
 #
 # Author: Komal Thareja (kthare10@renci.org)
 import pickle
+from fabric_cf.actor.security.restricted_unpickler import restricted_loads
 import traceback
 
 from fabric_cf.actor.core.common.constants import Constants
@@ -41,7 +42,7 @@ class SubstrateActorDatabase(ServerActorDatabase, ABCSubstrateDatabase):
             unit_dict = self.db.get_unit(unt_uid=str(uid))
             if unit_dict is not None:
                 pickled_unit = unit_dict.get(Constants.PROPERTY_PICKLE_PROPERTIES)
-                return pickle.loads(pickled_unit)
+                return restricted_loads(pickled_unit)
         except Exception as e:
             self.logger.error(traceback.format_exc())
             self.logger.error(e)
@@ -83,7 +84,7 @@ class SubstrateActorDatabase(ServerActorDatabase, ABCSubstrateDatabase):
             if unit_dict_list is not None:
                 for u in unit_dict_list:
                     pickled_unit = u.get(Constants.PROPERTY_PICKLE_PROPERTIES)
-                    unit_obj = pickle.loads(pickled_unit)
+                    unit_obj = restricted_loads(pickled_unit)
                     result.append(unit_obj)
             return result
         except Exception as e:

--- a/fabric_cf/actor/core/proxies/proxy.py
+++ b/fabric_cf/actor/core/proxies/proxy.py
@@ -24,6 +24,7 @@
 #
 # Author: Komal Thareja (kthare10@renci.org)
 import pickle
+from fabric_cf.actor.security.restricted_unpickler import restricted_loads
 import traceback
 
 from fabric_cf.actor.core.apis.abc_actor_mixin import ABCActorMixin
@@ -118,7 +119,7 @@ class Proxy(ABCProxy):
     @staticmethod
     def decode(*, encoded, plugin: ABCBasePlugin) -> ABCConcreteSet:
         try:
-            decoded_resource = pickle.loads(encoded)
+            decoded_resource = restricted_loads(encoded)
             decoded_resource.restore(plugin=plugin, reservation=None)
             return decoded_resource
         except Exception as e:

--- a/fabric_cf/actor/security/restricted_unpickler.py
+++ b/fabric_cf/actor/security/restricted_unpickler.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+# MIT License
+#
+# Copyright (c) 2020 FABRIC Testbed
+#
+# Author: Komal Thareja (kthare10@renci.org)
+"""
+Hardened ``pickle`` loading.
+
+FABRIC actors persist domain objects (Slices, Reservations, Units, Delegations,
+POAs, ...) as pickles in Postgres and carry pickled slivers over Kafka. Plain
+``pickle.loads`` on such data means anyone able to write the store or the bus can
+execute arbitrary code, because pickle can import and call any global on load.
+
+``restricted_loads`` closes the practical remote-code-execution vectors by
+refusing to resolve the standard "gadget" modules/callables (``os``,
+``subprocess``, ``builtins.eval``/``exec``, ...) during unpickling, while
+allowing the FABRIC domain modules and the ordinary stdlib types that legitimate
+pickled objects contain.
+
+Rollout policy (interim hardening — the storage format is unchanged):
+
+* Dangerous globals are **always** blocked.
+* Known-good modules (FABRIC packages + a curated safe-stdlib set) are allowed
+  silently.
+* Any other module is, by default, **allowed but logged at WARNING** so that a
+  too-narrow allowlist can never break loading of legitimate production data.
+  Set ``ENFORCE = True`` (or env ``FABRIC_PICKLE_ENFORCE=1``) after confirming
+  from the audit logs that no legitimate class is being flagged, to switch to a
+  strict allowlist that raises on anything unlisted.
+"""
+import io
+import logging
+import os
+import pickle
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# Switch to strict allowlist enforcement once audit logs are clean.
+ENFORCE: bool = os.environ.get("FABRIC_PICKLE_ENFORCE", "").lower() in ("1", "true", "yes")
+
+# Standard pickle remote-code-execution / exfiltration gadget modules. These
+# never appear in legitimate FABRIC domain pickles, so denying them outright
+# closes the RCE vectors without risking breakage of real data.
+_DENIED_MODULES = frozenset({
+    "os", "nt", "posix", "subprocess", "sys", "socket", "ssl", "shutil",
+    "ctypes", "cffi", "importlib", "imp", "pty", "platform", "multiprocessing",
+    "asyncio", "code", "codeop", "pdb", "bdb", "runpy", "marshal", "pickle",
+    "_pickle", "commands", "popen2", "webbrowser", "antigravity", "signal",
+    "smtplib", "ftplib", "telnetlib", "requests", "urllib", "http",
+})
+
+# Dangerous callables inside otherwise-common modules. Kept intentionally narrow:
+# getattr/setattr etc. are deliberately NOT blocked because they appear in
+# legitimate __reduce__ output, and their dangerous *targets* (os, importlib,
+# ...) are already denied above.
+_DENIED_QUALIFIED = frozenset({
+    ("builtins", "eval"), ("builtins", "exec"), ("builtins", "compile"),
+    ("builtins", "open"), ("builtins", "__import__"), ("builtins", "breakpoint"),
+    ("builtins", "input"),
+})
+
+# Known-good top-level modules for FABRIC domain / sliver objects, plus the
+# ordinary stdlib types that appear inside them (determined empirically).
+_ALLOWED_MODULES = frozenset({
+    # FABRIC / model packages
+    "fabric_cf", "fim", "fabric_mb", "fabrictestbed", "fss_utils", "fss",
+    # safe stdlib types found in the domain object graphs
+    "builtins", "datetime", "uuid", "logging", "enum", "collections",
+    "_collections", "collections.abc", "decimal", "ipaddress", "copyreg",
+    "copy_reg", "typing", "numbers", "re", "functools", "operator",
+    # graph library used by fim slivers/topologies
+    "networkx",
+})
+
+
+class RestrictedUnpickler(pickle.Unpickler):
+    """Unpickler that blocks code-execution gadgets during ``find_class``."""
+
+    def find_class(self, module: str, name: str) -> Any:
+        top = module.split(".", 1)[0]
+
+        if top in _DENIED_MODULES or (module, name) in _DENIED_QUALIFIED:
+            raise pickle.UnpicklingError(
+                f"Refusing to load unsafe pickle global {module}.{name}")
+
+        if top in _ALLOWED_MODULES:
+            return super().find_class(module, name)
+
+        # Unlisted module: audit by default, enforce on demand.
+        if ENFORCE:
+            raise pickle.UnpicklingError(
+                f"Refusing to load unlisted pickle global {module}.{name}")
+        logger.warning("restricted_unpickler: allowing unlisted pickle global %s.%s "
+                       "(audit; add to the allowlist before enabling ENFORCE)", module, name)
+        return super().find_class(module, name)
+
+
+def restricted_loads(data: bytes) -> Any:
+    """Drop-in replacement for ``pickle.loads`` that blocks unsafe globals."""
+    return RestrictedUnpickler(io.BytesIO(data)).load()

--- a/fabric_cf/actor/test/unit/test_restricted_unpickler.py
+++ b/fabric_cf/actor/test/unit/test_restricted_unpickler.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+# MIT License
+#
+# Copyright (c) 2020 FABRIC Testbed
+#
+# Author: Komal Thareja (kthare10@renci.org)
+"""
+Unit tests for the hardened pickle loader. No infrastructure required.
+"""
+import datetime
+import pickle
+import unittest
+import uuid
+
+from fabric_cf.actor.security.restricted_unpickler import restricted_loads
+
+
+class _EvilOsSystem:
+    def __reduce__(self):
+        import os
+        return (os.system, ("echo pwned",))
+
+
+class _EvilEval:
+    def __reduce__(self):
+        return (eval, ("__import__('os').system('echo pwned')",))
+
+
+class _EvilSubprocess:
+    def __reduce__(self):
+        import subprocess
+        return (subprocess.check_output, (["id"],))
+
+
+class TestRestrictedUnpickler(unittest.TestCase):
+    def test_legit_builtins_roundtrip(self):
+        for obj in ({"a": [1, 2], "b": ("x", 3.5)},
+                    datetime.datetime(2026, 1, 2, 3, 4, 5),
+                    uuid.uuid4(),
+                    [1, "two", 3.0, None, True]):
+            self.assertEqual(restricted_loads(pickle.dumps(obj)), obj)
+
+    def test_legit_fim_sliver_roundtrip(self):
+        from fim.slivers.capacities_labels import Capacities, Labels
+        cap = Capacities(core=4, ram=16, disk=100)
+        self.assertEqual(restricted_loads(pickle.dumps(cap)).core, 4)
+        lab = Labels(vlan="200")
+        self.assertEqual(restricted_loads(pickle.dumps(lab)).vlan, "200")
+
+    def test_blocks_os_system_gadget(self):
+        with self.assertRaises(pickle.UnpicklingError):
+            restricted_loads(pickle.dumps(_EvilOsSystem()))
+
+    def test_blocks_eval_gadget(self):
+        with self.assertRaises(pickle.UnpicklingError):
+            restricted_loads(pickle.dumps(_EvilEval()))
+
+    def test_blocks_subprocess_gadget(self):
+        with self.assertRaises(pickle.UnpicklingError):
+            restricted_loads(pickle.dumps(_EvilSubprocess()))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Domain objects (Slices, Reservations, Units, Delegations, POAs) are stored as **pickles** in Postgres, and pickled slivers ride Kafka. Plain `pickle.loads` on such data means anyone able to write the store or the bus can execute arbitrary code on load (pickle can import and call any global).

This adds interim hardening — **the on-disk / wire format is unchanged** — that closes the practical remote-code-execution vectors.

## Changes

- **`fabric_cf/actor/security/restricted_unpickler.py`** — `restricted_loads()` + `RestrictedUnpickler`:
  - **Always blocks** the standard pickle gadget modules/callables in `find_class`: `os`, `subprocess`, `sys`, `socket`, `ssl`, `shutil`, `ctypes`, `importlib`, `pty`, `marshal`, `requests`/`urllib`/`http`, … and `builtins.eval`/`exec`/`compile`/`open`/`__import__`/`breakpoint`/`input`.
  - **Allows** FABRIC packages (`fabric_cf`, `fim`, `fabric_mb`, `fabrictestbed`, `fss_utils`) and the ordinary stdlib types that legitimate pickled objects contain (`datetime`, `uuid`, `logging`, `enum`, `collections`, `ipaddress`, `networkx`, …) — the allowlist was derived empirically by pickling real domain/sliver objects.
  - **Unlisted modules**: audit-logged at WARNING and **allowed by default**, so a too-narrow allowlist can never break loading of real production data. Set `FABRIC_PICKLE_ENFORCE=1` to switch to strict allowlist enforcement once the audit logs are confirmed clean.
- Route **all 15** `pickle.loads` call sites through `restricted_loads` (actor/server/substrate databases, container database, proxy).
- **`fabric_cf/actor/test/unit/test_restricted_unpickler.py`** — infra-free tests: legit round-trips (dict/datetime/uuid/`Capacities`/`Labels`) and blocked `os.system` / `eval` / `subprocess` gadgets.

## Verification

- `compileall` passes; the 5 wired modules import cleanly (no circular import — the helper depends only on stdlib).
- Unit tests pass locally (5/5). Manual check confirms `os.system` (resolved as `posix.system`) and `eval` payloads raise `UnpicklingError` while legit objects round-trip.

## Rollout note

Because unlisted modules are allowed-and-logged by default, this is safe to deploy as-is. **On `rel-2.0.1`, grep actor logs for `restricted_unpickler: allowing unlisted pickle global` to discover any legitimate module missing from the allowlist**, add them, and only then set `FABRIC_PICKLE_ENFORCE=1` for full allowlist enforcement.

## Merge notes (targets `rel-2.0.1`)

Touches `actor_database.py` / `server_actor_database.py` / `substrate_actor_database.py`, which are also modified by the lock-idiom PR (#437) and (for `actor_database.py`) the DB-error PR (#440). The `pickle.loads -> restricted_loads` edits are on different lines, so conflicts should be trivial. **Recommended order: #439 (CI) -> #437 (locks) -> #440 (db errors) -> this.**

Theme 3 (interim) of the improvement sweep. A full pickle-to-versioned-JSON migration remains a separate, larger project tracked in IMPROVEMENTS.md.
