### PR TITLE
Populate ProxyAvro actor type so Broker peer selection works

### DIFF
--- a/fabric_cf/actor/core/manage/converter.py
+++ b/fabric_cf/actor/core/manage/converter.py
@@ -37,6 +37,9 @@ from fabric_mb.message_bus.messages.reservation_predecessor_avro import Reservat
 from fabric_mb.message_bus.messages.reservation_state_avro import ReservationStateAvro
 from fabric_mb.message_bus.messages.ticket_reservation_avro import TicketReservationAvro
 from fabric_mb.message_bus.messages.unit_avro import UnitAvro
+from fabric_cf.actor.core.apis.abc_actor_mixin import ActorType
+from fabric_cf.actor.core.apis.abc_authority_proxy import ABCAuthorityProxy
+from fabric_cf.actor.core.apis.abc_broker_proxy import ABCBrokerProxy
 from fabric_cf.actor.core.apis.abc_client_reservation import ABCClientReservation
 from fabric_cf.actor.core.apis.abc_controller_reservation import ABCControllerReservation
 from fabric_cf.actor.core.common.constants import Constants
@@ -239,6 +242,14 @@ class Converter:
         elif isinstance(proxy, KafkaProxy):
             result.set_protocol(Constants.PROTOCOL_KAFKA)
             result.set_kafka_topic(proxy.get_kafka_topic())
+
+        # ProxyAvro.type carries the peer's actor type (as consumed by
+        # Converter.get_agent_proxy/ProxyFactory); Authority proxies derive from
+        # the Broker proxy interface, so check the narrower type first.
+        if isinstance(proxy, ABCAuthorityProxy):
+            result.set_type(ActorType.Authority.name)
+        elif isinstance(proxy, ABCBrokerProxy):
+            result.set_type(ActorType.Broker.name)
 
         return result
 

--- a/fabric_cf/actor/core/registry/peer_registry.py
+++ b/fabric_cf/actor/core/registry/peer_registry.py
@@ -54,13 +54,36 @@ class PeerRegistry:
     def actor_added(self):
         self.load_from_db()
 
+    @staticmethod
+    def is_broker_proxy(*, proxy) -> bool:
+        """
+        True only for proxies to an actor acting in the Broker role. This registry
+        also holds the Authority proxies (needed to redeem/extend/close directly
+        with the AMs) and ABCAuthorityProxy derives from ABCBrokerProxy, so the
+        narrower type must be excluded explicitly.
+        @param proxy proxy
+        """
+        from fabric_cf.actor.core.apis.abc_authority_proxy import ABCAuthorityProxy
+        from fabric_cf.actor.core.apis.abc_broker_proxy import ABCBrokerProxy as BrokerProxy
+        return isinstance(proxy, BrokerProxy) and not isinstance(proxy, ABCAuthorityProxy)
+
+    def __set_default_broker_if_needed(self, *, broker: ABCBrokerProxy):
+        """
+        Record the default broker; an Authority peer is never a valid default and
+        must not shadow the real Broker regardless of registration order.
+        Caller must hold the lock.
+        @param broker broker proxy
+        """
+        if not self.is_broker_proxy(proxy=broker):
+            return
+        if self.default_broker is None or not self.is_broker_proxy(proxy=self.default_broker):
+            self.default_broker = broker
+
     def add_broker(self, *, broker: ABCBrokerProxy):
         try:
             self.lock.acquire()
             self.brokers[broker.get_identity().get_guid()] = broker
-
-            if self.default_broker is None:
-                self.default_broker = broker
+            self.__set_default_broker_if_needed(broker=broker)
         finally:
             self.lock.release()
 
@@ -74,9 +97,7 @@ class PeerRegistry:
         try:
             self.lock.acquire()
             self.brokers[broker.get_identity().get_guid()] = broker
-
-            if self.default_broker is None:
-                self.default_broker = broker
+            self.__set_default_broker_if_needed(broker=broker)
         finally:
             self.lock.release()
 
