### PR TITLE
Fix slice stuck in Configuring when site does not respond to extend/modify

### DIFF
--- a/fabric_cf/actor/core/kernel/reservation.py
+++ b/fabric_cf/actor/core/kernel/reservation.py
@@ -699,7 +699,7 @@ class Reservation(ABCReservationMixin):
             return False
 
         current_time = datetime.now(timezone.utc)
-        if (current_time - self.last_transition_time).seconds > timeout:
+        if (current_time - self.last_transition_time).total_seconds() > timeout:
             return True
 
         return False

--- a/fabric_cf/actor/core/kernel/reservation_client.py
+++ b/fabric_cf/actor/core/kernel/reservation_client.py
@@ -1252,6 +1252,42 @@ class ReservationClient(Reservation, ABCControllerReservation):
                     update_data.message = "Redeem/Ticket timeout"
                     self.mark_close_by_ticket_review(update_data=update_data)
 
+            # Handle pending response for an ExtendTicket from Broker or
+            # ExtendLease/ModifyLease from AM
+            # This happens usually in case of Kafka Message Timeout
+            # To avoid the slice from being stuck in Configuring/Modifying state
+            # Do not close the reservation - unlike Redeem/Ticket it holds resources
+            # on the user's behalf and the existing lease is valid until the original
+            # end time; instead revert the pending state and record an error so the
+            # slice can transition to StableError/ModifyError and the operation
+            # can be retried
+            # Timeout is configurable
+            if self.pending_state in [ReservationPendingStates.ExtendingTicket,
+                                      ReservationPendingStates.ExtendingLease,
+                                      ReservationPendingStates.ModifyingLease]:
+                from fabric_cf.actor.core.container.globals import GlobalsSingleton
+                if self.exceeds_timeout(timeout=GlobalsSingleton.get().RPC_TIMEOUT):
+                    if self.pending_state == ReservationPendingStates.ExtendingTicket:
+                        operation = "Extend Ticket"
+                        remote_name = self.broker.get_name() if self.broker is not None else None
+                    elif self.pending_state == ReservationPendingStates.ExtendingLease:
+                        operation = "Extend Lease"
+                        remote_name = self.authority.get_name() if self.authority is not None else None
+                    else:
+                        operation = "Modify Lease"
+                        remote_name = self.authority.get_name() if self.authority is not None else None
+
+                    self.error_message = f"{operation} timeout! No response received in " \
+                                         f"{GlobalsSingleton.get().RPC_TIMEOUT} seconds from {remote_name}!"
+                    self.logger.info(f"Res# {self.get_reservation_id()} {self.error_message}")
+
+                    # An un-redeemed extended ticket cannot be kept - ActiveTicketed
+                    # blocks the slice from reaching a stable state; fall back to Active
+                    prev_state = ReservationStates.Active if self.state == ReservationStates.ActiveTicketed \
+                        else self.state
+                    self.transition(prefix=f"{operation} timeout", state=prev_state,
+                                    pending=ReservationPendingStates.None_)
+
         if self.leased_resources is None:
             return
 


### PR DESCRIPTION
## Problem

On renew, the `ExtendLease` RPC to the AM (and `ExtendTicket` to the Broker, `ModifyLease` to the AM) had **no timeout**: only Claim/Reclaim and Query RPCs schedule timeout timers in `rpc_manager.py`, and `handle_failed_rpc` only fires when the Kafka produce itself fails. If the remote actor received the request but never responded (AM wedged, crashed mid-processing, message dropped), the reservation stayed pinned in a pending state — e.g. `(ActiveTicketed, ExtendingLease)` — and slice `Reevaluate` treats those pending states as in-flight, so the slice **never left Configuring** (or Modifying). The only recovery was an orchestrator restart, whose recovery path re-issues the RPC.

The existing `probe_pending` watchdog (whose comment already says *"To avoid the slice from being stuck in Configuring state"*) only covered `Redeeming`/`Ticketing`.

## Fix

- Extend the `probe_pending` watchdog to `ExtendingTicket`, `ExtendingLease`, and `ModifyingLease`, using the same `rpc.request.timeout.seconds`. Unlike the Redeem/Ticket case, **do not close the reservation** — it holds live resources on the user's behalf and the existing lease remains valid until the original end time. Instead:
  - revert the pending state to `None_` (falling back `ActiveTicketed → Active`, since `ActiveTicketed` also blocks the slice from reaching a stable state), and
  - record an `error_message` so `Reevaluate` transitions the slice to `StableError`/`ModifyError` and the operation can be retried.
- A late `UpdateLease` from a slow-but-alive AM is still absorbed safely: the `update_lease` handler accepts it as unsolicited data when the pending state no longer matches.
- Fix `exceeds_timeout` to use `total_seconds()` — `.seconds` discards whole days from the elapsed time (wraps every 24h).

## Verification

Behavioral checks driving the real `probe_pending` and `SliceStateMachine` code (13/13 pass): each of the three pending states reverts correctly on timeout; nothing fires before the timeout; the pre-fix scenario reproduces stuck-Configuring; the post-revert reservation takes the slice to StableError; the healthy path still reaches StableOK; the day-wrap timeout case now triggers.

## Notes / follow-ups (not in this PR)

1. After an `ExtendingLease` timeout revert, the broker has already extended the ticket, so the reservation term shows the new end while the site lease keeps the old end. A REST renew retry with the **same** end time is skipped by `renew_slice` (`new_end_time == current_end_time`) — comparing against the lease end instead would fix that. The mgmt CLI (`fabric-mgmt-cli slices renew`) has no equality skip and can force a re-drive; term checks pass since `extends_term` only validates start alignment.
2. `client_actor_management_object_helper.extend_reservation` always executes async, so renew reports success even if the kernel later rejects the extend; the sync-for-renew variant is present but commented out.