### PR TITLE
Return None from ActorClock.from_milliseconds for a None timestamp

### DIFF
--- a/fabric_cf/actor/core/time/actor_clock.py
+++ b/fabric_cf/actor/core/time/actor_clock.py
@@ -24,6 +24,7 @@
 #
 # Author: Komal Thareja (kthare10@renci.org)
 from datetime import datetime, timezone
+from typing import Optional
 
 from fabric_cf.actor.core.common.constants import Constants
 from fabric_cf.actor.core.common.exceptions import TimeException
@@ -179,7 +180,14 @@ class ActorClock:
         return int((when - epoch).total_seconds() * 1000)
 
     @staticmethod
-    def from_milliseconds(*, milli_seconds) -> datetime:
+    def from_milliseconds(*, milli_seconds) -> Optional[datetime]:
+        """
+        Converts milliseconds since epoch to a timezone aware datetime.
+        @params milli_seconds: milliseconds since epoch; may be None
+        @returns corresponding datetime or None if milli_seconds is None
+        """
+        if milli_seconds is None:
+            return None
         result = datetime.fromtimestamp(milli_seconds//1000, timezone.utc).replace(microsecond=milli_seconds%1000*1000)
         return result
 


### PR DESCRIPTION
Closed reservations can carry a `None` `start`/`end`/`requested_end`. Any caller converting one of those timestamps hit:

```
TypeError: unsupported operand type(s) for //: 'NoneType' and 'int'
```

`from_milliseconds` now returns `None` for a `None` input instead of raising, and the return type is `Optional[datetime]`.

Surfaced via `fabric-mgmt-cli slivers query` on a slice containing a closed L2Bridge sliver; the CLI-side guard is in ManagementCli#fix/sliver-none-timestamp.

### Call-site review

All existing callers are safe with a `None` return:
- `actor_clock.py` internal uses (`date`, `cycle_end_date`) and `term.py:120` pass computed ints.
- `translate.py:273-279` already guards on `> 0`.
- `broker_simpler_units_policy.py:2018,2033` pass computed cycle boundaries.
- `client_actor_management_object_helper.py:220-221` would build `Term(start=None, end=None)` and raise `TimeException` — a clearer failure than the previous `TypeError` for that already-invalid input.