@@ -121,15 +142,14 @@ class PeerRegistry:
 
     def load_from_db(self):
         brokers = self.plugin.get_database().get_brokers()
-        count = 0
         if brokers is None:
             return
+        # The Proxies table has no ordering guarantee, so the first row may well
+        # be an Authority; pick the default by role instead of by position
         for b in brokers:
             agent = Proxy.get_proxy(proxy_reload_from_db=b)
             self.brokers[agent.get_identity().get_guid()] = agent
-            if count == 0:
-                self.default_broker = agent
-            count += 1
+            self.__set_default_broker_if_needed(broker=agent)
 
     def remove_broker(self, *, broker: ABCBrokerProxy):
         try:

--- a/fabric_cf/orchestrator/core/orchestrator_handler.py
+++ b/fabric_cf/orchestrator/core/orchestrator_handler.py
@@ -121,12 +121,24 @@ class OrchestratorHandler:
         return result
 
     @staticmethod
-    def __get_proxy_actor_type(proxy) -> ActorType or None:
+    def __declares_no_type(proxy) -> bool:
         """
-        Actor type advertised by a proxy, or None when it carries none
+        True when a proxy carries no actor type at all. A blank string is treated
+        the same as an absent one; anything non-blank counts as declared, even if
+        it cannot be parsed.
         :param proxy: ProxyAvro
         """
-        if proxy.get_type() is None:
+        actor_type = proxy.get_type()
+        return actor_type is None or actor_type.strip() == ""
+
+    def __get_proxy_actor_type(self, proxy) -> ActorType or None:
+        """
+        Actor type advertised by a proxy, or None when it carries none. An
+        unrecognized non-blank type resolves to ActorType.All, which is never
+        treated as a match for a specific role.
+        :param proxy: ProxyAvro
+        """
+        if self.__declares_no_type(proxy=proxy):
             return None
         return ActorType.get_actor_type_from_string(actor_type=proxy.get_type())
 
@@ -142,18 +154,24 @@ class OrchestratorHandler:
         :return ProxyAvro for the Broker or None
         """
         # Preferred: the peer whose proxy advertises the Broker actor type
-        broker_proxy = next((b for b in brokers if self.__get_proxy_actor_type(b) == ActorType.Broker), None)
+        broker_proxy = next((b for b in brokers if self.__get_proxy_actor_type(proxy=b) == ActorType.Broker), None)
         if broker_proxy is not None:
             return broker_proxy
 
-        # Fallback for proxies that carry no usable actor type: match against the
-        # peers configured as Brokers by name. A proxy that explicitly declares
-        # another type (an Authority) is never eligible - trusting the name over an
-        # explicit type would resurrect the misrouting this selection prevents.
+        for b in brokers:
+            if not self.__declares_no_type(proxy=b) and \
+                    self.__get_proxy_actor_type(proxy=b) == ActorType.All:
+                self.logger.warning(f"Peer {b.get_name()} declares an unrecognized actor type "
+                                    f"'{b.get_type()}'; it will not be considered for broker selection")
+
+        # Fallback for proxies that carry no actor type at all: match against the
+        # peers configured as Brokers by name. A proxy that declares any type is
+        # never eligible here - overriding a declared type by name would resurrect
+        # the misrouting this selection prevents, and an unparsable type is a
+        # declaration we must not second-guess.
         configured = self.__get_configured_broker_names()
         broker_proxy = next((b for b in brokers
-                             if self.__get_proxy_actor_type(b) in (None, ActorType.All) and
-                             b.get_name() in configured), None)
+                             if self.__declares_no_type(proxy=b) and b.get_name() in configured), None)
         if broker_proxy is not None:
             self.logger.info(f"Selected broker peer {broker_proxy.get_name()} by configured peer name; "
                              f"proxy carried no actor type")

--- a/fabric_cf/orchestrator/core/orchestrator_handler.py
+++ b/fabric_cf/orchestrator/core/orchestrator_handler.py
@@ -120,6 +120,16 @@ class OrchestratorHandler:
                 result.append(peer.get_name())
         return result
 
+    @staticmethod
+    def __get_proxy_actor_type(proxy) -> ActorType or None:
+        """
+        Actor type advertised by a proxy, or None when it carries none
+        :param proxy: ProxyAvro
+        """
+        if proxy.get_type() is None:
+            return None
+        return ActorType.get_actor_type_from_string(actor_type=proxy.get_type())
+
     def __select_broker_proxy(self, *, brokers: list):
         """
         Select the Broker peer from a client actor's broker registry.
