### PR TITLE
Hotfix: restore dropped 'raise' in get_components/get_links

### DIFF
--- a/fabric_cf/actor/core/plugins/db/actor_database.py
+++ b/fabric_cf/actor/core/plugins/db/actor_database.py
@@ -539,6 +539,7 @@ class ActorDatabase(ABCDatabase):
             # Do not swallow DB/infra errors: returning None on failure would be read by
             # allocation logic as "no components in use", risking double-allocation.
             self.logger.error(e)
+            raise
 
     def get_links(self, *, node_id: str, states: list[int], rsv_type: list[str], start: datetime = None,
                   end: datetime = None, excludes: List[str] = None) -> Dict[str, int]:
@@ -549,6 +550,7 @@ class ActorDatabase(ABCDatabase):
             # Do not swallow DB/infra errors: returning None on failure would be read by
             # allocation logic as "no bandwidth in use", risking over-allocation.
             self.logger.error(e)
+            raise
 
     def get_link_allocations(self, *, states: list[int], rsv_type: list[str],
                              start: datetime = None, end: datetime = None) -> list[dict]:


### PR DESCRIPTION
## Summary

**rel-2.0.1 is currently broken**: the unit tests added by #440 fail on it, because when #437 (lock idiom) and #440 (DB error propagation) were merged, both edited `get_components`/`get_links` and the conflict resolution kept #440's comment but **dropped its `raise` statement**.

So `rel-2.0.1` shipped the theme-2 test without the theme-2 fix: DB/infra errors are still swallowed and returned as `None`, which the allocation logic reads as "nothing in use" (the double-allocation risk #440 set out to fix), and CI is red.

## Fix

Re-add `raise` after logging in both methods (2 lines).

## Verification

- `python -m compileall` passes.
- Full unit suite `fabric_cf/actor/test/unit` passes (11/11), including the previously-failing `test_actor_database_read_errors`.

## Note

This also unblocks the pickle PR #441, whose CI was red only because it merges into this broken `rel-2.0.1`. Merge this first; #441 will then go green on refresh.