### PR TITLE
Fix orchestrator sending broker requests to an Authority after restart

### DIFF
--- a/fabric_cf/orchestrator/core/orchestrator_handler.py
+++ b/fabric_cf/orchestrator/core/orchestrator_handler.py
@@ -47,6 +47,7 @@ from fabric_cf.actor.core.kernel.poa import PoaStates
 from fabric_cf.actor.core.kernel.reservation_states import ReservationStates
 from fabric_cf.actor.core.time.actor_clock import ActorClock
 from fabric_cf.actor.fim.fim_helper import FimHelper
+from fabric_cf.actor.core.apis.abc_actor_mixin import ActorType
 from fabric_cf.actor.core.apis.abc_mgmt_controller_mixin import ABCMgmtControllerMixin
 from fabric_cf.actor.core.common.constants import Constants, ErrorCodes
 from fabric_cf.actor.core.kernel.slice_state_machine import SliceState
@@ -121,7 +122,16 @@ class OrchestratorHandler:
             self.logger.debug(f"Brokers: {brokers}")
             self.logger.error(f"Last Error: {controller.get_last_error()}")
             if brokers is not None:
-                result = ID(uid=next(iter(brokers), None).get_guid())
+                # A client actor's broker registry also holds the Authority proxies
+                # (needed for redeem/extend/close) and its ordering is not guaranteed
+                # across restarts; pick the peer that actually is a Broker
+                broker_proxy = next((b for b in brokers if b.get_type() is not None and
+                                     ActorType.get_actor_type_from_string(actor_type=b.get_type()) ==
+                                     ActorType.Broker), None)
+                if broker_proxy is None:
+                    self.logger.error(f"No broker peer found among proxies: {brokers}")
+                    return None
+                result = ID(uid=broker_proxy.get_guid())
                 self.controller_state.set_broker(broker=result)
                 return result
         except Exception as e:


### PR DESCRIPTION
## Problem

After an orchestrator restart, broker-bound requests (`discover.bqm` model queries, ticket requests) can be sent to a site Authority's Kafka topic instead of the Broker. Observed on beta: the orchestrator sent `Query` with `discover.bqm` to `uky-am`.

Root cause chain:
1. A client actor's broker registry also holds the **Authority** proxies — `remote_actor_cache.establish_peer_private` registers any `Authority`/`Broker` peer via `add_broker` (by design, so the orchestrator has Kafka proxies for redeem/extend/close). Boot logs show *"Added renc-am as broker"*, *"Added uky-am as broker"*, etc.
2. On recovery, `peer_registry.load_from_db()` fills the registry from `psql_database.get_proxies()`, which has **no ORDER BY** — row order is arbitrary and shifts across restarts because boot updates every proxy row.
3. `orchestrator_handler.get_broker()` took `next(iter(brokers))` — the first list entry — and cached it in `controller_state` for the life of the process. If an AM happened to come back first, every broker request went to that AM until the next (lucky) restart.

## Fix

Select the peer whose proxy type is actually `Broker` (each `ProxyAvro` carries its type — `broker` vs `authority`) instead of blindly taking the first entry; log and return `None` if no broker peer exists.

## Verification

Compile check plus selection-logic tests: picks the broker when AMs precede it in the list (the observed failure ordering), still picks it when first, returns `None` when absent, and matches case-insensitively.