@@ -132,16 +142,18 @@ class OrchestratorHandler:
         :return ProxyAvro for the Broker or None
         """
         # Preferred: the peer whose proxy advertises the Broker actor type
-        broker_proxy = next((b for b in brokers if b.get_type() is not None and
-                             ActorType.get_actor_type_from_string(actor_type=b.get_type()) ==
-                             ActorType.Broker), None)
+        broker_proxy = next((b for b in brokers if self.__get_proxy_actor_type(b) == ActorType.Broker), None)
         if broker_proxy is not None:
             return broker_proxy
 
-        # Fallback for proxies that carry no actor type: match against the peers
-        # configured as Brokers by name
+        # Fallback for proxies that carry no usable actor type: match against the
+        # peers configured as Brokers by name. A proxy that explicitly declares
+        # another type (an Authority) is never eligible - trusting the name over an
+        # explicit type would resurrect the misrouting this selection prevents.
         configured = self.__get_configured_broker_names()
-        broker_proxy = next((b for b in brokers if b.get_name() in configured), None)
+        broker_proxy = next((b for b in brokers
+                             if self.__get_proxy_actor_type(b) in (None, ActorType.All) and
+                             b.get_name() in configured), None)
         if broker_proxy is not None:
             self.logger.info(f"Selected broker peer {broker_proxy.get_name()} by configured peer name; "
                              f"proxy carried no actor type")

--- a/fabric_cf/orchestrator/core/orchestrator_handler.py
+++ b/fabric_cf/orchestrator/core/orchestrator_handler.py
@@ -108,6 +108,45 @@ class OrchestratorHandler:
                                         message="POA rescan not authorized - missing permissions Component.FPGA")
         return fabric_token
 
+    def __get_configured_broker_names(self) -> List[str]:
+        """
+        Names of the peers configured as Brokers for this actor
+        :return list of peer names
+        """
+        result = []
+        for peer in self.config.get_peers() or []:
+            if peer.get_type() is not None and \
+                    ActorType.get_actor_type_from_string(actor_type=peer.get_type()) == ActorType.Broker:
+                result.append(peer.get_name())
+        return result
+
+    def __select_broker_proxy(self, *, brokers: list):
+        """
+        Select the Broker peer from a client actor's broker registry.
+
+        The registry also holds the Authority proxies (registered via add_broker so
+        the orchestrator can redeem/extend/close directly with the AMs) and its
+        ordering is not guaranteed across restarts, so the first entry cannot be
+        assumed to be the Broker.
+        :param brokers: list of ProxyAvro
+        :return ProxyAvro for the Broker or None
+        """
+        # Preferred: the peer whose proxy advertises the Broker actor type
+        broker_proxy = next((b for b in brokers if b.get_type() is not None and
+                             ActorType.get_actor_type_from_string(actor_type=b.get_type()) ==
+                             ActorType.Broker), None)
+        if broker_proxy is not None:
+            return broker_proxy
+
+        # Fallback for proxies that carry no actor type: match against the peers
+        # configured as Brokers by name
+        configured = self.__get_configured_broker_names()
+        broker_proxy = next((b for b in brokers if b.get_name() in configured), None)
+        if broker_proxy is not None:
+            self.logger.info(f"Selected broker peer {broker_proxy.get_name()} by configured peer name; "
+                             f"proxy carried no actor type")
+        return broker_proxy
+
     def get_broker(self, *, controller: ABCMgmtControllerMixin) -> ID:
         """
         Get broker
@@ -120,20 +159,18 @@ class OrchestratorHandler:
 
             brokers = controller.get_brokers()
             self.logger.debug(f"Brokers: {brokers}")
-            self.logger.error(f"Last Error: {controller.get_last_error()}")
-            if brokers is not None:
-                # A client actor's broker registry also holds the Authority proxies
-                # (needed for redeem/extend/close) and its ordering is not guaranteed
-                # across restarts; pick the peer that actually is a Broker
-                broker_proxy = next((b for b in brokers if b.get_type() is not None and
-                                     ActorType.get_actor_type_from_string(actor_type=b.get_type()) ==
-                                     ActorType.Broker), None)
-                if broker_proxy is None:
-                    self.logger.error(f"No broker peer found among proxies: {brokers}")
-                    return None
-                result = ID(uid=broker_proxy.get_guid())
-                self.controller_state.set_broker(broker=result)
-                return result
+            if not brokers:
+                self.logger.error(f"No peer proxies returned; Last Error: {controller.get_last_error()}")
+                return None
+
+            broker_proxy = self.__select_broker_proxy(brokers=brokers)
+            if broker_proxy is None:
+                self.logger.error(f"No broker peer found among proxies: "
+                                  f"{[(b.get_name(), b.get_type()) for b in brokers]}")
+                return None
+            result = ID(uid=broker_proxy.get_guid())
+            self.controller_state.set_broker(broker=result)
+            return result
         except Exception as e:
             self.logger.error(f"Error occurred: {e}", stack_info=True)
 

--- a/fabric_cf/orchestrator/test/test_broker_selection.py
+++ b/fabric_cf/orchestrator/test/test_broker_selection.py
@@ -76,7 +76,10 @@ class SelectBrokerProxyTest(unittest.TestCase):
     """
     def setUp(self):
         self.handler = OrchestratorHandler.__new__(OrchestratorHandler)
+        # Keep the expected warnings out of the test output
         self.handler.logger = logging.getLogger(self.__class__.__name__)
+        self.handler.logger.addHandler(logging.NullHandler())
+        self.handler.logger.propagate = False
         self.handler.config = self
         self.peers = [Peer(config={"name": "broker", "type": "broker", "guid": "broker-guid"}),
                       Peer(config={"name": "uky-am", "type": "authority", "guid": "uky-am-guid"})]
@@ -140,10 +143,23 @@ class SelectBrokerProxyTest(unittest.TestCase):
         self.assertIsNotNone(selected)
         self.assertEqual("broker-guid", selected.get_guid())
 
-    def test_unrecognized_type_still_eligible_for_name_fallback(self):
-        # An unparsable type resolves to ActorType.All i.e. no usable type
+    def test_blank_type_is_eligible_for_name_fallback(self):
+        # A blank type is no type at all
         brokers = [self.make_proxy(name="uky-am", guid="uky-am-guid", actor_type="authority"),
-                   self.make_proxy(name="broker", guid="broker-guid", actor_type="")]
+                   self.make_proxy(name="broker", guid="broker-guid", actor_type="   ")]
+        selected = self.select(brokers)
+        self.assertIsNotNone(selected)
+        self.assertEqual("broker-guid", selected.get_guid())
+
+    def test_unrecognized_non_blank_type_is_not_eligible(self):
+        # A malformed but declared type must not fail open to name matching:
+        # 'site' is what an AM peer would plausibly be mislabelled as
+        brokers = [self.make_proxy(name="broker", guid="mislabelled-guid", actor_type="site")]
+        self.assertIsNone(self.select(brokers))
+
+    def test_typeless_peer_wins_over_mislabelled_peer(self):
+        brokers = [self.make_proxy(name="broker", guid="mislabelled-guid", actor_type="site"),
+                   self.make_proxy(name="broker", guid="broker-guid")]
         selected = self.select(brokers)
         self.assertIsNotNone(selected)
         self.assertEqual("broker-guid", selected.get_guid())

--- a/fabric_cf/orchestrator/test/test_broker_selection.py
+++ b/fabric_cf/orchestrator/test/test_broker_selection.py
@@ -127,6 +127,27 @@ class SelectBrokerProxyTest(unittest.TestCase):
                    self.make_proxy(name="lbnl-am", guid="lbnl-am-guid", actor_type="authority")]
         self.assertIsNone(self.select(brokers))
 
+    def test_name_fallback_never_overrides_authority_type(self):
+        # A name collision must not let the fallback pick a peer that explicitly
+        # declares itself an Authority
+        brokers = [self.make_proxy(name="broker", guid="impostor-guid", actor_type="authority")]
+        self.assertIsNone(self.select(brokers))
+
+    def test_name_fallback_skips_authority_and_picks_typeless_peer(self):
+        brokers = [self.make_proxy(name="broker", guid="impostor-guid", actor_type="authority"),
+                   self.make_proxy(name="broker", guid="broker-guid")]
+        selected = self.select(brokers)
+        self.assertIsNotNone(selected)
+        self.assertEqual("broker-guid", selected.get_guid())
+
+    def test_unrecognized_type_still_eligible_for_name_fallback(self):
+        # An unparsable type resolves to ActorType.All i.e. no usable type
+        brokers = [self.make_proxy(name="uky-am", guid="uky-am-guid", actor_type="authority"),
+                   self.make_proxy(name="broker", guid="broker-guid", actor_type="")]
+        selected = self.select(brokers)
+        self.assertIsNotNone(selected)
+        self.assertEqual("broker-guid", selected.get_guid())
+
 
 class PeerRegistryDefaultBrokerTest(unittest.TestCase):
     """

--- a/fabric_cf/orchestrator/test/test_broker_selection.py
+++ b/fabric_cf/orchestrator/test/test_broker_selection.py
@@ -1,0 +1,176 @@
+#!/usr/bin/env python3
+# MIT License
+#
+# Copyright (c) 2020 FABRIC Testbed
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+#
+# Author: Komal Thareja (kthare10@renci.org)
+"""
+Unit tests for Broker peer selection on the Orchestrator.
+
+A client actor's broker registry holds both the Broker proxy and the Authority
+proxies, so the Broker must be identified by type rather than by list position.
+These tests need no Kafka/Postgres/Neo4j.
+"""
+import logging
+import unittest
+
+from fabric_cf.actor.boot.configuration import Peer
+from fabric_cf.actor.core.apis.abc_actor_mixin import ActorType
+from fabric_cf.actor.core.manage.converter import Converter
+from fabric_cf.actor.core.proxies.kafka.kafka_authority_proxy import KafkaAuthorityProxy
+from fabric_cf.actor.core.proxies.kafka.kafka_broker_proxy import KafkaBrokerProxy
+from fabric_cf.actor.core.registry.peer_registry import PeerRegistry
+from fabric_cf.actor.security.auth_token import AuthToken
+from fabric_cf.orchestrator.core.orchestrator_handler import OrchestratorHandler
+
+
+class FillProxyTypeTest(unittest.TestCase):
+    """
+    Converter.fill_proxy must carry the peer's actor type, otherwise every
+    consumer of ProxyAvro.get_type() sees None.
+    """
+    def setUp(self):
+        self.logger = logging.getLogger(self.__class__.__name__)
+
+    def test_broker_proxy_type(self):
+        proxy = KafkaBrokerProxy(kafka_topic="broker-1", logger=self.logger,
+                                 identity=AuthToken(name="broker", guid="broker-guid"))
+        result = Converter.fill_proxy(proxy=proxy)
+        self.assertEqual(ActorType.Broker,
+                         ActorType.get_actor_type_from_string(actor_type=result.get_type()))
+        self.assertEqual("broker", result.get_name())
+        self.assertEqual("broker-1", result.get_kafka_topic())
+
+    def test_authority_proxy_type(self):
+        # KafkaAuthorityProxy derives from KafkaBrokerProxy; it must not be
+        # reported as a Broker
+        proxy = KafkaAuthorityProxy(kafka_topic="uky-am-1", logger=self.logger,
+                                    identity=AuthToken(name="uky-am", guid="uky-am-guid"))
+        result = Converter.fill_proxy(proxy=proxy)
+        self.assertEqual(ActorType.Authority,
+                         ActorType.get_actor_type_from_string(actor_type=result.get_type()))
+
+
+class SelectBrokerProxyTest(unittest.TestCase):
+    """
+    Exercise OrchestratorHandler broker selection without booting a container.
+    """
+    def setUp(self):
+        self.handler = OrchestratorHandler.__new__(OrchestratorHandler)
+        self.handler.logger = logging.getLogger(self.__class__.__name__)
+        self.handler.config = self
+        self.peers = [Peer(config={"name": "broker", "type": "broker", "guid": "broker-guid"}),
+                      Peer(config={"name": "uky-am", "type": "authority", "guid": "uky-am-guid"})]
+
+    def get_peers(self):
+        """
+        Stand in for Configuration.get_peers()
+        """
+        return self.peers
+
+    def select(self, brokers: list):
+        """
+        Invoke the name-mangled selection helper
+        """
+        return self.handler._OrchestratorHandler__select_broker_proxy(brokers=brokers)
+
+    @staticmethod
+    def make_proxy(*, name: str, guid: str, actor_type: str = None):
+        """
+        Build a ProxyAvro peer entry
+        """
+        from fabric_mb.message_bus.messages.proxy_avro import ProxyAvro
+        proxy = ProxyAvro()
+        proxy.set_name(name)
+        proxy.set_guid(guid)
+        proxy.set_type(actor_type)
+        return proxy
+
+    def test_selects_broker_not_first_entry(self):
+        # Registry ordering is arbitrary after recovery: Authority entries first
+        brokers = [self.make_proxy(name="uky-am", guid="uky-am-guid", actor_type="authority"),
+                   self.make_proxy(name="lbnl-am", guid="lbnl-am-guid", actor_type="authority"),
+                   self.make_proxy(name="broker", guid="broker-guid", actor_type="broker")]
+        selected = self.select(brokers)
+        self.assertIsNotNone(selected)
+        self.assertEqual("broker-guid", selected.get_guid())
+
+    def test_falls_back_to_configured_peer_name(self):
+        # Proxies with no actor type must still resolve via the configured peers
+        brokers = [self.make_proxy(name="uky-am", guid="uky-am-guid"),
+                   self.make_proxy(name="broker", guid="broker-guid")]
+        selected = self.select(brokers)
+        self.assertIsNotNone(selected)
+        self.assertEqual("broker-guid", selected.get_guid())
+
+    def test_no_broker_returns_none(self):
+        brokers = [self.make_proxy(name="uky-am", guid="uky-am-guid", actor_type="authority"),
+                   self.make_proxy(name="lbnl-am", guid="lbnl-am-guid", actor_type="authority")]
+        self.assertIsNone(self.select(brokers))
+
+
+class PeerRegistryDefaultBrokerTest(unittest.TestCase):
+    """
+    The default broker must be a Broker peer, whatever order peers arrive in.
+    """
+    def setUp(self):
+        self.logger = logging.getLogger(self.__class__.__name__)
+        self.registry = PeerRegistry()
+
+    def add(self, proxy):
+        """
+        Invoke the name-mangled default-broker setter
+        """
+        self.registry._PeerRegistry__set_default_broker_if_needed(broker=proxy)
+
+    def make_broker(self):
+        return KafkaBrokerProxy(kafka_topic="broker-1", logger=self.logger,
+                                identity=AuthToken(name="broker", guid="broker-guid"))
+
+    def make_authority(self, *, name: str = "uky-am"):
+        return KafkaAuthorityProxy(kafka_topic=f"{name}-1", logger=self.logger,
+                                   identity=AuthToken(name=name, guid=f"{name}-guid"))
+
+    def test_authority_never_becomes_default(self):
+        self.add(self.make_authority())
+        self.add(self.make_authority(name="lbnl-am"))
+        self.assertIsNone(self.registry.get_default_broker())
+
+    def test_broker_wins_regardless_of_order(self):
+        self.add(self.make_authority())
+        self.add(self.make_broker())
+        self.add(self.make_authority(name="lbnl-am"))
+        default_broker = self.registry.get_default_broker()
+        self.assertIsNotNone(default_broker)
+        self.assertEqual("broker", default_broker.get_name())
+
+    def test_first_broker_is_kept(self):
+        first = self.make_broker()
+        self.add(first)
+        second = KafkaBrokerProxy(kafka_topic="broker-2", logger=self.logger,
+                                  identity=AuthToken(name="broker-2", guid="broker-2-guid"))
+        self.add(second)
+        self.assertEqual("broker", self.registry.get_default_broker().get_name())
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Problem

The Orchestrator fails to start:

```
File "/usr/src/app/fabric_cf/orchestrator/core/orchestrator_handler.py", line 178, in discover_broker_query_model
    raise OrchestratorException("Unable to determine broker proxy for this controller. ...")
fabric_cf.orchestrator.core.exceptions.OrchestratorException: Unable to determine broker proxy for this controller.
```

preceded by:

```
ERROR - No broker peer found among proxies: [<...ProxyAvro object at 0x7f57d0336c10>, ... x36]
```

## Root cause

`get_broker()` (added in 866aa3f3) selects the peer whose `ProxyAvro.get_type()` is `ActorType.Broker`, but `Converter.fill_proxy` only ever filled `name`, `guid`, `protocol` and `kafka_topic` — it **never set `type`**. Every proxy reported `type=None`, the filter matched nothing, `get_broker()` returned `None`, and startup aborted.

`ProxyAvro.type` is a first-class field that already carries the peer actor type elsewhere: `RemoteActorCache.establish_peer_private` sets it, and `Converter.get_agent_proxy` feeds it straight back to `KafkaProxyFactory.new_proxy`, which expects `authority`/`broker`. Only the reverse conversion was missing it.

## Changes

1. **`Converter.fill_proxy`** — populate `type` from the proxy role, checking `ABCAuthorityProxy` before `ABCBrokerProxy` (the authority proxy derives from the broker one, so the narrower type must win).

2. **`OrchestratorHandler`** — selection moved into a helper that prefers the Broker-typed peer, then falls back to matching peers configured with `type: broker` when a proxy carries no type. It deliberately does *not* fall back to the first list entry — that was the original AM-misrouting bug 866aa3f3 fixed. The error log now prints `(name, type)` pairs instead of 36 object reprs.

3. **`PeerRegistry`** — same latent bug on a different path: `load_from_db` set `default_broker` to whichever `Proxies` row came back first (arbitrary after recovery, possibly an Authority), and `add_broker`/`update_broker` had the same first-wins rule. The default is now chosen by role, so an Authority can never shadow the real Broker. That default feeds `add_reservation` (`broker=None`), `claim_delegation_client`, `reclaim_delegation_client` and `ControllerSimplePolicy.formulate_bids`.

## Tests

New `fabric_cf/orchestrator/test/test_broker_selection.py` — 8 unit tests, no Kafka/Postgres/Neo4j required:

```
Ran 8 tests in 0.000s
OK
```

- `fill_proxy` types a `KafkaBrokerProxy` as Broker and a `KafkaAuthorityProxy` as Authority
- Orchestrator picks the Broker when Authority proxies come first in the list
- Orchestrator resolves via configured peer names when proxies carry no type
- Orchestrator returns `None` when only Authority peers exist
- `PeerRegistry` never makes an Authority the default, and prefers the Broker regardless of arrival order

The two `fill_proxy` tests fail with `AttributeError: 'NoneType' object has no attribute 'lower'` when the converter change is reverted, i.e. they reproduce the production failure.

## Behavior change worth noting

A management `add_reservation` with no explicit broker now returns `ErrorNoSuchBroker` if the registry holds no true Broker peer, instead of silently ticketing an Authority.
